### PR TITLE
Revit_Toolkit - Issue 244 - Include Non Visible Objects

### DIFF
--- a/Adapter_Revit_UI/Read/Read.cs
+++ b/Adapter_Revit_UI/Read/Read.cs
@@ -173,7 +173,7 @@ namespace BH.UI.Revit.Adapter
                         Options aOptions = new Options();
                         aOptions.ComputeReferences = false;
                         aOptions.DetailLevel = ViewDetailLevel.Fine;
-                        aOptions.IncludeNonVisibleObjects = false;
+                        aOptions.IncludeNonVisibleObjects = BH.Engine.Adapters.Revit.Query.IncludeNonVisibleObjects(aFilterQueries);
 
                         foreach(IBHoMObject aIBHoMObject in aIBHoMObjects)
                         {

--- a/Revit_Engine/Convert/FilterQuery.cs
+++ b/Revit_Engine/Convert/FilterQuery.cs
@@ -40,6 +40,7 @@ namespace BH.Engine.Adapters.Revit
             public const string FamilyTypeName = "FamilyTypeName";
             public const string SelectionSetName = "SelectionSetName";
             public const string PullEdges = "PullEdges";
+            public const string IncludeNonVisibleObjects = "IncludeNonVisibleObjects";
         }
     }
 }

--- a/Revit_Engine/Modify/SetPullEdges.cs
+++ b/Revit_Engine/Modify/SetPullEdges.cs
@@ -51,6 +51,16 @@ namespace BH.Engine.Adapters.Revit
             return aFilterQuery;
         }
 
+        [Deprecated("2.2")]
+        [Description("Sets Pull Edges option for FilterQuery.")]
+        [Input("filterQuery", "FilterQuery")]
+        [Input("pullEdges", "Set to true if include geometry edges of Revit Element in CustomData of BHoMObject")]
+        [Output("FilterQuery")]
+        public static FilterQuery SetPullEdges(this FilterQuery filterQuery, bool pullEdges)
+        {
+            return SetPullEdges(filterQuery, pullEdges, false);
+        }
+
         /***************************************************/
     }
 }

--- a/Revit_Engine/Query/IncludeNonVisibleObjects.cs
+++ b/Revit_Engine/Query/IncludeNonVisibleObjects.cs
@@ -20,35 +20,50 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System.Collections.Generic;
 using System.ComponentModel;
 
 using BH.oM.DataManipulation.Queries;
 using BH.oM.Reflection.Attributes;
+using System.Linq;
 
 namespace BH.Engine.Adapters.Revit
 {
-    public static partial class Modify
+    public static partial class Query
     {
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Sets Pull Edges option for FilterQuery.")]
+        [Description("Returns true if FilterQuery should include non visible objects when pulling edges")]
         [Input("filterQuery", "FilterQuery")]
-        [Input("pullEdges", "Set to true if include geometry edges of Revit Element in CustomData of BHoMObject")]
-        [Input("includeNonVisibleObjects", "Set to true if include non visible objects of Revit Element in geometry")]
-        [Output("FilterQuery")]
-        public static FilterQuery SetPullEdges(this FilterQuery filterQuery, bool pullEdges = true, bool includeNonVisibleObjects = false)
+        [Output("IncludeNonVisibleObjects")]
+        public static bool IncludeNonVisibleObjects(this FilterQuery filterQuery)
         {
             if (filterQuery == null)
-                return null;
+                return false;
 
-            FilterQuery aFilterQuery = Query.Duplicate(filterQuery);
+            if (filterQuery.Equalities.ContainsKey(Convert.FilterQuery.IncludeNonVisibleObjects))
+            {
+                object aObject = filterQuery.Equalities[Convert.FilterQuery.IncludeNonVisibleObjects];
+                if (aObject is bool)
+                    return (bool)aObject;
+            }
 
-            aFilterQuery.Equalities[Convert.FilterQuery.PullEdges] = pullEdges;
-            aFilterQuery.Equalities[Convert.FilterQuery.IncludeNonVisibleObjects] = includeNonVisibleObjects;
+            return false;
+        }
 
-            return aFilterQuery;
+        /***************************************************/
+
+        [Description("Returns true if at least one FilterQuery on list should include non visible objects when pulling edges")]
+        [Input("filterQueries", "FilterQueries")]
+        [Output("IncludeNonVisibleObjects")]
+        public static bool IncludeNonVisibleObjects(this IEnumerable<FilterQuery> filterQueries)
+        {
+            if (filterQueries == null)
+                return false;
+
+            return filterQueries.ToList().Any(x => x.IncludeNonVisibleObjects());
         }
 
         /***************************************************/

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Query\AdjacentSpaceId.cs" />
     <Compile Include="Query\Height.cs" />
     <Compile Include="Query\Plane.cs" />
+    <Compile Include="Query\IncludeNonVisibleObjects.cs" />
     <Compile Include="Query\SpaceId.cs" />
     <Compile Include="Query\PullEdges.cs" />
     <Compile Include="Query\Shell.cs" />


### PR DESCRIPTION

### Issues addressed by this PR
Include Non Visible Objects when pulling edges of Revit Element

Closes #244