### PR TITLE
Revit_Toolkit-Issue284-PullSpaceTypes

### DIFF
--- a/Engine_Revit_UI/Query/BuiltInCategory.cs
+++ b/Engine_Revit_UI/Query/BuiltInCategory.cs
@@ -156,6 +156,12 @@ namespace BH.UI.Revit.Engine
                 if (aCategory.Name == categoryName)
                     return (BuiltInCategory)aCategory.Id.IntegerValue;
 
+            switch(categoryName)
+            {
+                case "Space Type Settings":
+                    return Autodesk.Revit.DB.BuiltInCategory.OST_HVAC_Load_Space_Types;
+            }
+
             return Autodesk.Revit.DB.BuiltInCategory.INVALID;
         }
 

--- a/Engine_Revit_UI/Query/ElementIds.cs
+++ b/Engine_Revit_UI/Query/ElementIds.cs
@@ -271,7 +271,14 @@ namespace BH.UI.Revit.Engine
             }
 
             if (aType == null)
-                return null;
+            {
+                foreach(TypeInfo aTypeInfo in aAssembly.DefinedTypes)
+                    if(aTypeInfo.Name == typeName)
+                    {
+                        aType = aTypeInfo.AsType();
+                        break;
+                    }
+            }
 
 
             return new FilteredElementCollector(document).OfClass(aType).ToElementIds();


### PR DESCRIPTION
  
### Issues addressed by this PR
Fix for CategoryFilter and TypeNameFilter. Enable to pull Space Types and similar kinds of objects

Closes #284 

### Test files
[Dynamo script and Sample Model](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Revit_Toolkit/Revit_Toolkit-Issue284-PullSpaceTypes?csf=1&e=O6c3fg)