### PR TITLE
Revit_Toolkit - Issue241 - GenericObject Updates

### DIFF
--- a/Adapter_Revit_UI/Read/Read.cs
+++ b/Adapter_Revit_UI/Read/Read.cs
@@ -211,17 +211,20 @@ namespace BH.UI.Revit.Adapter
 
             List<IBHoMObject> aResult = new List<IBHoMObject>();
 
-            IEnumerable<Type> aTypes = Query.BHoMTypes(element);
-            if (aTypes != null && aTypes.Count() > 0)
+            if(pullSettings.Discipline != Discipline.Undefined)
             {
-                try
+                IEnumerable<Type> aTypes = Query.BHoMTypes(element);
+                if (aTypes != null && aTypes.Count() > 0)
                 {
-                    aObject = Engine.Convert.ToBHoM(element as dynamic, pullSettings);
-                }
-                catch (Exception aException)
-                {
-                    BH.Engine.Reflection.Compute.RecordError(string.Format("BHoM object could not be properly converted becasue of missing ToBHoM method. Element Id: {0}, Element Name: {1}, Exception Message: {2}", element.Id.IntegerValue, element.Name, aException.Message));
-                    aConverted = false;
+                    try
+                    {
+                        aObject = Engine.Convert.ToBHoM(element as dynamic, pullSettings);
+                    }
+                    catch (Exception aException)
+                    {
+                        BH.Engine.Reflection.Compute.RecordError(string.Format("BHoM object could not be properly converted becasue of missing ToBHoM method. Element Id: {0}, Element Name: {1}, Exception Message: {2}", element.Id.IntegerValue, element.Name, aException.Message));
+                        aConverted = false;
+                    }
                 }
             }
 

--- a/Adapter_Revit_UI/RevitUIAdapter.cs
+++ b/Adapter_Revit_UI/RevitUIAdapter.cs
@@ -33,6 +33,10 @@ namespace BH.UI.Revit.Adapter
         /**** Private Properties                        ****/
         /***************************************************/
 
+        private UIControlledApplication m_UIControlledApplication;
+
+        /***************************************************/
+
         private Document m_Document;
 
 
@@ -40,7 +44,7 @@ namespace BH.UI.Revit.Adapter
         /**** Public Constructors                       ****/
         /***************************************************/
         
-        public RevitUIAdapter(Document document)
+        public RevitUIAdapter(UIControlledApplication uIControlledApplication, Document document)
             : base()
         {
             AdapterId = BH.Engine.Adapters.Revit.Convert.AdapterId;
@@ -48,7 +52,9 @@ namespace BH.UI.Revit.Adapter
             Config.ProcessInMemory = false;
             Config.SeparateProperties = true;
             Config.CloneBeforePush = true;
+
             m_Document = document;
+            m_UIControlledApplication = uIControlledApplication;
         }
 
 
@@ -74,6 +80,16 @@ namespace BH.UI.Revit.Adapter
                     return null;
 
                 return new UIDocument(m_Document);
+            }
+        }
+
+        /***************************************************/
+
+        public UIControlledApplication UIControlledApplication
+        {
+            get
+            {
+                return m_UIControlledApplication;
             }
         }
 

--- a/Engine_Revit_UI/Compute/Errors.cs
+++ b/Engine_Revit_UI/Compute/Errors.cs
@@ -22,11 +22,6 @@
 
 using Autodesk.Revit.DB;
 using BH.oM.Base;
-using BH.oM.Adapters.Revit.Settings;
-using BH.oM.Structure.Elements;
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 
 namespace BH.UI.Revit.Engine
 {
@@ -42,6 +37,31 @@ namespace BH.UI.Revit.Engine
         }
 
         /***************************************************/
+
+        internal static void FamilyPlacementTypeMismatchError(this IBHoMObject iBHoMObject, Family family)
+        {
+            string aMessage = "Family Placement Type conflict. Family Instance could not be created.";
+
+            if (iBHoMObject != null)
+                aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);
+
+            if (family != null)
+                aMessage = string.Format("{0} Element Id : {1}", aMessage, family.Id.IntegerValue);
+
+            BH.Engine.Reflection.Compute.RecordError(aMessage);
+        }
+
+        /***************************************************/
+
+        internal static void FamilySymbolNotFoundError(this IBHoMObject iBHoMObject)
+        {
+            string aMessage = "Family symbol has not been found for given BHoM Object.";
+
+            if (iBHoMObject != null)
+                aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);
+
+            BH.Engine.Reflection.Compute.RecordError(aMessage);
+        }
 
     }
 }

--- a/Engine_Revit_UI/Compute/Errors.cs
+++ b/Engine_Revit_UI/Compute/Errors.cs
@@ -37,31 +37,5 @@ namespace BH.UI.Revit.Engine
         }
 
         /***************************************************/
-
-        internal static void FamilyPlacementTypeMismatchError(this IBHoMObject iBHoMObject, Family family)
-        {
-            string aMessage = "Family Placement Type conflict. Family Instance could not be created.";
-
-            if (iBHoMObject != null)
-                aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);
-
-            if (family != null)
-                aMessage = string.Format("{0} Element Id : {1}", aMessage, family.Id.IntegerValue);
-
-            BH.Engine.Reflection.Compute.RecordError(aMessage);
-        }
-
-        /***************************************************/
-
-        internal static void FamilySymbolNotFoundError(this IBHoMObject iBHoMObject)
-        {
-            string aMessage = "Family symbol has not been found for given BHoM Object.";
-
-            if (iBHoMObject != null)
-                aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);
-
-            BH.Engine.Reflection.Compute.RecordError(aMessage);
-        }
-
     }
 }

--- a/Engine_Revit_UI/Compute/Warnings.cs
+++ b/Engine_Revit_UI/Compute/Warnings.cs
@@ -298,9 +298,9 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        internal static void InvalidLocationTypeWarning(this IBHoMObject iBHoMObject, ElementType elementType)
+        internal static void InvalidFamilyPlacementTypeWarning(this IBHoMObject iBHoMObject, ElementType elementType)
         {
-            string aMessage = "BHoM Object location does not match with the required Location of family";
+            string aMessage = "BHoM Object location does not match with the required placement type of Revit family";
 
             if (iBHoMObject != null)
                 aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);
@@ -309,6 +309,33 @@ namespace BH.UI.Revit.Engine
                 aMessage = string.Format("{0} Element Id : {1}", aMessage, elementType.Id.IntegerValue);
 
             BH.Engine.Reflection.Compute.RecordWarning(aMessage);
+        }
+
+        /***************************************************/
+
+        internal static void FamilyPlacementTypeNotSupportedWarning(this IBHoMObject iBHoMObject, ElementType elementType)
+        {
+            string aMessage = "lacement type of Revit family is not supported.";
+
+            if (iBHoMObject != null)
+                aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);
+
+            if (elementType != null)
+                aMessage = string.Format("{0} Element Id : {1}", aMessage, elementType.Id.IntegerValue);
+
+            BH.Engine.Reflection.Compute.RecordWarning(aMessage);
+        }
+
+        /***************************************************/
+
+        internal static void ElementTypeNotFoundWarning(this IBHoMObject iBHoMObject)
+        {
+            string aMessage = "Element type has not been found for given BHoM Object.";
+
+            if (iBHoMObject != null)
+                aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);
+
+            BH.Engine.Reflection.Compute.RecordError(aMessage);
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Compute/Warnings.cs
+++ b/Engine_Revit_UI/Compute/Warnings.cs
@@ -297,5 +297,20 @@ namespace BH.UI.Revit.Engine
         }
 
         /***************************************************/
+
+        internal static void InvalidLocationTypeWarning(this IBHoMObject iBHoMObject, ElementType elementType)
+        {
+            string aMessage = "BHoM Object location does not match with the required Location of family";
+
+            if (iBHoMObject != null)
+                aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);
+
+            if (elementType != null)
+                aMessage = string.Format("{0} Element Id : {1}", aMessage, elementType.Id.IntegerValue);
+
+            BH.Engine.Reflection.Compute.RecordWarning(aMessage);
+        }
+
+        /***************************************************/
     }
 }

--- a/Engine_Revit_UI/Convert/Common/ToRevit/Element.cs
+++ b/Engine_Revit_UI/Convert/Common/ToRevit/Element.cs
@@ -81,6 +81,46 @@ namespace BH.UI.Revit.Engine
                                 aElement = document.Create.NewFamilyInstance(aXYZ, aFamilySymbol, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
                             }
                             break;
+                        case FamilyPlacementType.CurveDrivenStructural:
+                            if(aIGeometry is ICurve)
+                            {
+                                Level aLevel = ((ICurve)aIGeometry).BottomLevel(document, pushSettings.ConvertUnits);
+                                if (aLevel == null)
+                                    break;
+
+                                Curve aCurve = ToRevitCurve((ICurve)aIGeometry, pushSettings);
+
+                                Autodesk.Revit.DB.Structure.StructuralType aStructuralType = Autodesk.Revit.DB.Structure.StructuralType.NonStructural;
+
+                                aBuiltInCategory = (BuiltInCategory)aFamilySymbol.Category.Id.IntegerValue;
+                                switch (aBuiltInCategory)
+                                {
+                                    case BuiltInCategory.OST_StructuralColumns:
+                                        aStructuralType = Autodesk.Revit.DB.Structure.StructuralType.Column;
+                                        break;
+                                    case BuiltInCategory.OST_StructuralFraming:
+                                        aStructuralType = Autodesk.Revit.DB.Structure.StructuralType.Beam;
+                                        break;
+                                }
+                                if (aStructuralType == Autodesk.Revit.DB.Structure.StructuralType.NonStructural)
+                                    break;
+
+                                aElement = document.Create.NewFamilyInstance(aCurve, aFamilySymbol, aLevel, aStructuralType);
+                            }
+                            break;
+                    }
+                }
+                else if(aElementType is WallType)
+                {
+                    IGeometry aIGeometry = genericObject.Location;
+                    if(aIGeometry is ICurve)
+                    {
+                        Level aLevel = ((ICurve)aIGeometry).BottomLevel(document, pushSettings.ConvertUnits);
+                        if (aLevel != null)
+                        {
+                            Curve aCurve = ToRevitCurve((ICurve)aIGeometry, pushSettings);
+                            aElement = Wall.Create(document, aCurve, aLevel.Id, false);
+                        }
                     }
                 }
             }

--- a/Engine_Revit_UI/Convert/Common/ToRevit/Element.cs
+++ b/Engine_Revit_UI/Convert/Common/ToRevit/Element.cs
@@ -122,7 +122,8 @@ namespace BH.UI.Revit.Engine
 
             pushSettings = pushSettings.DefaultIfNull();
 
-            List<View> aViewList = new FilteredElementCollector(document).OfClass(typeof(ViewDrafting)).Cast<View>().ToList();
+            List<View> aViewList = new FilteredElementCollector(document).OfClass(typeof(View)).Cast<View>().ToList();
+            aViewList.RemoveAll(x => x.IsTemplate || x is ViewSchedule || x is View3D || x is ViewSheet);
             if(aViewList == null || aViewList.Count == 0)
                 return null;
 

--- a/Engine_Revit_UI/Convert/Common/ToRevit/Element.cs
+++ b/Engine_Revit_UI/Convert/Common/ToRevit/Element.cs
@@ -105,6 +105,8 @@ namespace BH.UI.Revit.Engine
         }
 
         /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
 
         private static Element ToRevitElement(this DraftingObject draftingObject, Document document, PushSettings pushSettings = null)
         {
@@ -205,6 +207,8 @@ namespace BH.UI.Revit.Engine
             return aDocument.Create.NewFamilyInstance(aCurve, familySymbol, aLevel, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
         }
 
+        /***************************************************/
+
         private static Element ToRevitElement_OneLevelBased(this GenericObject genericObject, FamilySymbol familySymbol, PushSettings pushSettings = null)
         {
             if (familySymbol == null || genericObject == null)
@@ -227,6 +231,8 @@ namespace BH.UI.Revit.Engine
             XYZ aXYZ = ToRevitXYZ(aPoint, pushSettings);
             return aDocument.Create.NewFamilyInstance(aXYZ, familySymbol, aLevel, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
         }
+
+        /***************************************************/
 
         private static Element ToRevitElement_CurveDrivenStructural(this GenericObject genericObject, FamilySymbol familySymbol, PushSettings pushSettings = null)
         {
@@ -267,6 +273,8 @@ namespace BH.UI.Revit.Engine
             return aDocument.Create.NewFamilyInstance(aCurve, familySymbol, aLevel, aStructuralType);
         }
 
+        /***************************************************/
+
         private static Element ToRevitElement_TwoLevelsBased(this GenericObject genericObject, FamilySymbol familySymbol, PushSettings pushSettings = null)
         {
             if (familySymbol == null || genericObject == null)
@@ -306,6 +314,8 @@ namespace BH.UI.Revit.Engine
             return aDocument.Create.NewFamilyInstance(aXYZ, familySymbol, aLevel, aStructuralType);
         }
 
+        /***************************************************/
+
         private static Element ToRevitElement_Wall(this GenericObject genericObject, WallType wallType, PushSettings pushSettings = null)
         {
             if (wallType == null || genericObject == null)
@@ -328,5 +338,7 @@ namespace BH.UI.Revit.Engine
             Curve aCurve = ToRevitCurve(Curve, pushSettings);
             return Wall.Create(aDocument, aCurve, aLevel.Id, false);
         }
+
+        /***************************************************/
     }
 }

--- a/Engine_Revit_UI/Convert/Common/ToRevit/Element.cs
+++ b/Engine_Revit_UI/Convert/Common/ToRevit/Element.cs
@@ -73,12 +73,20 @@ namespace BH.UI.Revit.Engine
                                 Curve aCurve = ToRevitCurve((ICurve)aIGeometry, pushSettings);
                                 aElement = document.Create.NewFamilyInstance(aCurve, aFamilySymbol, aLevel, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
                             }
+                            else
+                            {
+                                Compute.InvalidLocationTypeWarning(genericObject, aElementType);
+                            }
                             break;
                         case FamilyPlacementType.OneLevelBased:
                             if (aIGeometry is oM.Geometry.Point)
                             {
                                 XYZ aXYZ = ToRevit((oM.Geometry.Point)aIGeometry, pushSettings);
                                 aElement = document.Create.NewFamilyInstance(aXYZ, aFamilySymbol, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
+                            }
+                            else
+                            {
+                                Compute.InvalidLocationTypeWarning(genericObject, aElementType);
                             }
                             break;
                         case FamilyPlacementType.CurveDrivenStructural:
@@ -107,6 +115,10 @@ namespace BH.UI.Revit.Engine
 
                                 aElement = document.Create.NewFamilyInstance(aCurve, aFamilySymbol, aLevel, aStructuralType);
                             }
+                            else
+                            {
+                                Compute.InvalidLocationTypeWarning(genericObject, aElementType);
+                            }
                             break;
                     }
                 }
@@ -121,6 +133,10 @@ namespace BH.UI.Revit.Engine
                             Curve aCurve = ToRevitCurve((ICurve)aIGeometry, pushSettings);
                             aElement = Wall.Create(document, aCurve, aLevel.Id, false);
                         }
+                    }
+                    else
+                    {
+                        Compute.InvalidLocationTypeWarning(genericObject, aElementType);
                     }
                 }
             }

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/ICurve.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/ICurve.cs
@@ -59,6 +59,22 @@ namespace BH.UI.Revit.Engine
                 }
                 return BH.Engine.Geometry.Create.Arc(ToBHoM(plane, pullSettings), radius, startAngle, endAngle);
             }
+            if (curve is NurbSpline)
+            {
+                NurbSpline nurbs = curve as NurbSpline;
+
+                List<double> knots = nurbs.Knots.Cast<double>().ToList();
+                knots.RemoveAt(knots.Count - 1);
+                knots.RemoveAt(0);
+
+                return new BH.oM.Geometry.NurbsCurve
+                {
+                    ControlPoints = nurbs.CtrlPoints.Select(x => x.ToBHoM(pullSettings)).ToList(),
+                    Knots = knots,
+                    Weights = nurbs.Weights.Cast<double>().ToList()
+
+                };
+            }
             
             return null;
         }

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/CoordinateSystem.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/CoordinateSystem.cs
@@ -23,6 +23,7 @@
 using Autodesk.Revit.DB;
 using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Adapters.Revit.Settings;
+using BH.Engine.Geometry;
 
 namespace BH.UI.Revit.Engine
 {
@@ -37,8 +38,8 @@ namespace BH.UI.Revit.Engine
             pushSettings = pushSettings.DefaultIfNull();
 
             XYZ origin = coordinateSystem.Origin.ToRevit(pushSettings);
-            XYZ X = coordinateSystem.X.ToRevit(pushSettings);
-            XYZ Y = coordinateSystem.Y.ToRevit(pushSettings);
+            XYZ X = coordinateSystem.X.ToRevit(pushSettings).Normalize();
+            XYZ Y = coordinateSystem.Y.ToRevit(pushSettings).Normalize();
             return Plane.CreateByOriginAndBasis(origin, X, Y);
         }
 

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Curve.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Curve.cs
@@ -23,6 +23,8 @@
 using Autodesk.Revit.DB;
 using BH.oM.Geometry;
 using BH.oM.Adapters.Revit.Settings;
+using BH.Engine.Geometry;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BH.UI.Revit.Engine
@@ -53,7 +55,11 @@ namespace BH.UI.Revit.Engine
             if (curve is NurbsCurve)
             {
                 NurbsCurve aNurbCurve = curve as NurbsCurve;
-                return NurbSpline.Create(HermiteSpline.Create(aNurbCurve.ControlPoints.Cast<oM.Geometry.Point>().ToList().ConvertAll(x => ToRevit(x, pushSettings)), false));
+                List<double> knots = aNurbCurve.Knots.ToList();
+                knots.Insert(0, knots[0]);
+                knots.Add(knots[knots.Count - 1]);
+                return NurbSpline.CreateCurve(aNurbCurve.Degree(), knots, aNurbCurve.ControlPoints.Select(x => x.ToRevit(pushSettings)).ToList(), aNurbCurve.Weights);
+                //return NurbSpline.Create(HermiteSpline.Create(aNurbCurve.ControlPoints.Cast<oM.Geometry.Point>().ToList().ConvertAll(x => ToRevit(x, pushSettings)), false));
             }
 
             if (curve is oM.Geometry.Ellipse)

--- a/Engine_Revit_UI/Convert/Structure/ToRevit/FamilyInstance.cs
+++ b/Engine_Revit_UI/Convert/Structure/ToRevit/FamilyInstance.cs
@@ -94,9 +94,16 @@ namespace BH.UI.Revit.Engine
 
                 if (aFamilySymbol == null)
                 {
-                    BH.Engine.Reflection.Compute.RecordError(string.Format("Family symbol has not been found for given BHoM framing property. BHoM Guid: {0}", framingElement.BHoM_Guid));
+                    Compute.FamilySymbolNotFoundError(framingElement);
                     return null;
                 }
+            }
+
+            FamilyPlacementType aFamilyPlacementType = aFamilySymbol.Family.FamilyPlacementType;
+            if (aFamilyPlacementType != FamilyPlacementType.CurveBased && aFamilyPlacementType != FamilyPlacementType.CurveBasedDetail && aFamilyPlacementType != FamilyPlacementType.CurveDrivenStructural)
+            {
+                Compute.FamilyPlacementTypeMismatchError(framingElement, aFamilySymbol.Family);
+                return null;
             }
 
             aFamilyInstance = document.Create.NewFamilyInstance(aCurve, aFamilySymbol, aLevel, Autodesk.Revit.DB.Structure.StructuralType.Column);
@@ -177,9 +184,16 @@ namespace BH.UI.Revit.Engine
 
                 if (aFamilySymbol == null)
                 {
-                    BH.Engine.Reflection.Compute.RecordError(string.Format("Family symbol has not been found for given BHoM framing property. BHoM Guid: {0}", framingElement.BHoM_Guid));
+                    Compute.FamilySymbolNotFoundError(framingElement);
                     return null;
                 }
+            }
+
+            FamilyPlacementType aFamilyPlacementType = aFamilySymbol.Family.FamilyPlacementType;
+            if (aFamilyPlacementType != FamilyPlacementType.CurveBased && aFamilyPlacementType != FamilyPlacementType.CurveBasedDetail && aFamilyPlacementType != FamilyPlacementType.CurveDrivenStructural)
+            {
+                Compute.FamilyPlacementTypeMismatchError(framingElement, aFamilySymbol.Family);
+                return null;
             }
 
             switch (framingElement.StructuralUsage)

--- a/Engine_Revit_UI/Convert/Structure/ToRevit/FamilyInstance.cs
+++ b/Engine_Revit_UI/Convert/Structure/ToRevit/FamilyInstance.cs
@@ -94,7 +94,7 @@ namespace BH.UI.Revit.Engine
 
                 if (aFamilySymbol == null)
                 {
-                    Compute.FamilySymbolNotFoundError(framingElement);
+                    Compute.ElementTypeNotFoundWarning(framingElement);
                     return null;
                 }
             }
@@ -102,7 +102,7 @@ namespace BH.UI.Revit.Engine
             FamilyPlacementType aFamilyPlacementType = aFamilySymbol.Family.FamilyPlacementType;
             if (aFamilyPlacementType != FamilyPlacementType.CurveBased && aFamilyPlacementType != FamilyPlacementType.CurveBasedDetail && aFamilyPlacementType != FamilyPlacementType.CurveDrivenStructural)
             {
-                Compute.FamilyPlacementTypeMismatchError(framingElement, aFamilySymbol.Family);
+                Compute.InvalidFamilyPlacementTypeWarning(framingElement, aFamilySymbol);
                 return null;
             }
 
@@ -184,7 +184,7 @@ namespace BH.UI.Revit.Engine
 
                 if (aFamilySymbol == null)
                 {
-                    Compute.FamilySymbolNotFoundError(framingElement);
+                    Compute.ElementTypeNotFoundWarning(framingElement);
                     return null;
                 }
             }
@@ -192,7 +192,7 @@ namespace BH.UI.Revit.Engine
             FamilyPlacementType aFamilyPlacementType = aFamilySymbol.Family.FamilyPlacementType;
             if (aFamilyPlacementType != FamilyPlacementType.CurveBased && aFamilyPlacementType != FamilyPlacementType.CurveBasedDetail && aFamilyPlacementType != FamilyPlacementType.CurveDrivenStructural)
             {
-                Compute.FamilyPlacementTypeMismatchError(framingElement, aFamilySymbol.Family);
+                Compute.InvalidFamilyPlacementTypeWarning(framingElement, aFamilySymbol);
                 return null;
             }
 

--- a/Engine_Revit_UI/Query/BottomLevel.cs
+++ b/Engine_Revit_UI/Query/BottomLevel.cs
@@ -37,12 +37,13 @@ namespace BH.UI.Revit.Engine
             if (curve == null)
                 return null;
 
-            double aMinElevation = BH.Engine.Geometry.Query.Bounds(curve as dynamic).Min.Z;
+            double aMinElevation = MinElevation(curve);//BH.Engine.Geometry.Query.Bounds(curve as dynamic).Min.Z;
             if (convertUnits)
                 aMinElevation = UnitUtils.ConvertToInternalUnits(aMinElevation, DisplayUnitType.DUT_METERS);
 
             return BottomLevel(aMinElevation, document, convertUnits);
         }
+
 
         /***************************************************/
 
@@ -75,6 +76,19 @@ namespace BH.UI.Revit.Engine
                     return aLevelList[i - 1];
 
             return null;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        static private double MinElevation(oM.Geometry.ICurve curve)
+        {
+            //TODO: Method to be removed as zoon as a proper Bounds method is implemented for NurbsCurve
+            if (curve is oM.Geometry.NurbsCurve)
+                return BH.Engine.Geometry.Query.Bounds(((oM.Geometry.NurbsCurve)curve).ControlPoints).Min.Z;
+
+            return BH.Engine.Geometry.Query.Bounds(curve as dynamic).Min.Z;
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Query/BottomLevel.cs
+++ b/Engine_Revit_UI/Query/BottomLevel.cs
@@ -34,22 +34,45 @@ namespace BH.UI.Revit.Engine
         
         static public Level BottomLevel(this oM.Geometry.ICurve curve, Document document, bool convertUnits = true)
         {
+            if (curve == null)
+                return null;
+
             double aMinElevation = BH.Engine.Geometry.Query.Bounds(curve as dynamic).Min.Z;
             if (convertUnits)
                 aMinElevation = UnitUtils.ConvertToInternalUnits(aMinElevation, DisplayUnitType.DUT_METERS);
 
+            return BottomLevel(aMinElevation, document, convertUnits);
+        }
+
+        /***************************************************/
+
+        static public Level BottomLevel(this oM.Geometry.Point point, Document document, bool convertUnits = true)
+        {
+            if (point == null)
+                return null;
+
+            return BottomLevel(point.Z, document, convertUnits);
+        }
+
+        /***************************************************/
+
+        static public Level BottomLevel(this double elevation, Document document, bool convertUnits = true)
+        {
+            if (double.IsNaN(elevation) || double.IsNegativeInfinity(elevation) || double.IsPositiveInfinity(elevation))
+                return null;
+
             List<Level> aLevelList = new FilteredElementCollector(document).OfClass(typeof(Level)).Cast<Level>().ToList();
             aLevelList.Sort((x, y) => x.Elevation.CompareTo(y.Elevation));
 
-            if (aMinElevation <= aLevelList.First().Elevation)
+            if (elevation <= aLevelList.First().Elevation)
                 return aLevelList.First();
 
-            if (aMinElevation >= aLevelList.Last().Elevation)
+            if (elevation >= aLevelList.Last().Elevation)
                 return aLevelList.Last();
 
             for (int i = 1; i < aLevelList.Count; i++)
-                if (aLevelList[i].Elevation > aMinElevation)
-                    return aLevelList[i -1];
+                if (aLevelList[i].Elevation > elevation)
+                    return aLevelList[i - 1];
 
             return null;
         }

--- a/Revit_Engine/Convert/AdapterID.cs
+++ b/Revit_Engine/Convert/AdapterID.cs
@@ -36,6 +36,7 @@ namespace BH.Engine.Adapters.Revit
         public const string FamilyName = "Revit_familyName";
         public const string FamilyTypeName = "Revit_familyTypeName";
         public const string CategoryName = "Revit_categoryName";
+        public const string ViewName = "Revit_viewName";
         public const string Edges = "Revit_edges";
 
         /***************************************************/

--- a/Revit_Engine/Create/Settings/GeneralSettings.cs
+++ b/Revit_Engine/Create/Settings/GeneralSettings.cs
@@ -37,15 +37,16 @@ namespace BH.Engine.Adapters.Revit
         [Input("defaultDiscipline", "Default disciplne for pull method")]
         [Input("replace", "Replace existing elements in the model for push method. Update parameters (CustomData) only if set to false.")]
         [Input("tagsParameterName", "Name of the parameter which stores Tags assigned to BHoM object")]
+        [Input("suppressFailureMessages", "Revit will suppress pop up messages")]
         [Output("GeneralSettings")]
-        public static GeneralSettings GeneralSettings(Discipline defaultDiscipline = Discipline.Structural, bool replace = true, string tagsParameterName = "BHE_Tags")
+        public static GeneralSettings GeneralSettings(Discipline defaultDiscipline = Discipline.Undefined, bool replace = true, string tagsParameterName = "BHE_Tags", bool suppressFailureMessages = false)
         {
             return new GeneralSettings()
             {
                 DefaultDiscipline = defaultDiscipline,
                 Replace = replace,
-                TagsParameterName = tagsParameterName
-
+                TagsParameterName = tagsParameterName,
+                SuppressFailureMessages = suppressFailureMessages
             };
         }
 

--- a/Revit_Test/Test.cs
+++ b/Revit_Test/Test.cs
@@ -101,7 +101,7 @@ namespace Revit_Test
         public Result Execute_Old_1(ExternalCommandData ExternalCommandData, ref string Message, ElementSet Elements)
         {
             //Creating Revit Adapter for active Revit Document
-            RevitUIAdapter pRevitInternalAdapter = new RevitUIAdapter(ExternalCommandData.Application.ActiveUIDocument.Document);
+            RevitUIAdapter pRevitInternalAdapter = new RevitUIAdapter(null, ExternalCommandData.Application.ActiveUIDocument.Document);
 
             FilterQuery aFilterQuery = null;
             List<IBHoMObject> aBHoMObjectList = null;
@@ -168,7 +168,7 @@ namespace Revit_Test
         public Result Execute_Old_2(ExternalCommandData ExternalCommandData, ref string Message, ElementSet Elements)
         {
             //Creating Revit Adapter for active Revit Document
-            RevitUIAdapter pRevitInternalAdapter = new RevitUIAdapter(ExternalCommandData.Application.ActiveUIDocument.Document);
+            RevitUIAdapter pRevitInternalAdapter = new RevitUIAdapter(null, ExternalCommandData.Application.ActiveUIDocument.Document);
 
             FamilyLibrary aFamilyLibrary = Create.FamilyLibrary(@"C:\Users\jziolkow\Desktop\Families");
 
@@ -208,7 +208,7 @@ namespace Revit_Test
         public Result Execute_Old_3(ExternalCommandData ExternalCommandData, ref string Message, ElementSet Elements)
         {
             //Creating Revit Adapter for active Revit Document
-            RevitUIAdapter pRevitInternalAdapter = new RevitUIAdapter(ExternalCommandData.Application.ActiveUIDocument.Document);
+            RevitUIAdapter pRevitInternalAdapter = new RevitUIAdapter(null, ExternalCommandData.Application.ActiveUIDocument.Document);
 
             FamilyLibrary aFamilyLibrary = Create.FamilyLibrary(@"C:\Users\jziolkow\Desktop\Families");
 

--- a/Revit_UI/RevitListener.cs
+++ b/Revit_UI/RevitListener.cs
@@ -61,6 +61,10 @@ namespace BH.UI.Revit
 
         /***************************************************/
 
+        public UIControlledApplication UIControlledApplication = null;
+
+        /***************************************************/
+
         public KeyValuePair<string, object> LatestKeyValuePair { get; set; }
 
         /***************************************************/
@@ -70,7 +74,6 @@ namespace BH.UI.Revit
         /***************************************************/
 
         public static RevitSettings AdapterSettings { get; set; } = null;
-
 
         /***************************************************/
         /**** Public methods                            ****/
@@ -82,7 +85,7 @@ namespace BH.UI.Revit
 
             if (!m_adapters.TryGetValue(document, out adapter))
             {
-                adapter = new RevitUIAdapter(document);
+                adapter = new RevitUIAdapter(UIControlledApplication, document);
                 m_adapters[document] = adapter;
             }
 
@@ -135,15 +138,17 @@ namespace BH.UI.Revit
 
         /***************************************************/
 
-        public Result OnStartup(UIControlledApplication application)
+        public Result OnStartup(UIControlledApplication uIControlledApplication)
         {
+            UIControlledApplication = uIControlledApplication;
+
             //Make sure all BHoM assemblies are loaded
-            string versionNumber = application.ControlledApplication.VersionNumber;
+            string versionNumber = uIControlledApplication.ControlledApplication.VersionNumber;
             string path = Environment.GetEnvironmentVariable("APPDATA") + @"\Autodesk\Revit\Addins\" + versionNumber +  @"\BHoM";
             BH.Engine.Reflection.Compute.LoadAllAssemblies(path);
 
             //Add button to set socket ports
-            AddRibbonItems(application);
+            AddRibbonItems(uIControlledApplication);
 
             //Define static instance of the listener
             Listener = this;
@@ -167,7 +172,7 @@ namespace BH.UI.Revit
 
             m_linkOut = new SocketLink_Tcp(14129);
 
-            application.ViewActivated += Application_ViewActivated;
+            uIControlledApplication.ViewActivated += Application_ViewActivated;
 
             return Result.Succeeded;
         }

--- a/Revit_oM/Enums.cs
+++ b/Revit_oM/Enums.cs
@@ -24,6 +24,7 @@ namespace BH.oM.Adapters.Revit.Enums
 {
     public enum Discipline
     {
+        Undefined,
         Environmental,
         Structural,
         Architecture

--- a/Revit_oM/Settings/GeneralSettings.cs
+++ b/Revit_oM/Settings/GeneralSettings.cs
@@ -31,9 +31,10 @@ namespace BH.oM.Adapters.Revit.Settings
         /**** Public Properties                        ****/
         /***************************************************/
 
-        public Enums.Discipline DefaultDiscipline { get; set; } = Enums.Discipline.Structural;
+        public Enums.Discipline DefaultDiscipline { get; set; } = Enums.Discipline.Undefined;
         public bool Replace { get; set; } = true;
         public string TagsParameterName { get; set; } = "BHE_Tags";
+        public bool SuppressFailureMessages { get; set; } = false;
 
         /***************************************************/
     }


### PR DESCRIPTION
### NOTE: Depends on 
 [BHoM #421](https://github.com/BHoM/BHoM/pull/421)

### Issues addressed by this PR
Closes #241
Closes #242 
Closes #235
Closes #251 

### Changelog
Failure Processing added
Undefined Discipline added
Pull for Undefined discipline updated (pull as GenericObject and DraftingObject)
Implements workaround for #235 - Pull Framing Element as GenericObject and gets Location Curve
Implements GenericObject Push for Structural Families
Change FramingElement LocationCurve from Line to ICurve to align with [BHoM Pull Request 421](https://github.com/BHoM/BHoM/pull/421)
Warning added for pull GenericObject