### PR TITLE
Revit toolkit deprecated properties

### DIFF
--- a/Adapter_Revit_UI/Create/Environment/BuildingElement.cs
+++ b/Adapter_Revit_UI/Create/Environment/BuildingElement.cs
@@ -37,7 +37,8 @@ namespace BH.UI.Revit.Adapter
 
         private static Element Create(BuildingElement buildingElement, Document document, PushSettings pushSettings = null)
         {
-            if (buildingElement == null)
+            throw new System.NotImplementedException("The method to create a Revit Element from a BHoM Building Element has not been fixed yet. Check Issue #247 for more info");
+            /*if (buildingElement == null)
             {
                 NullObjectCreateError(typeof(BuildingElement));
                 return null;
@@ -61,10 +62,10 @@ namespace BH.UI.Revit.Adapter
             /*if (buildingElement.Level != null)
                 Create(buildingElement.Level, pushSettings);*/
 
-            if (pushSettings.Replace)
+            /*if (pushSettings.Replace)
                 Delete(buildingElement, document);
 
-            return buildingElement.ToRevit(document, pushSettings);
+            return buildingElement.ToRevit(document, pushSettings);*/
         }
 
         /***************************************************/

--- a/Adapter_Revit_UI/Delete/Delete.cs
+++ b/Adapter_Revit_UI/Delete/Delete.cs
@@ -98,9 +98,10 @@ namespace BH.UI.Revit.Adapter
 
         /***************************************************/
         
-        public static bool Delete(BuildingElementProperties buildingElementProperties, Document document, bool deleteByName)
+        public static bool Delete(ElementProperties buildingElementProperties, Document document, bool deleteByName)
         {
-            if (document == null)
+            throw new System.NotImplementedException("The method to delete a BHoM Element Properties from Revit has not been fixed yet. Check Issue #247 for more info");
+            /*if (document == null)
             {
                 BH.Engine.Reflection.Compute.RecordError("Revit objects could not be deleted because Revit Document is null.");
                 return false;
@@ -122,14 +123,15 @@ namespace BH.UI.Revit.Adapter
                     aResult = DeleteByUniqueId(buildingElementProperties, document);
                 aTransaction.Commit();
             }
-            return aResult;
+            return aResult;*/
         }
 
         /***************************************************/
         
-        public static bool Delete(IEnumerable<BuildingElementProperties> buildingElementProperties, Document document, bool deleteByName)
+        public static bool Delete(IEnumerable<ElementProperties> buildingElementProperties, Document document, bool deleteByName)
         {
-            if (document == null)
+            throw new System.NotImplementedException("The method to delete a BHoM Element Properties from Revit has not been fixed yet. Check Issue #247 for more info");
+            /*if (document == null)
             {
                 BH.Engine.Reflection.Compute.RecordError("Revit objects could not be deleted because Revit Document is null.");
                 return false;
@@ -164,7 +166,7 @@ namespace BH.UI.Revit.Adapter
                     
                 aTransaction.Commit();
             }
-            return aResult;
+            return aResult;*/
         }
 
 

--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/BuildingElement.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/BuildingElement.cs
@@ -49,7 +49,7 @@ namespace BH.UI.Revit.Engine
 
             ElementType aElementType = element.Document.GetElement(element.GetTypeId()) as ElementType;
 
-            ElementProperties aBuildingElementProperties = aElementType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = aElementType.ToBHoMElementProperties(pullSettings);
 
             aBuildingElement = Create.BuildingElement(aBuildingElementProperties, crv);
             aBuildingElement.Name = Query.FamilyTypeFullName(element);
@@ -98,7 +98,7 @@ namespace BH.UI.Revit.Engine
             if (aBuildingElement != null)
                 return aBuildingElement;
 
-            ElementProperties aBuildingElementProperties = familyInstance.Symbol.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = familyInstance.Symbol.ToBHoMElementProperties(pullSettings);
 
             PolyCurve aPolyCurve = Query.PolyCurve(familyInstance, pullSettings);
 
@@ -159,7 +159,7 @@ namespace BH.UI.Revit.Engine
             if (aElement != null)
             {
                 aElementType = aElement.Document.GetElement(aElement.GetTypeId()) as ElementType;
-                ElementProperties aBuildingElementProperties = aElementType.ToBHoMBuildingElementProperties(pullSettings);
+                ElementProperties aBuildingElementProperties = aElementType.ToBHoMElementProperties(pullSettings);
                 aBuildingElement = Create.BuildingElement(Query.FamilyTypeFullName(aElement), aCurve, aBuildingElementProperties);
             }
 
@@ -268,7 +268,7 @@ namespace BH.UI.Revit.Engine
         //    if (aElement != null)
         //    {
         //        aElementType = aElement.Document.GetElement(aElement.GetTypeId()) as ElementType;
-        //        BuildingElementProperties aBuildingElementProperties = aElementType.ToBHoMBuildingElementProperties(pullSettings);
+        //        BuildingElementProperties aBuildingElementProperties = aElementType.ToBHoMElementProperties(pullSettings);
         //        aBuildingElementProperties.Construction = Query.Construction(energyAnalysisOpening, pullSettings);
         //        aBuildingElement = Create.BuildingElement(Query.FamilyTypeFullName(aElement), aCurve, aBuildingElementProperties);
         //        aBuildingElement.ElementID = aElement.Id.IntegerValue.ToString();
@@ -365,7 +365,7 @@ namespace BH.UI.Revit.Engine
             aBuildingElements = new List<BuildingElement>();
 
             CeilingType aCeilingType = ceiling.Document.GetElement(ceiling.GetTypeId()) as CeilingType;
-            ElementProperties aBuildingElementProperties = aCeilingType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = aCeilingType.ToBHoMElementProperties(pullSettings);
             aBuildingElementProperties.Construction = Query.Construction(aCeilingType, pullSettings);
 
             List<PolyCurve> aPolyCurveList_Outer = BH.Engine.Adapters.Revit.Query.OuterPolyCurves(aPolyCurveList);
@@ -425,7 +425,7 @@ namespace BH.UI.Revit.Engine
 
             aBuildingElements = new List<BuildingElement>();
 
-            ElementProperties aBuildingElementProperties = floor.FloorType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = floor.FloorType.ToBHoMElementProperties(pullSettings);
             aBuildingElementProperties.Construction = Query.Construction(floor.FloorType);
 
             List<PolyCurve> aPolyCurveList_Outer = BH.Engine.Adapters.Revit.Query.OuterPolyCurves(aPolyCurveList);
@@ -485,7 +485,7 @@ namespace BH.UI.Revit.Engine
 
             aBuildingElements = new List<BuildingElement>();
 
-            ElementProperties aBuildingElementProperties = roofBase.RoofType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = roofBase.RoofType.ToBHoMElementProperties(pullSettings);
             aBuildingElementProperties.Construction = Query.Construction(roofBase.RoofType, pullSettings);
 
             List<PolyCurve> aPolyCurveList_Outer = BH.Engine.Adapters.Revit.Query.OuterPolyCurves(aPolyCurveList);
@@ -541,7 +541,7 @@ namespace BH.UI.Revit.Engine
 
             aBuildingElements = new List<BuildingElement>();
 
-            ElementProperties aBuildingElementProperties = wall.WallType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = wall.WallType.ToBHoMElementProperties(pullSettings);
             aBuildingElementProperties.Construction = Query.Construction(wall.WallType, pullSettings);
 
             List<PolyCurve> aPolyCurveList = Query.Profiles(wall, pullSettings);

--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/BuildingElement.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/BuildingElement.cs
@@ -49,11 +49,10 @@ namespace BH.UI.Revit.Engine
 
             ElementType aElementType = element.Document.GetElement(element.GetTypeId()) as ElementType;
 
-            BuildingElementProperties aBuildingElementProperties = aElementType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = aElementType.ToBHoMBuildingElementProperties(pullSettings);
 
             aBuildingElement = Create.BuildingElement(aBuildingElementProperties, crv);
             aBuildingElement.Name = Query.FamilyTypeFullName(element);
-            aBuildingElement.ElementID = element.Id.IntegerValue.ToString();
 
             //Set ExtendedProperties
             EnvironmentContextProperties aEnvironmentContextProperties = new EnvironmentContextProperties();
@@ -99,13 +98,12 @@ namespace BH.UI.Revit.Engine
             if (aBuildingElement != null)
                 return aBuildingElement;
 
-            BuildingElementProperties aBuildingElementProperties = familyInstance.Symbol.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = familyInstance.Symbol.ToBHoMBuildingElementProperties(pullSettings);
 
             PolyCurve aPolyCurve = Query.PolyCurve(familyInstance, pullSettings);
 
             aBuildingElement = Create.BuildingElement(aBuildingElementProperties, aPolyCurve);
             aBuildingElement.Name = Query.FamilyTypeFullName(familyInstance);
-            aBuildingElement.ElementID = familyInstance.Id.IntegerValue.ToString();
 
             //Set ExtendedProperties
             EnvironmentContextProperties aEnvironmentContextProperties = new EnvironmentContextProperties();
@@ -161,9 +159,8 @@ namespace BH.UI.Revit.Engine
             if (aElement != null)
             {
                 aElementType = aElement.Document.GetElement(aElement.GetTypeId()) as ElementType;
-                BuildingElementProperties aBuildingElementProperties = aElementType.ToBHoMBuildingElementProperties(pullSettings);
+                ElementProperties aBuildingElementProperties = aElementType.ToBHoMBuildingElementProperties(pullSettings);
                 aBuildingElement = Create.BuildingElement(Query.FamilyTypeFullName(aElement), aCurve, aBuildingElementProperties);
-                aBuildingElement.ElementID = aElement.Id.IntegerValue.ToString();
             }
 
             //Set ExtendedProperties
@@ -368,7 +365,7 @@ namespace BH.UI.Revit.Engine
             aBuildingElements = new List<BuildingElement>();
 
             CeilingType aCeilingType = ceiling.Document.GetElement(ceiling.GetTypeId()) as CeilingType;
-            BuildingElementProperties aBuildingElementProperties = aCeilingType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = aCeilingType.ToBHoMBuildingElementProperties(pullSettings);
             aBuildingElementProperties.Construction = Query.Construction(aCeilingType, pullSettings);
 
             List<PolyCurve> aPolyCurveList_Outer = BH.Engine.Adapters.Revit.Query.OuterPolyCurves(aPolyCurveList);
@@ -377,7 +374,6 @@ namespace BH.UI.Revit.Engine
                 //Create the BuildingElement
                 BuildingElement aBuildingElement = Create.BuildingElement(aBuildingElementProperties, aCurve);
                 aBuildingElement.Name = Query.FamilyTypeFullName(ceiling);
-                aBuildingElement.ElementID = ceiling.Id.IntegerValue.ToString();
 
                 //Set ExtendedProperties
                 EnvironmentContextProperties aEnvironmentContextProperties = new EnvironmentContextProperties();
@@ -429,7 +425,7 @@ namespace BH.UI.Revit.Engine
 
             aBuildingElements = new List<BuildingElement>();
 
-            BuildingElementProperties aBuildingElementProperties = floor.FloorType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = floor.FloorType.ToBHoMBuildingElementProperties(pullSettings);
             aBuildingElementProperties.Construction = Query.Construction(floor.FloorType);
 
             List<PolyCurve> aPolyCurveList_Outer = BH.Engine.Adapters.Revit.Query.OuterPolyCurves(aPolyCurveList);
@@ -438,7 +434,6 @@ namespace BH.UI.Revit.Engine
                 //Create the BuildingElement
                 BuildingElement aBuildingElement = Create.BuildingElement(aBuildingElementProperties, aCurve);
                 aBuildingElement.Name = Query.FamilyTypeFullName(floor);
-                aBuildingElement.ElementID = floor.Id.IntegerValue.ToString();
 
                 //Set ExtendedProperties
                 EnvironmentContextProperties aEnvironmentContextProperties = new EnvironmentContextProperties();
@@ -490,7 +485,7 @@ namespace BH.UI.Revit.Engine
 
             aBuildingElements = new List<BuildingElement>();
 
-            BuildingElementProperties aBuildingElementProperties = roofBase.RoofType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = roofBase.RoofType.ToBHoMBuildingElementProperties(pullSettings);
             aBuildingElementProperties.Construction = Query.Construction(roofBase.RoofType, pullSettings);
 
             List<PolyCurve> aPolyCurveList_Outer = BH.Engine.Adapters.Revit.Query.OuterPolyCurves(aPolyCurveList);
@@ -499,7 +494,6 @@ namespace BH.UI.Revit.Engine
                 //Create the BuildingElement
                 BuildingElement aBuildingElement = Create.BuildingElement(aBuildingElementProperties, aCurve);
                 aBuildingElement.Name = Query.FamilyTypeFullName(roofBase);
-                aBuildingElement.ElementID = roofBase.Id.IntegerValue.ToString();
 
                 //Set ExtendedProperties
                 EnvironmentContextProperties aEnvironmentContextProperties = new EnvironmentContextProperties();
@@ -547,7 +541,7 @@ namespace BH.UI.Revit.Engine
 
             aBuildingElements = new List<BuildingElement>();
 
-            BuildingElementProperties aBuildingElementProperties = wall.WallType.ToBHoMBuildingElementProperties(pullSettings);
+            ElementProperties aBuildingElementProperties = wall.WallType.ToBHoMBuildingElementProperties(pullSettings);
             aBuildingElementProperties.Construction = Query.Construction(wall.WallType, pullSettings);
 
             List<PolyCurve> aPolyCurveList = Query.Profiles(wall, pullSettings);
@@ -558,7 +552,6 @@ namespace BH.UI.Revit.Engine
                 //Create the BuildingElement
                 BuildingElement aBuildingElement = Create.BuildingElement(aBuildingElementProperties, aCurve);
                 aBuildingElement.Name = Query.FamilyTypeFullName(wall);
-                aBuildingElement.ElementID = wall.Id.IntegerValue.ToString();
 
                 //Set ExtendedProperties
                 EnvironmentContextProperties aEnvironmentContextProperties = new EnvironmentContextProperties();

--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/BuildingElementProperties.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/BuildingElementProperties.cs
@@ -35,12 +35,12 @@ namespace BH.UI.Revit.Engine
         /****             Internal methods              ****/
         /***************************************************/
 
-        internal static BuildingElementProperties ToBHoMBuildingElementProperties(this ElementType elementType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMBuildingElementProperties(this ElementType elementType, PullSettings pullSettings = null)
         {
             //TODO: dynamic does not work. ToBHoM for WallType not recognized
             //aBuildingElementProperties = (elementType as dynamic).ToBHoM(discipline, copyCustomData, convertUnits) as BuildingElementProperties;
 
-            BuildingElementProperties aBuildingElementProperties = null;
+            ElementProperties aBuildingElementProperties = null;
 
             if (elementType is WallType)
                 aBuildingElementProperties = (elementType as WallType).ToBHoMBuildingElementProperties(pullSettings);
@@ -54,142 +54,58 @@ namespace BH.UI.Revit.Engine
                 aBuildingElementProperties = (elementType as FamilySymbol).ToBHoMBuildingElementProperties(pullSettings);
 
             if (aBuildingElementProperties == null)
-                aBuildingElementProperties = new BuildingElementProperties();
+                aBuildingElementProperties = new ElementProperties();
 
             return aBuildingElementProperties;
         }
 
         /***************************************************/
 
-        internal static BuildingElementProperties ToBHoMBuildingElementProperties(this WallType wallType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMBuildingElementProperties(this WallType wallType, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
 
-            BuildingElementProperties aBuildingElementProperties = pullSettings.FindRefObject<BuildingElementProperties>(wallType.Id.IntegerValue);
-            if (aBuildingElementProperties != null)
-                return aBuildingElementProperties;
-
-            aBuildingElementProperties = Create.BuildingElementProperties(Query.FamilyTypeFullName(wallType), BuildingElementType.Wall);
-            aBuildingElementProperties.Construction = Query.Construction(wallType, pullSettings);
-            //aBuildingElementProperties = Create.BuildingElementProperties(wallType.Name, BuildingElementType.Wall);
-
-            aBuildingElementProperties = Modify.SetIdentifiers(aBuildingElementProperties, wallType) as BuildingElementProperties;
-            if (pullSettings.CopyCustomData)
-            {
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, wallType, pullSettings.ConvertUnits) as BuildingElementProperties;
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, wallType, BuiltInParameter.ALL_MODEL_FAMILY_NAME, pullSettings.ConvertUnits) as BuildingElementProperties;
-            }
-
-            pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aBuildingElementProperties);
-
-            return aBuildingElementProperties;
+            return Create.ElementProperties(BuildingElementType.Wall, Query.Construction(wallType, pullSettings));
         }
 
         /***************************************************/
 
-        internal static BuildingElementProperties ToBHoMBuildingElementProperties(this FloorType floorType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMBuildingElementProperties(this FloorType floorType, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
 
-            BuildingElementProperties aBuildingElementProperties = pullSettings.FindRefObject<BuildingElementProperties>(floorType.Id.IntegerValue);
-            if (aBuildingElementProperties != null)
-                return aBuildingElementProperties;
-
-            aBuildingElementProperties = Create.BuildingElementProperties(Query.FamilyTypeFullName(floorType), BuildingElementType.Floor);
-            aBuildingElementProperties.Construction = Query.Construction(floorType, pullSettings);
-            //aBuildingElementProperties = Create.BuildingElementProperties(floorType.Name, BuildingElementType.Floor);
-
-            aBuildingElementProperties = Modify.SetIdentifiers(aBuildingElementProperties, floorType) as BuildingElementProperties;
-            if (pullSettings.CopyCustomData)
-            {
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, floorType, pullSettings.ConvertUnits) as BuildingElementProperties;
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, floorType, BuiltInParameter.ALL_MODEL_FAMILY_NAME, pullSettings.ConvertUnits) as BuildingElementProperties;
-            }
-
-            pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aBuildingElementProperties);
-
-            return aBuildingElementProperties;
+            return Create.ElementProperties(BuildingElementType.Floor, Query.Construction(floorType, pullSettings));
         }
 
         /***************************************************/
 
-        internal static BuildingElementProperties ToBHoMBuildingElementProperties(this CeilingType ceilingType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMBuildingElementProperties(this CeilingType ceilingType, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
 
-            BuildingElementProperties aBuildingElementProperties = pullSettings.FindRefObject<BuildingElementProperties>(ceilingType.Id.IntegerValue);
-            if (aBuildingElementProperties != null)
-                return aBuildingElementProperties;
-
-            aBuildingElementProperties = Create.BuildingElementProperties(Query.FamilyTypeFullName(ceilingType), BuildingElementType.Ceiling);
-            aBuildingElementProperties.Construction = Query.Construction(ceilingType, pullSettings);
-            //aBuildingElementProperties = Create.BuildingElementProperties(ceilingType.Name, BuildingElementType.Ceiling);
-
-            aBuildingElementProperties = Modify.SetIdentifiers(aBuildingElementProperties, ceilingType) as BuildingElementProperties;
-            if (pullSettings.CopyCustomData)
-            {
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, ceilingType, pullSettings.ConvertUnits) as BuildingElementProperties;
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, ceilingType, BuiltInParameter.ALL_MODEL_FAMILY_NAME, pullSettings.ConvertUnits) as BuildingElementProperties;
-            }
-
-            pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aBuildingElementProperties);
-
-            return aBuildingElementProperties;
+            return Create.ElementProperties(BuildingElementType.Ceiling, Query.Construction(ceilingType, pullSettings));
         }
 
         /***************************************************/
 
-        internal static BuildingElementProperties ToBHoMBuildingElementProperties(this RoofType roofType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMBuildingElementProperties(this RoofType roofType, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
 
-            BuildingElementProperties aBuildingElementProperties = pullSettings.FindRefObject<BuildingElementProperties>(roofType.Id.IntegerValue);
-            if (aBuildingElementProperties != null)
-                return aBuildingElementProperties;
-
-            aBuildingElementProperties = Create.BuildingElementProperties(Query.FamilyTypeFullName(roofType), BuildingElementType.Roof);
-            aBuildingElementProperties.Construction = Query.Construction(roofType, pullSettings);
-            //aBuildingElementProperties = Create.BuildingElementProperties(roofType.Name, BuildingElementType.Roof);
-
-            aBuildingElementProperties = Modify.SetIdentifiers(aBuildingElementProperties, roofType) as BuildingElementProperties;
-            if (pullSettings.CopyCustomData)
-            {
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, roofType, pullSettings.ConvertUnits) as BuildingElementProperties;
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, roofType, BuiltInParameter.ALL_MODEL_FAMILY_NAME, pullSettings.ConvertUnits) as BuildingElementProperties;
-            }
-
-            pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aBuildingElementProperties);
-
-            return aBuildingElementProperties;
+            return Create.ElementProperties(BuildingElementType.Roof, Query.Construction(roofType, pullSettings));
         }
 
         /***************************************************/
 
-        internal static BuildingElementProperties ToBHoMBuildingElementProperties(this FamilySymbol familySymbol, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMBuildingElementProperties(this FamilySymbol familySymbol, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
-
-            BuildingElementProperties aBuildingElementProperties = pullSettings.FindRefObject<BuildingElementProperties>(familySymbol.Id.IntegerValue);
-            if (aBuildingElementProperties != null)
-                return aBuildingElementProperties;
 
             BuildingElementType? aBuildingElementType = Query.BuildingElementType(familySymbol.Category);
             if (!aBuildingElementType.HasValue)
                 aBuildingElementType = BuildingElementType.Undefined;
 
-            aBuildingElementProperties = Create.BuildingElementProperties(Query.FamilyTypeFullName(familySymbol), aBuildingElementType.Value);
-            //aBuildingElementProperties = Create.BuildingElementProperties(familySymbol.Name, aBuildingElementType.Value);
-
-            aBuildingElementProperties = Modify.SetIdentifiers(aBuildingElementProperties, familySymbol) as BuildingElementProperties;
-            if (pullSettings.CopyCustomData)
-            {
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, familySymbol, pullSettings.ConvertUnits) as BuildingElementProperties;
-                aBuildingElementProperties = Modify.SetCustomData(aBuildingElementProperties, familySymbol, BuiltInParameter.ALL_MODEL_FAMILY_NAME, pullSettings.ConvertUnits) as BuildingElementProperties;
-            }
-
-            pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aBuildingElementProperties);
-
-            return aBuildingElementProperties;
+            return Create.ElementProperties(aBuildingElementType.Value);
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/ElementProperties.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/ElementProperties.cs
@@ -35,7 +35,7 @@ namespace BH.UI.Revit.Engine
         /****             Internal methods              ****/
         /***************************************************/
 
-        internal static ElementProperties ToBHoMBuildingElementProperties(this ElementType elementType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMElementProperties(this ElementType elementType, PullSettings pullSettings = null)
         {
             //TODO: dynamic does not work. ToBHoM for WallType not recognized
             //aBuildingElementProperties = (elementType as dynamic).ToBHoM(discipline, copyCustomData, convertUnits) as BuildingElementProperties;
@@ -43,15 +43,15 @@ namespace BH.UI.Revit.Engine
             ElementProperties aBuildingElementProperties = null;
 
             if (elementType is WallType)
-                aBuildingElementProperties = (elementType as WallType).ToBHoMBuildingElementProperties(pullSettings);
+                aBuildingElementProperties = (elementType as WallType).ToBHoMElementProperties(pullSettings);
             else if (elementType is FloorType)
-                aBuildingElementProperties = (elementType as FloorType).ToBHoMBuildingElementProperties(pullSettings);
+                aBuildingElementProperties = (elementType as FloorType).ToBHoMElementProperties(pullSettings);
             else if (elementType is CeilingType)
-                aBuildingElementProperties = (elementType as CeilingType).ToBHoMBuildingElementProperties(pullSettings);
+                aBuildingElementProperties = (elementType as CeilingType).ToBHoMElementProperties(pullSettings);
             else if (elementType is RoofType)
-                aBuildingElementProperties = (elementType as RoofType).ToBHoMBuildingElementProperties(pullSettings);
+                aBuildingElementProperties = (elementType as RoofType).ToBHoMElementProperties(pullSettings);
             else if (elementType is FamilySymbol)
-                aBuildingElementProperties = (elementType as FamilySymbol).ToBHoMBuildingElementProperties(pullSettings);
+                aBuildingElementProperties = (elementType as FamilySymbol).ToBHoMElementProperties(pullSettings);
 
             if (aBuildingElementProperties == null)
                 aBuildingElementProperties = new ElementProperties();
@@ -61,7 +61,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        internal static ElementProperties ToBHoMBuildingElementProperties(this WallType wallType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMElementProperties(this WallType wallType, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
 
@@ -70,7 +70,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        internal static ElementProperties ToBHoMBuildingElementProperties(this FloorType floorType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMElementProperties(this FloorType floorType, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
 
@@ -79,7 +79,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        internal static ElementProperties ToBHoMBuildingElementProperties(this CeilingType ceilingType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMElementProperties(this CeilingType ceilingType, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
 
@@ -88,7 +88,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        internal static ElementProperties ToBHoMBuildingElementProperties(this RoofType roofType, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMElementProperties(this RoofType roofType, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
 
@@ -97,7 +97,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        internal static ElementProperties ToBHoMBuildingElementProperties(this FamilySymbol familySymbol, PullSettings pullSettings = null)
+        internal static ElementProperties ToBHoMElementProperties(this FamilySymbol familySymbol, PullSettings pullSettings = null)
         {
             pullSettings = pullSettings.DefaultIfNull();
 

--- a/Engine_Revit_UI/Convert/Environment/ToRevit/Element.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToRevit/Element.cs
@@ -40,7 +40,8 @@ namespace BH.UI.Revit.Engine
 
         internal static Element ToRevitElement(this BuildingElement buildingElement, Document document, PushSettings pushSettings = null)
         {
-            if (buildingElement == null || buildingElement.BuildingElementProperties == null || document == null)
+            throw new System.NotImplementedException("The method to convert a BHoM Building Element into a Revit Element has not been fixed yet. Check Issue #247 for more info");
+            /*if (buildingElement == null || buildingElement.BuildingElementProperties == null || document == null)
                 return null;
 
             Element aElement = pushSettings.FindRefObject<Element>(document, buildingElement.BHoM_Guid);
@@ -234,7 +235,7 @@ namespace BH.UI.Revit.Engine
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(buildingElement, aElement);
 
-            return aElement;
+            return aElement;*/
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Environment/ToRevit/ElementType.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToRevit/ElementType.cs
@@ -37,9 +37,10 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        internal static ElementType ToRevitElementType(this BuildingElementProperties buildingElementProperties, Document document, PushSettings pushSettings = null)
+        internal static ElementType ToRevitElementType(this ElementProperties buildingElementProperties, Document document, PushSettings pushSettings = null)
         {
-            if (buildingElementProperties == null || document == null)
+            throw new System.NotImplementedException("The method to convert a BHoM Building Element into a Revit Element has not been fixed yet. Check Issue #247 for more info");
+            /*if (buildingElementProperties == null || document == null)
                 return null;
 
             ElementType aElementType = pushSettings.FindRefObject<ElementType>(document, buildingElementProperties.BHoM_Guid);
@@ -69,7 +70,7 @@ namespace BH.UI.Revit.Engine
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(buildingElementProperties, aElementType);
 
-            return aElementType;
+            return aElementType;*/
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Environment/ToRevit/ElementType.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToRevit/ElementType.cs
@@ -39,7 +39,7 @@ namespace BH.UI.Revit.Engine
 
         internal static ElementType ToRevitElementType(this ElementProperties buildingElementProperties, Document document, PushSettings pushSettings = null)
         {
-            throw new System.NotImplementedException("The method to convert a BHoM Building Element into a Revit Element has not been fixed yet. Check Issue #247 for more info");
+            throw new System.NotImplementedException("The method to convert a BHoM Building Element Type into a Revit Element Type has not been fixed yet. Check Issue #247 for more info");
             /*if (buildingElementProperties == null || document == null)
                 return null;
 

--- a/Engine_Revit_UI/Convert/ToBHoM.cs
+++ b/Engine_Revit_UI/Convert/ToBHoM.cs
@@ -195,7 +195,7 @@ namespace BH.UI.Revit.Engine
             switch (pullSettings.Discipline)
             {
                 //case Discipline.Environmental:
-                    //return wallType.ToBHoMBuildingElementProperties(pullSettings); 
+                    //return wallType.ToBHoMElementProperties(pullSettings); 
                 case Discipline.Structural:
                     return wallType.ToBHoMSurfaceProperty(pullSettings) as IBHoMObject;
             }
@@ -215,7 +215,7 @@ namespace BH.UI.Revit.Engine
             switch (pullSettings.Discipline)
             {
                 //case Discipline.Environmental:
-                    //return floorType.ToBHoMBuildingElementProperties(pullSettings);
+                    //return floorType.ToBHoMElementProperties(pullSettings);
                 case Discipline.Structural:
                     return floorType.ToBHoMSurfaceProperty(pullSettings) as IBHoMObject;
             }
@@ -235,7 +235,7 @@ namespace BH.UI.Revit.Engine
             switch (pullSettings.Discipline)
             {
                 //case Discipline.Environmental:
-                    //return ceilingType.ToBHoMBuildingElementProperties(pullSettings);
+                    //return ceilingType.ToBHoMElementProperties(pullSettings);
             }
 
             ceilingType.NotConvertedWarning();
@@ -253,7 +253,7 @@ namespace BH.UI.Revit.Engine
             switch (pullSettings.Discipline)
             {
                 //case Discipline.Environmental:
-                    //return roofType.ToBHoMBuildingElementProperties(pullSettings);
+                    //return roofType.ToBHoMElementProperties(pullSettings);
             }
 
             roofType.NotConvertedWarning();
@@ -271,7 +271,7 @@ namespace BH.UI.Revit.Engine
             switch (pullSettings.Discipline)
             {
                 //case Discipline.Environmental:
-                    //return familySymbol.ToBHoMBuildingElementProperties(pullSettings);
+                    //return familySymbol.ToBHoMElementProperties(pullSettings);
                 case Discipline.Structural:
                     return familySymbol.ToBHoMProfile(pullSettings);
             }
@@ -331,7 +331,7 @@ namespace BH.UI.Revit.Engine
             switch (pullSettings.Discipline)
             {
                 //case Discipline.Environmental:
-                    //return elementType.ToBHoMBuildingElementProperties(pullSettings);
+                    //return elementType.ToBHoMElementProperties(pullSettings);
             }
 
             elementType.NotConvertedWarning();

--- a/Engine_Revit_UI/Convert/ToBHoM.cs
+++ b/Engine_Revit_UI/Convert/ToBHoM.cs
@@ -194,8 +194,8 @@ namespace BH.UI.Revit.Engine
 
             switch (pullSettings.Discipline)
             {
-                case Discipline.Environmental:
-                    return wallType.ToBHoMBuildingElementProperties(pullSettings); 
+                //case Discipline.Environmental:
+                    //return wallType.ToBHoMBuildingElementProperties(pullSettings); 
                 case Discipline.Structural:
                     return wallType.ToBHoMSurfaceProperty(pullSettings) as IBHoMObject;
             }
@@ -214,8 +214,8 @@ namespace BH.UI.Revit.Engine
 
             switch (pullSettings.Discipline)
             {
-                case Discipline.Environmental:
-                    return floorType.ToBHoMBuildingElementProperties(pullSettings);
+                //case Discipline.Environmental:
+                    //return floorType.ToBHoMBuildingElementProperties(pullSettings);
                 case Discipline.Structural:
                     return floorType.ToBHoMSurfaceProperty(pullSettings) as IBHoMObject;
             }
@@ -234,8 +234,8 @@ namespace BH.UI.Revit.Engine
 
             switch (pullSettings.Discipline)
             {
-                case Discipline.Environmental:
-                    return ceilingType.ToBHoMBuildingElementProperties(pullSettings);
+                //case Discipline.Environmental:
+                    //return ceilingType.ToBHoMBuildingElementProperties(pullSettings);
             }
 
             ceilingType.NotConvertedWarning();
@@ -252,8 +252,8 @@ namespace BH.UI.Revit.Engine
 
             switch (pullSettings.Discipline)
             {
-                case Discipline.Environmental:
-                    return roofType.ToBHoMBuildingElementProperties(pullSettings);
+                //case Discipline.Environmental:
+                    //return roofType.ToBHoMBuildingElementProperties(pullSettings);
             }
 
             roofType.NotConvertedWarning();
@@ -270,8 +270,8 @@ namespace BH.UI.Revit.Engine
 
             switch (pullSettings.Discipline)
             {
-                case Discipline.Environmental:
-                    return familySymbol.ToBHoMBuildingElementProperties(pullSettings);
+                //case Discipline.Environmental:
+                    //return familySymbol.ToBHoMBuildingElementProperties(pullSettings);
                 case Discipline.Structural:
                     return familySymbol.ToBHoMProfile(pullSettings);
             }
@@ -330,8 +330,8 @@ namespace BH.UI.Revit.Engine
 
             switch (pullSettings.Discipline)
             {
-                case Discipline.Environmental:
-                    return elementType.ToBHoMBuildingElementProperties(pullSettings);
+                //case Discipline.Environmental:
+                    //return elementType.ToBHoMBuildingElementProperties(pullSettings);
             }
 
             elementType.NotConvertedWarning();

--- a/Engine_Revit_UI/Convert/ToRevit.cs
+++ b/Engine_Revit_UI/Convert/ToRevit.cs
@@ -121,7 +121,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static Element ToRevit(this BuildingElementProperties buildingElementProperties, Document document, PushSettings pushSettings = null)
+        public static Element ToRevit(this ElementProperties buildingElementProperties, Document document, PushSettings pushSettings = null)
         {
             pushSettings = pushSettings.DefaultIfNull();
 

--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -185,7 +185,7 @@
     <Compile Include="Convert\Environment\ToBHoM\Building.cs" />
     <Compile Include="Convert\Environment\ToBHoM\BuildingElement.cs" />
     <Compile Include="Convert\Environment\ToBHoM\Panel.cs" />
-    <Compile Include="Convert\Environment\ToBHoM\BuildingElementProperties.cs" />
+    <Compile Include="Convert\Environment\ToBHoM\ElementProperties.cs" />
     <Compile Include="Convert\Environment\ToBHoM\Space.cs" />
     <Compile Include="Convert\Environment\ToRevit\CompoundStructureLayer.cs" />
     <Compile Include="Convert\Environment\ToRevit\Element.cs" />

--- a/Engine_Revit_UI/Query/BHoMTypes.cs
+++ b/Engine_Revit_UI/Query/BHoMTypes.cs
@@ -81,34 +81,34 @@ namespace BH.UI.Revit.Engine
                 {
                     case Autodesk.Revit.DB.BuiltInCategory.OST_Windows:
                     case Autodesk.Revit.DB.BuiltInCategory.OST_Doors:
-                        aResult.Add(typeof(BuildingElementProperties));
+                        aResult.Add(typeof(ElementProperties));
                         return aResult;
                 }
             }
 
             if (element is CeilingType)
             {
-                aResult.Add(typeof(BuildingElementProperties));
+                aResult.Add(typeof(ElementProperties));
                 return aResult;
             }
 
             if (element is WallType)
             {
-                aResult.Add(typeof(BuildingElementProperties));
+                aResult.Add(typeof(ElementProperties));
                 aResult.Add(typeof(ISurfaceProperty));
                 return aResult;
             }
 
             if (element is FloorType)
             {
-                aResult.Add(typeof(BuildingElementProperties));
+                aResult.Add(typeof(ElementProperties));
                 aResult.Add(typeof(ISurfaceProperty));
                 return aResult;
             }
 
             if (element is RoofType)
             {
-                aResult.Add(typeof(BuildingElementProperties));
+                aResult.Add(typeof(ElementProperties));
                 aResult.Add(typeof(ISurfaceProperty));
                 return aResult;
             }

--- a/Revit_Engine/Create/Elements/BuildingElement.cs
+++ b/Revit_Engine/Create/Elements/BuildingElement.cs
@@ -29,6 +29,8 @@ using BH.oM.Environment.Properties;
 using System.Collections.Generic;
 using System.Linq;
 
+using BH.Engine.Environment;
+
 namespace BH.Engine.Adapters.Revit
 {
     public static partial class Create
@@ -60,12 +62,17 @@ namespace BH.Engine.Adapters.Revit
 
             PolyCurve aPolyCurve = Geometry.Create.PolyCurve(new ICurve[] { curve, Geometry.Create.Line(aPoint_Min_1, aPoint_Max_1) , aCurve, Geometry.Create.Line(aPoint_Max_2, aPoint_Min_2) });
 
-            BuildingElementProperties aBuildingElementProperties = Environment.Create.BuildingElementProperties(familyTypeName, BuildingElementType.Wall);
-            aBuildingElementProperties = Modify.SetFamilyTypeName(aBuildingElementProperties, familyTypeName);
+            ElementProperties aBuildingElementProperties = Environment.Create.ElementProperties(BuildingElementType.Wall);
+
+            EnvironmentContextProperties aEnvironmentContextProperties = new EnvironmentContextProperties();
+            aEnvironmentContextProperties.TypeName = familyTypeName;
 
             BuildingElement aBuildingElement = Environment.Create.BuildingElement(aBuildingElementProperties, aPolyCurve);
             aBuildingElement.Name = familyTypeName;
             aBuildingElement.CustomData.Add(Convert.CategoryName, "Walls");
+
+            aBuildingElement.AddExtendedProperty(aEnvironmentContextProperties);
+            aBuildingElement.AddExtendedProperty(aBuildingElementProperties);
 
             return aBuildingElement;
         }
@@ -81,7 +88,7 @@ namespace BH.Engine.Adapters.Revit
             if (polyCurve == null || string.IsNullOrEmpty(familyTypeName))
                 return null;
 
-            BuildingElement aBuildingElement = Environment.Create.BuildingElement(Environment.Create.BuildingElementProperties(familyTypeName), polyCurve);
+            BuildingElement aBuildingElement = Environment.Create.BuildingElement(polyCurve);
             aBuildingElement.Name = familyTypeName;
 
             return aBuildingElement;
@@ -99,11 +106,16 @@ namespace BH.Engine.Adapters.Revit
             if (polyCurve == null || string.IsNullOrEmpty(familyTypeName))
                 return null;
 
-            BuildingElementProperties aBuildingElementProperties = Environment.Create.BuildingElementProperties(familyTypeName, buildingElementType);
-            aBuildingElementProperties = Modify.SetFamilyTypeName(aBuildingElementProperties, familyTypeName);
+            ElementProperties aBuildingElementProperties = Environment.Create.ElementProperties(buildingElementType);
+
+            EnvironmentContextProperties aEnvironmentContextProperties = new EnvironmentContextProperties();
+            aEnvironmentContextProperties.TypeName = familyTypeName;
 
             BuildingElement aBuildingElement = Environment.Create.BuildingElement(aBuildingElementProperties, polyCurve);
             aBuildingElement.Name = familyTypeName;
+
+            aBuildingElement.AddExtendedProperty(aEnvironmentContextProperties);
+            aBuildingElement.AddExtendedProperty(aBuildingElementProperties);
 
             return aBuildingElement;
         }
@@ -147,7 +159,7 @@ namespace BH.Engine.Adapters.Revit
             if (points == null || string.IsNullOrEmpty(familyTypeName) || points.Count() < 3)
                 return null;
 
-            ElementProperties aBuildingElementProperties = Environment.Create.BuildingElementProperties(buildingElementType);
+            ElementProperties aBuildingElementProperties = Environment.Create.ElementProperties(buildingElementType);
             EnvironmentContextProperties envContextProperties = new EnvironmentContextProperties();
             envContextProperties.TypeName = familyTypeName;
 

--- a/Revit_Engine/Create/Elements/BuildingElement.cs
+++ b/Revit_Engine/Create/Elements/BuildingElement.cs
@@ -147,11 +147,13 @@ namespace BH.Engine.Adapters.Revit
             if (points == null || string.IsNullOrEmpty(familyTypeName) || points.Count() < 3)
                 return null;
 
-            BuildingElementProperties aBuildingElementProperties = Environment.Create.BuildingElementProperties(familyTypeName, buildingElementType);
-            aBuildingElementProperties = Modify.SetFamilyTypeName(aBuildingElementProperties, familyTypeName);
+            ElementProperties aBuildingElementProperties = Environment.Create.BuildingElementProperties(buildingElementType);
+            EnvironmentContextProperties envContextProperties = new EnvironmentContextProperties();
+            envContextProperties.TypeName = familyTypeName;
 
             BuildingElement aBuildingElement = BuildingElement(points, familyTypeName);
-            aBuildingElement.BuildingElementProperties = aBuildingElementProperties;
+            aBuildingElement.ExtendedProperties.Add(aBuildingElementProperties);
+            aBuildingElement.ExtendedProperties.Add(envContextProperties);
 
             return aBuildingElement;
         }

--- a/Revit_Engine/Modify/SetFamilyName.cs
+++ b/Revit_Engine/Modify/SetFamilyName.cs
@@ -33,10 +33,10 @@ namespace BH.Engine.Adapters.Revit
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Sets Family Type name for Builiding Element Properties")]
-        [Input("buildingElementProperties", "Building Element Properties")]
+        [Description("Sets Family Type name for Environment Context Properties")]
+        [Input("environmentContextProperties", "Environment Context Properties")]
         [Input("familyTypeName", "Revit Family Type Name")]
-        [Output("BuildingElementProperties")]
+        [Output("EnvironmentContextProperties")]
         public static EnvironmentContextProperties SetFamilyTypeName(this EnvironmentContextProperties environmentContextProperties, string familyTypeName)
         {
             if (environmentContextProperties == null)

--- a/Revit_Engine/Modify/SetFamilyName.cs
+++ b/Revit_Engine/Modify/SetFamilyName.cs
@@ -37,17 +37,15 @@ namespace BH.Engine.Adapters.Revit
         [Input("buildingElementProperties", "Building Element Properties")]
         [Input("familyTypeName", "Revit Family Type Name")]
         [Output("BuildingElementProperties")]
-        public static BuildingElementProperties SetFamilyTypeName(this BuildingElementProperties buildingElementProperties, string familyTypeName)
+        public static EnvironmentContextProperties SetFamilyTypeName(this EnvironmentContextProperties environmentContextProperties, string familyTypeName)
         {
-            if (buildingElementProperties == null)
+            if (environmentContextProperties == null)
                 return null;
 
-            BuildingElementProperties aBuildingElementProperties = buildingElementProperties.GetShallowClone() as BuildingElementProperties;
-
-            if (aBuildingElementProperties.CustomData.ContainsKey(Convert.FamilyTypeName))
-                aBuildingElementProperties.CustomData[Convert.FamilyTypeName] = familyTypeName;
-            else
-                aBuildingElementProperties.CustomData.Add(Convert.FamilyTypeName, familyTypeName);
+            EnvironmentContextProperties aBuildingElementProperties = new EnvironmentContextProperties();
+            aBuildingElementProperties.Description = environmentContextProperties.Description;
+            aBuildingElementProperties.ElementID = environmentContextProperties.ElementID;
+            aBuildingElementProperties.TypeName = familyTypeName;
 
             return aBuildingElementProperties;
         }

--- a/Revit_Engine/Modify/SetFamilyTypeName.cs
+++ b/Revit_Engine/Modify/SetFamilyTypeName.cs
@@ -42,17 +42,15 @@ namespace BH.Engine.Adapters.Revit
         [Input("buildingElementProperties", "Building Element Properties")]
         [Input("familyName", "Revit Family Name")]
         [Output("BuildingElementProperties")]
-        public static BuildingElementProperties SetFamilyName(this BuildingElementProperties buildingElementProperties, string familyName)
+        public static EnvironmentContextProperties SetFamilyName(this EnvironmentContextProperties environmentContextProperties, string familyName)
         {
-            if (buildingElementProperties == null)
+            if (environmentContextProperties == null)
                 return null;
 
-            BuildingElementProperties aBuildingElementProperties = buildingElementProperties.GetShallowClone() as BuildingElementProperties;
-
-            if (aBuildingElementProperties.CustomData.ContainsKey(Convert.FamilyName))
-                aBuildingElementProperties.CustomData[Convert.FamilyName] = familyName;
-            else
-                aBuildingElementProperties.CustomData.Add(Convert.FamilyName, familyName);
+            EnvironmentContextProperties aBuildingElementProperties = new EnvironmentContextProperties();
+            aBuildingElementProperties.Description = environmentContextProperties.Description;
+            aBuildingElementProperties.ElementID = environmentContextProperties.ElementID;
+            aBuildingElementProperties.TypeName = familyName;
 
             return aBuildingElementProperties;
         }

--- a/Revit_Engine/Modify/SetFamilyTypeName.cs
+++ b/Revit_Engine/Modify/SetFamilyTypeName.cs
@@ -38,10 +38,10 @@ namespace BH.Engine.Adapters.Revit
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Sets Family name for Builiding Element Properties")]
-        [Input("buildingElementProperties", "Building Element Properties")]
+        [Description("Sets Family name for Environment Context Properties")]
+        [Input("environmentElementProperties", "Environment Context Properties")]
         [Input("familyName", "Revit Family Name")]
-        [Output("BuildingElementProperties")]
+        [Output("EnvironmentContextProperties")]
         public static EnvironmentContextProperties SetFamilyName(this EnvironmentContextProperties environmentContextProperties, string familyName)
         {
             if (environmentContextProperties == null)


### PR DESCRIPTION
### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/851

   
### Issues addressed by this PR
Fixes #252 

Removes references to deprecated properties of Environment_oM

### Test files
All of @michaldengusiak previous test scripts


### Changelog
#### Removed
 - Removed references to deprecated properties from Environment_oM