### PR TITLE
Revit_Toolkit - issue 304: Update calling of Join() to match changes in Bhom_Engine

### DIFF
--- a/Engine_Revit_UI/Query/Outlines.cs
+++ b/Engine_Revit_UI/Query/Outlines.cs
@@ -58,7 +58,7 @@ namespace BH.UI.Revit.Engine
                         
                 }
 
-                result = wallCurves.IJoin().ConvertAll(c => c as ICurve);
+                result = BH.Engine.Geometry.Compute.IJoin(wallCurves).ConvertAll(c => c as ICurve);
             }
 
             else
@@ -91,7 +91,7 @@ namespace BH.UI.Revit.Engine
                                         }
                                     }
 
-                                    result.AddRange(aPolyCurve.Curves.IJoin().Select(c => c.Translate(toWallLine)));
+                                    result.AddRange(BH.Engine.Geometry.Compute.IJoin(aPolyCurve.Curves).Select(c => c.Translate(toWallLine)));
                                 }
                                 break;                          //TODO: is this OK?
                             }
@@ -133,7 +133,7 @@ namespace BH.UI.Revit.Engine
                     }
                 }
 
-                result = floorCurves.IJoin().ConvertAll(c => c as oM.Geometry.ICurve);
+                result = BH.Engine.Geometry.Compute.IJoin(floorCurves).ConvertAll(c => c as oM.Geometry.ICurve);
             }
 
             else
@@ -164,7 +164,7 @@ namespace BH.UI.Revit.Engine
                                         }
                                     }
 
-                                    result.AddRange(aPolyCurve.Curves.IJoin().Select(c => c.Translate(toFloorLine)));
+                                    result.AddRange(BH.Engine.Geometry.Compute.IJoin(aPolyCurve.Curves).Select(c => c.Translate(toFloorLine)));
                                 }
                                 break;                          //TODO: is this OK?
                             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
[#979](https://github.com/BHoM/BHoM_Engine/pull/979)


 ### Issues addressed by this PR

 Closes #304 

 <!-- Add short description of what has been fixed -->


 ### Test files
No additional test file needed.

 ### Changelog
Updated:
- Outlines

 ### Additional comments
<!-- As required -->
Join() is being moved from BH.Engine.Geometry.Modify to BH.Engine.Geometry.Compute, what requires changes in calls to avoid ambiguity.
