### PR TITLE
Revit_Toolkit - Issue272 - Assemblies To AppData

### DIFF
--- a/Adapter_Revit_UI/Adapter_Revit_UI.csproj
+++ b/Adapter_Revit_UI/Adapter_Revit_UI.csproj
@@ -42,6 +42,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AssemblyName>Adapter_Revit_UI_2018</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -53,6 +54,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AssemblyName>Adapter_Revit_UI_2019</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Analytical_oM, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -42,6 +42,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AssemblyName>Engine_Revit_UI_2018</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -53,6 +54,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AssemblyName>Engine_Revit_UI_2019</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Analytical_oM, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Revit_UI/Files/BHoM_2018.Addin
+++ b/Revit_UI/Files/BHoM_2018.Addin
@@ -2,7 +2,7 @@
 <RevitAddIns>
   <AddIn Type="Application">
     <Name>BHoM Revit</Name>
-    <Assembly>BHoM\Revit_UI.dll</Assembly>
+    <Assembly>..\..\..\..\BHoM\Assemblies\Revit_UI_2018.dll</Assembly>
     <FullClassName>BH.UI.Revit.RevitListener</FullClassName> |
     <AddInId>05D16C68-EA24-4E38-A9D9-6029E2F8C760</AddInId>
     <Text>Buildings and Habitats object Model (BHoM) Revit Addin</Text>

--- a/Revit_UI/Files/BHoM_2019.Addin
+++ b/Revit_UI/Files/BHoM_2019.Addin
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<RevitAddIns>
+  <AddIn Type="Application">
+    <Name>BHoM Revit</Name>
+    <Assembly>..\..\..\..\BHoM\Assemblies\Revit_UI_2019.dll</Assembly>
+    <FullClassName>BH.UI.Revit.RevitListener</FullClassName> |
+    <AddInId>05D16C68-EA24-4E38-A9D9-6029E2F8C760</AddInId>
+    <Text>Buildings and Habitats object Model (BHoM) Revit Addin</Text>
+    <VendorId>BHoM</VendorId>
+  </AddIn>
+</RevitAddIns>

--- a/Revit_UI/RevitListener.cs
+++ b/Revit_UI/RevitListener.cs
@@ -143,7 +143,6 @@ namespace BH.UI.Revit
             UIControlledApplication = uIControlledApplication;
 
             //Make sure all BHoM assemblies are loaded
-            string versionNumber = uIControlledApplication.ControlledApplication.VersionNumber;
             BH.Engine.Reflection.Compute.LoadAllAssemblies();
 
             //Add button to set socket ports

--- a/Revit_UI/RevitListener.cs
+++ b/Revit_UI/RevitListener.cs
@@ -144,8 +144,7 @@ namespace BH.UI.Revit
 
             //Make sure all BHoM assemblies are loaded
             string versionNumber = uIControlledApplication.ControlledApplication.VersionNumber;
-            string path = Environment.GetEnvironmentVariable("APPDATA") + @"\Autodesk\Revit\Addins\" + versionNumber +  @"\BHoM";
-            BH.Engine.Reflection.Compute.LoadAllAssemblies(path);
+            BH.Engine.Reflection.Compute.LoadAllAssemblies();
 
             //Add button to set socket ports
             AddRibbonItems(uIControlledApplication);

--- a/Revit_UI/Revit_UI.csproj
+++ b/Revit_UI/Revit_UI.csproj
@@ -47,6 +47,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\Build\Revit_UI.xml</DocumentationFile>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AssemblyName>Revit_UI_2018</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -58,6 +59,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\Build\Revit_UI.xml</DocumentationFile>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AssemblyName>Revit_UI_2019</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BHoM">
@@ -151,12 +153,6 @@
     <Compile Include="UpdatePorts.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Files\BHoM.Addin">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <SubType>Designer</SubType>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Adapter_Revit_UI\Adapter_Revit_UI.csproj">
       <Project>{c2bd93af-8853-4685-8bd4-223055de1cc6}</Project>
       <Name>Adapter_Revit_UI</Name>
@@ -179,22 +175,22 @@
       <DependentUpon>UpdatePortsForm.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Files\BHoM_2018.Addin">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Files\BHoM_2019.Addin">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2018|AnyCPU'">
-    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2018\BHoM"
-
-C:\Windows\System32\xcopy "$(ProjectDir)Files\BHoM.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2018" /Y /I /E</PostBuildEvent>
+    <PostBuildEvent>C:\Windows\System32\xcopy "$(ProjectDir)Files\BHoM_2018.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2018" /Y /I /E</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|AnyCPU'">
-    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2019\BHoM"
-
-C:\Windows\System32\xcopy "$(ProjectDir)Files\BHoM.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2019" /Y /I /E</PostBuildEvent>
+    <PostBuildEvent>C:\Windows\System32\xcopy "$(ProjectDir)Files\BHoM_2019.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2019" /Y /I /E</PostBuildEvent>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <PropertyGroup>
+    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "$(AppData)\BHoM\Assemblies"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Revit_UI/Revit_UI.csproj
+++ b/Revit_UI/Revit_UI.csproj
@@ -185,12 +185,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2018|AnyCPU'">
-    <PostBuildEvent>C:\Windows\System32\xcopy "$(ProjectDir)Files\BHoM_2018.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2018" /Y /I /E</PostBuildEvent>
+    <PostBuildEvent>C:\Windows\System32\xcopy "$(ProjectDir)Files\BHoM_2018.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2018" /Y /I /E
+	call "$(TargetDir)UI_PostBuild.exe" ..\..\ "$(AppData)\BHoM\Assemblies"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|AnyCPU'">
-    <PostBuildEvent>C:\Windows\System32\xcopy "$(ProjectDir)Files\BHoM_2019.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2019" /Y /I /E</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "$(AppData)\BHoM\Assemblies"</PostBuildEvent>
+    <PostBuildEvent>C:\Windows\System32\xcopy "$(ProjectDir)Files\BHoM_2019.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2019" /Y /I /E
+	call "$(TargetDir)UI_PostBuild.exe" ..\..\ "$(AppData)\BHoM\Assemblies"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
N/A
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #272 

<!-- Add short description of what has been fixed -->

- BHoM.Addin split into two files (version dependent) - temporary solution
- UI dll prefixed with version of Revit


### Test files
<!-- Link to test files to validate the proposed changes -->
No test files needed. Test procedure: 
- Build Revit_Toolkit
- Ensure files are moved to correct location (%AppData%\BHoM\Assemblies)
- Run Revit (2018 and 2019)
- Run Dynamo/Grashopper and make sure BHoM is loaded
- Do test pull/push


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Adapter_Revit_UI.csproj (Assembly name updated)
- Engine_Revit_UI.csproj (Assembly name updated)
- BHoM.Addin replaced by BHoM_2018.Addin and BHoM_2019.Addin
- RevitListener.cs (Directory of Assemblies updated to default)
- Revit_UI.csproj (Post-buid command and assembly names updated)
 

### Additional comments
<!-- As required -->
N/A