### PR TITLE
Revit_Toolkit-Issue287-FamilySymbolOfStructuralFramingBug

### DIFF
--- a/Engine_Revit_UI/Convert/Structure/ToRevit/FamilyInstance.cs
+++ b/Engine_Revit_UI/Convert/Structure/ToRevit/FamilyInstance.cs
@@ -180,7 +180,7 @@ namespace BH.UI.Revit.Engine
 
             if (aFamilySymbol == null)
             {
-                aFamilySymbol = Query.ElementType(framingElement, document, BuiltInCategory.OST_StructuralColumns, pushSettings.FamilyLoadSettings) as FamilySymbol;
+                aFamilySymbol = Query.ElementType(framingElement, document, BuiltInCategory.OST_StructuralFraming, pushSettings.FamilyLoadSettings) as FamilySymbol;
 
                 if (aFamilySymbol == null)
                 {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #287 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
No test file as the fix is quite obvious.