### PR TITLE
Revit_Toolkit-Issue261-ProfileExtraction

### DIFF
--- a/Adapter_Revit_UI/Create/Create.cs
+++ b/Adapter_Revit_UI/Create/Create.cs
@@ -321,7 +321,7 @@ namespace BH.UI.Revit.Adapter
                 if (aParameter != null)
                 {
                     string aValue = aParameter.AsValueString();
-                    if (string.IsNullOrEmpty(aValue))
+                    if (!string.IsNullOrEmpty(aValue))
                         SetCustomData(bHoMObject, BH.Engine.Adapters.Revit.Convert.FamilyName, aValue);
                 }
 
@@ -330,7 +330,7 @@ namespace BH.UI.Revit.Adapter
                 if (aParameter != null)
                 {
                     string aValue = aParameter.AsValueString();
-                    if (string.IsNullOrEmpty(aValue))
+                    if (!string.IsNullOrEmpty(aValue))
                         SetCustomData(bHoMObject, BH.Engine.Adapters.Revit.Convert.FamilyTypeName, aValue);
                 }
 
@@ -339,7 +339,7 @@ namespace BH.UI.Revit.Adapter
                 if (aParameter != null)
                 {
                     string aValue = aParameter.AsValueString();
-                    if (string.IsNullOrEmpty(aValue))
+                    if (!string.IsNullOrEmpty(aValue))
                         SetCustomData(bHoMObject, BH.Engine.Adapters.Revit.Convert.CategoryName, aValue);
                 }
             }

--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -246,8 +246,10 @@
     <Compile Include="Query\BoundingBox.cs" />
     <Compile Include="Query\CompoundLayer.cs" />
     <Compile Include="Query\CompoundLayers.cs" />
+    <Compile Include="Query\FamilySymbols.cs" />
     <Compile Include="Query\HighElevation.cs" />
     <Compile Include="Query\IsValid.cs" />
+    <Compile Include="Query\FamilyPlacementTypeName.cs" />
     <Compile Include="Query\OpeningType.cs" />
     <Compile Include="Query\UpdatePanelTypeByCustomData.cs" />
     <Compile Include="Query\LowElevation.cs" />

--- a/Engine_Revit_UI/Modify/LoadFamilySymbol.cs
+++ b/Engine_Revit_UI/Modify/LoadFamilySymbol.cs
@@ -44,11 +44,11 @@ namespace BH.UI.Revit.Engine
 
             FamilyLibrary aFamilyLibrary = FamilyLoadSettings.FamilyLibrary;
 
-            List<string> aPathList = BH.Engine.Adapters.Revit.Query.Paths(aFamilyLibrary, categoryName, familyName, familyTypeName);
-            if (aPathList == null || aPathList.Count == 0)
+            IEnumerable<string> aPaths = BH.Engine.Adapters.Revit.Query.Paths(aFamilyLibrary, categoryName, familyName, familyTypeName);
+            if (aPaths == null || aPaths.Count() == 0)
                 return null;
 
-            string aPath = aPathList.First();
+            string aPath = aPaths.First();
 
             string aTypeName = familyTypeName;
             if (string.IsNullOrEmpty(aTypeName))

--- a/Engine_Revit_UI/Modify/SetIdentifiers.cs
+++ b/Engine_Revit_UI/Modify/SetIdentifiers.cs
@@ -61,6 +61,8 @@ namespace BH.UI.Revit.Engine
 
                 if (aFamily.FamilyCategory != null)
                     aBHoMObject = aBHoMObject.SetCustomData(BH.Engine.Adapters.Revit.Convert.CategoryName, aFamily.FamilyCategory.Name);
+
+                aBHoMObject = aBHoMObject.SetCustomData(BH.Engine.Adapters.Revit.Convert.FamilyPlacementTypeName, Query.FamilyPlacementTypeName(aFamily));
             }
             else
             {

--- a/Engine_Revit_UI/Query/FamilyPlacementTypeName.cs
+++ b/Engine_Revit_UI/Query/FamilyPlacementTypeName.cs
@@ -20,42 +20,22 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Linq;
-using System.Collections.Generic;
-
-using BH.oM.Adapters.Revit.Generic;
-using BH.Engine.Adapters.Revit;
-using BH.oM.Adapters.Revit.Settings;
-
 using Autodesk.Revit.DB;
 
 namespace BH.UI.Revit.Engine
 {
-    public static partial class Modify
+    public static partial class Query
     {
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
-
-        public static Family LoadFamily(this FamilyLoadSettings FamilyLoadSettings, Document document, string categoryName, string familyName)
+        
+        static public string FamilyPlacementTypeName(this Family family)
         {
-            if (FamilyLoadSettings == null || FamilyLoadSettings.FamilyLibrary == null || document == null)
+            if (family == null)
                 return null;
 
-            FamilyLibrary aFamilyLibrary = FamilyLoadSettings.FamilyLibrary;
-
-            IEnumerable<string> aPaths = BH.Engine.Adapters.Revit.Query.Paths(aFamilyLibrary, categoryName, familyName, null);
-            if (aPaths == null || aPaths.Count() == 0)
-                return null;
-
-            string aPath = aPaths.First();
-
-            Family aFamily= null;
-
-            if (document.LoadFamily(aPath, new FamilyLoadOptions(FamilyLoadSettings), out aFamily))
-                return aFamily;
-
-            return null;
+            return family.FamilyPlacementType.ToString();
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Query/RevitTypes.cs
+++ b/Engine_Revit_UI/Query/RevitTypes.cs
@@ -118,6 +118,12 @@ namespace BH.UI.Revit.Engine
                 return aResult;
             }
 
+            if (type == typeof(oM.Adapters.Revit.Generic.RevitFilePreview))
+            {
+                aResult.Add(typeof(Autodesk.Revit.DB.Family));
+                return aResult;
+            }
+
             return null;
         }
 

--- a/Revit_Engine/Convert/AdapterID.cs
+++ b/Revit_Engine/Convert/AdapterID.cs
@@ -39,6 +39,7 @@ namespace BH.Engine.Adapters.Revit
         public const string ViewName = "Revit_viewName";
         public const string Edges = "Revit_edges";
         public const string ViewTemplate = "View Template";
+        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
         /***************************************************/
     }
 }

--- a/Revit_Engine/Create/Generic/RevitFilePreview.cs
+++ b/Revit_Engine/Create/Generic/RevitFilePreview.cs
@@ -48,50 +48,51 @@ namespace BH.Engine.Adapters.Revit
         {
             XDocument aXDocument = null;
 
-            if (!File.Exists(path))
-                return null;
-
-            StorageInfo aStorageInfo = (StorageInfo)InvokeStorageRootMethod(null, "Open", path, FileMode.Open, FileAccess.Read, FileShare.Read);
-
-            if (aStorageInfo != null)
+            if (File.Exists(path))
             {
-                StreamInfo[] aStreamInfoArray = aStorageInfo.GetStreams();
-                List<string> aNames = aStreamInfoArray.ToList().ConvertAll(x => x.Name);
-                foreach (StreamInfo aStreamInfo in aStreamInfoArray)
-                {
-                    if (aStreamInfo.Name.Equals("PartAtom"))
-                    {
-                        byte[] aBytes = ParseStreamInfo(aStreamInfo);
-                        try
-                        {
-                            aXDocument = XDocument.Parse(Encoding.UTF8.GetString(aBytes));
-                        }
-                        catch
-                        {
-                            aXDocument = null;
-                        }
+                StorageInfo aStorageInfo = (StorageInfo)InvokeStorageRootMethod(null, "Open", path, FileMode.Open, FileAccess.Read, FileShare.Read);
 
-                        if(aXDocument == null)
+                if (aStorageInfo != null)
+                {
+                    StreamInfo[] aStreamInfoArray = aStorageInfo.GetStreams();
+                    List<string> aNames = aStreamInfoArray.ToList().ConvertAll(x => x.Name);
+                    foreach (StreamInfo aStreamInfo in aStreamInfoArray)
+                    {
+                        if (aStreamInfo.Name.Equals("PartAtom"))
                         {
+                            byte[] aBytes = ParseStreamInfo(aStreamInfo);
                             try
                             {
-                                aXDocument = XDocument.Parse(Encoding.Default.GetString(aBytes));
+                                aXDocument = XDocument.Parse(Encoding.UTF8.GetString(aBytes));
                             }
                             catch
                             {
                                 aXDocument = null;
                             }
-                        }
-                        
-                        break;
-                    }
-                }
 
-                CloseStorageInfo(aStorageInfo);
+                            if (aXDocument == null)
+                            {
+                                try
+                                {
+                                    aXDocument = XDocument.Parse(Encoding.Default.GetString(aBytes));
+                                }
+                                catch
+                                {
+                                    aXDocument = null;
+                                }
+                            }
+
+                            break;
+                        }
+                    }
+
+                    CloseStorageInfo(aStorageInfo);
+                }
             }
 
             RevitFilePreview aRevitFilePreview = new RevitFilePreview()
             {
+                Path = path,
                 XDocument = aXDocument
             };
 

--- a/Revit_Engine/Query/Family.cs
+++ b/Revit_Engine/Query/Family.cs
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Adapters.Revit.Generic;
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Engine.Adapters.Revit
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Returns Family based on RevitFilePreview and sepcified Family Type Names")]
+        [Input("revitFilePreview", "RevitFilePreview")]
+        [Input("FamilyTypeNames", "Family Type Names.")]
+        [Output("Family")]
+        public static Family Family(this RevitFilePreview revitFilePreview, IEnumerable<string> FamilyTypeNames)
+        {
+            if (revitFilePreview == null)
+                return null;
+
+            string aFamilyName = revitFilePreview.FamilyName();
+            if (string.IsNullOrEmpty(aFamilyName))
+                return null;
+
+            string aCategoryName = revitFilePreview.CategoryName();
+
+            List<oM.Adapters.Revit.Properties.InstanceProperties> aInstancePropertiesList = new List<oM.Adapters.Revit.Properties.InstanceProperties>();
+
+            List<string> aFamilyTypeNameList = revitFilePreview.FamilyTypeNames();
+            if (aFamilyTypeNameList != null)
+            {
+                foreach (string aFamilyTypeName in aFamilyTypeNameList)
+                {
+                    if (FamilyTypeNames != null && !FamilyTypeNames.Contains(aFamilyTypeName))
+                        continue;
+
+                    oM.Adapters.Revit.Properties.InstanceProperties aInstanceProperties = Create.InstanceProperties(aFamilyName, aFamilyTypeName);
+                    aInstanceProperties = aInstanceProperties.UpdateCustomDataValue(Convert.CategoryName, aCategoryName) as oM.Adapters.Revit.Properties.InstanceProperties;
+                    aInstancePropertiesList.Add(aInstanceProperties);
+                }
+            }
+
+            Family aFamily = new Family()
+            {
+                PropertiesList = aInstancePropertiesList
+            };
+
+            aFamily = aFamily.UpdateCustomDataValue(Convert.FamilyName, aFamilyName) as Family;
+            aFamily = aFamily.UpdateCustomDataValue(Convert.CategoryName, aCategoryName) as Family;
+
+            aFamily = aFamily.UpdateCustomDataValue(Convert.FamilyPlacementTypeName, revitFilePreview.CustomDataValue(Convert.FamilyPlacementTypeName)) as Family;
+
+            return aFamily;
+        }
+
+        /***************************************************/
+
+        [Description("Returns Family based on RevitFilePreview")]
+        [Input("revitFilePreview", "RevitFilePreview")]
+        [Output("Family")]
+        public static Family Family(this RevitFilePreview revitFilePreview)
+        {
+            if (revitFilePreview == null)
+                return null;
+
+            return Family(revitFilePreview, null);
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Revit_Engine/Query/FamilyName.cs
+++ b/Revit_Engine/Query/FamilyName.cs
@@ -88,5 +88,18 @@ namespace BH.Engine.Adapters.Revit
         }
 
         /***************************************************/
+
+        [Description("Gets Revit Family name from Family Type Full Name in format [Family Name] : [Family Type Name].")]
+        [Input("RevitFilePreview", "RevitFilePreview")]
+        [Output("FamilyName")]
+        public static string FamilyName(this oM.Adapters.Revit.Generic.RevitFilePreview revitFilePreview)
+        {
+            if (revitFilePreview == null || string.IsNullOrWhiteSpace(revitFilePreview.Path))
+                return null;
+
+            return System.IO.Path.GetFileNameWithoutExtension(revitFilePreview.Path);
+        }
+
+        /***************************************************/
     }
 }

--- a/Revit_Engine/Query/FamilyPlacementTypeName.cs
+++ b/Revit_Engine/Query/FamilyPlacementTypeName.cs
@@ -20,42 +20,45 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Linq;
-using System.Collections.Generic;
+using System.ComponentModel;
 
-using BH.oM.Adapters.Revit.Generic;
-using BH.Engine.Adapters.Revit;
-using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.DataManipulation.Queries;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Adapters.Revit.Elements;
 
-using Autodesk.Revit.DB;
-
-namespace BH.UI.Revit.Engine
+namespace BH.Engine.Adapters.Revit
 {
-    public static partial class Modify
+    public static partial class Query
     {
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static Family LoadFamily(this FamilyLoadSettings FamilyLoadSettings, Document document, string categoryName, string familyName)
+        static public string FamilyPlacementTypeName(this oM.Adapters.Revit.Generic.RevitFilePreview revitFilePreview)
         {
-            if (FamilyLoadSettings == null || FamilyLoadSettings.FamilyLibrary == null || document == null)
+            if (revitFilePreview == null || revitFilePreview.CustomData == null)
                 return null;
 
-            FamilyLibrary aFamilyLibrary = FamilyLoadSettings.FamilyLibrary;
-
-            IEnumerable<string> aPaths = BH.Engine.Adapters.Revit.Query.Paths(aFamilyLibrary, categoryName, familyName, null);
-            if (aPaths == null || aPaths.Count() == 0)
+            object aValue = null;
+            if (!revitFilePreview.CustomData.TryGetValue(Convert.FamilyPlacementTypeName, out aValue))
                 return null;
 
-            string aPath = aPaths.First();
+            return aValue as string;
+        }
 
-            Family aFamily= null;
+        /***************************************************/
 
-            if (document.LoadFamily(aPath, new FamilyLoadOptions(FamilyLoadSettings), out aFamily))
-                return aFamily;
+        static public string FamilyPlacementTypeName(this Family family)
+        {
+            if (family == null || family.CustomData == null)
+                return null;
 
-            return null;
+            object aValue = null;
+            if (!family.CustomData.TryGetValue(Convert.FamilyPlacementTypeName, out aValue))
+                return null;
+
+            return aValue as string;
         }
 
         /***************************************************/

--- a/Revit_Engine/Query/Paths.cs
+++ b/Revit_Engine/Query/Paths.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Adapters.Revit
         [Description("Returns all Paths in FamilyLibrary of given Category, Family and Family Type")]
         [Input("familyLibrary", "FamilyLibrary")]
         [Output("Paths")]
-        public static List<string> Paths(this FamilyLibrary familyLibrary, string categoryName = null, string familyName = null, string typeName = null)
+        public static IEnumerable<string> Paths(this FamilyLibrary familyLibrary, string categoryName = null, string familyName = null, string typeName = null)
         {
             if (familyLibrary == null || familyLibrary.Dictionary == null || familyLibrary.Dictionary.Keys.Count == 0)
                 return null;
@@ -86,7 +86,7 @@ namespace BH.Engine.Adapters.Revit
                 }
             }
 
-            return aPathList;
+            return aPathList.Distinct();
         }
 
         /***************************************************/

--- a/Revit_Engine/Query/RevitFilePreviews.cs
+++ b/Revit_Engine/Query/RevitFilePreviews.cs
@@ -21,41 +21,45 @@
  */
 
 using System.Linq;
+using System.ComponentModel;
 using System.Collections.Generic;
 
 using BH.oM.Adapters.Revit.Generic;
-using BH.Engine.Adapters.Revit;
-using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Reflection.Attributes;
 
-using Autodesk.Revit.DB;
 
-namespace BH.UI.Revit.Engine
+namespace BH.Engine.Adapters.Revit
 {
-    public static partial class Modify
+    public static partial class Query
     {
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static Family LoadFamily(this FamilyLoadSettings FamilyLoadSettings, Document document, string categoryName, string familyName)
+        [Description("Returns all RevitFilePreviews for FamilyLibrary of given Category, Family and Family Type Name")]
+        [Input("familyLibrary", "FamilyLibrary")]
+        [Input("categoryName", "Family Category Name")]
+        [Input("familyName", "Family Name")]
+        [Input("familyTypeName", "FamilyTypeName")]
+        [Output("RevitFilePreviews")]
+        public static List<RevitFilePreview> RevitFilePreviews(this FamilyLibrary familyLibrary, string categoryName = null, string familyName = null, string familyTypeName = null)
         {
-            if (FamilyLoadSettings == null || FamilyLoadSettings.FamilyLibrary == null || document == null)
+            if (familyLibrary == null || familyLibrary.Dictionary == null || familyLibrary.Dictionary.Keys.Count == 0)
                 return null;
 
-            FamilyLibrary aFamilyLibrary = FamilyLoadSettings.FamilyLibrary;
-
-            IEnumerable<string> aPaths = BH.Engine.Adapters.Revit.Query.Paths(aFamilyLibrary, categoryName, familyName, null);
-            if (aPaths == null || aPaths.Count() == 0)
+            IEnumerable<string> aPaths = familyLibrary.Paths(categoryName, familyName, familyTypeName);
+            if (aPaths == null)
                 return null;
 
-            string aPath = aPaths.First();
+            List<RevitFilePreview> aResult = new List<RevitFilePreview>();
+            if (aPaths.Count() == 0)
+                return aResult;
 
-            Family aFamily= null;
+            foreach (string aPath in aPaths)
+                aResult.Add(Create.RevitFilePreview(aPath));
 
-            if (document.LoadFamily(aPath, new FamilyLoadOptions(FamilyLoadSettings), out aFamily))
-                return aFamily;
 
-            return null;
+            return aResult;
         }
 
         /***************************************************/

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -145,7 +145,10 @@
     <Compile Include="Modify\SetMapSettings.cs" />
     <Compile Include="Modify\SetTag.cs" />
     <Compile Include="Modify\Move.cs" />
+    <Compile Include="Query\FamilyPlacementTypeName.cs" />
     <Compile Include="Query\InnerPolyCurves.cs" />
+    <Compile Include="Query\Family.cs" />
+    <Compile Include="Query\RevitFilePreviews.cs" />
     <Compile Include="Query\RelatedFilterQuery.cs" />
     <Compile Include="Query\Value.cs" />
     <Compile Include="Query\ParameterName.cs" />

--- a/Revit_oM/Generic/RevitFilePreview.cs
+++ b/Revit_oM/Generic/RevitFilePreview.cs
@@ -31,6 +31,7 @@ namespace BH.oM.Adapters.Revit.Generic
         /**** Public Properties                        ****/
         /***************************************************/
 
+        public string Path { get; set; } = null;
         public XDocument XDocument { get; set; } = null;
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
Functionality to Load multiple families and place FamilySymbols

PR related to #261 

### Test files
Sample script and families for tests saved [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Revit_Toolkit/Revit_Toolkit-Issue261-ProfileExtraction?csf=1&e=d0JR1k)


### Changelog
RevitFilePreview Push loads family
Revit_Toolkit Family PlacementType information added
Path property added to RevitFilePreview
RevitFilePreview to Revit_Toolkit Family method added
RevitFilePreview Paths method updated to pull unique path only