### PR TITLE
Revit_Toolkit - Issue 311 - Remove property objects which cannot be serialised 

### DIFF
--- a/Revit_Engine/Create/Generic/RevitFilePreview.cs
+++ b/Revit_Engine/Create/Generic/RevitFilePreview.cs
@@ -20,15 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
-using System.IO.Packaging;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Xml.Linq;
 
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
@@ -46,104 +38,13 @@ namespace BH.Engine.Adapters.Revit
         [Output("RevitFilePreview")]
         public static RevitFilePreview RevitFilePreview(string path)
         {
-            XDocument aXDocument = null;
-
-            if (File.Exists(path))
-            {
-                StorageInfo aStorageInfo = (StorageInfo)InvokeStorageRootMethod(null, "Open", path, FileMode.Open, FileAccess.Read, FileShare.Read);
-
-                if (aStorageInfo != null)
-                {
-                    StreamInfo[] aStreamInfoArray = aStorageInfo.GetStreams();
-                    List<string> aNames = aStreamInfoArray.ToList().ConvertAll(x => x.Name);
-                    foreach (StreamInfo aStreamInfo in aStreamInfoArray)
-                    {
-                        if (aStreamInfo.Name.Equals("PartAtom"))
-                        {
-                            byte[] aBytes = ParseStreamInfo(aStreamInfo);
-                            try
-                            {
-                                aXDocument = XDocument.Parse(Encoding.UTF8.GetString(aBytes));
-                            }
-                            catch
-                            {
-                                aXDocument = null;
-                            }
-
-                            if (aXDocument == null)
-                            {
-                                try
-                                {
-                                    aXDocument = XDocument.Parse(Encoding.Default.GetString(aBytes));
-                                }
-                                catch
-                                {
-                                    aXDocument = null;
-                                }
-                            }
-
-                            break;
-                        }
-                    }
-
-                    CloseStorageInfo(aStorageInfo);
-                }
-            }
-
             RevitFilePreview aRevitFilePreview = new RevitFilePreview()
             {
-                Path = path,
-                XDocument = aXDocument
+                Path = path
             };
 
             return aRevitFilePreview;
         }
-
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
-
-        private static object InvokeStorageRootMethod(StorageInfo storageInfoRoot, string methodName, params object[] methodArgs)
-        {
-            BindingFlags aBindingFlags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.InvokeMethod;
-            Type aStorageRootType = typeof(StorageInfo).Assembly.GetType("System.IO.Packaging.StorageRoot", true, false);
-            object aResult = aStorageRootType.InvokeMember(methodName, aBindingFlags, null, storageInfoRoot, methodArgs);
-            return aResult;
-        }
-
-        /***************************************************/
-
-        private static byte[] ParseStreamInfo(StreamInfo streamInfo)
-        {
-            byte[] aResult = null;
-            try
-            {
-                using (Stream aStream = streamInfo.GetStream(FileMode.Open, FileAccess.Read))
-                {
-                    aResult = new byte[aStream.Length];
-                    aStream.Read(aResult, 0, aResult.Length);
-                    return aResult;
-                }
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
-            finally
-            {
-                aResult = null;
-            }
-        }
-
-        /***************************************************/
-
-        private static void CloseStorageInfo(StorageInfo storageInfo)
-        {
-            InvokeStorageRootMethod(storageInfo, "Close");
-        }
-
-        /***************************************************/
-
 
     }
 }

--- a/Revit_Engine/Query/OmniClass.cs
+++ b/Revit_Engine/Query/OmniClass.cs
@@ -41,34 +41,43 @@ namespace BH.Engine.Adapters.Revit
         [Output("OmniClass")]
         public static string OmniClass(this RevitFilePreview revitFilePreview)
         {
-            if (revitFilePreview == null || revitFilePreview.XDocument == null)
+            if (revitFilePreview == null)
                 return null;
 
-            XDocument aXDocument = revitFilePreview.XDocument;
+            return OmniClass(revitFilePreview.XDocument());
+        }
 
-            if (aXDocument != null && aXDocument.Root != null)
+        /***************************************************/
+
+        [Description("Returns OmniClass assigned to Revit Family (RevitFilePreview)")]
+        [Input("xDocument", "XDocument from Header of Revit Family File (*.rfa)")]
+        [Output("OmniClass")]
+        public static string OmniClass(this XDocument xDocument)
+        {
+            if (xDocument == null || xDocument.Root == null)
+                return null;
+
+            List<XElement> aXElementList = xDocument.Root.Elements().ToList();
+            if (aXElementList != null && aXElementList.Count > 0)
             {
-                List<XElement> aXElementList = aXDocument.Root.Elements().ToList();
-                if (aXElementList != null && aXElementList.Count > 0)
-                {
-                    XName aName = XName.Get("category", "http://www.w3.org/2005/Atom");
-                    aXElementList = aXElementList.FindAll(x => x.Name == aName);
-                    if (aXElementList != null)
-                        foreach (XElement aXElement in aXElementList)
-                        {
-                            List<XElement> aChildXElementList = aXElement.Elements().ToList();
-                            aName = XName.Get("scheme", "http://www.w3.org/2005/Atom");
+                XName aName = XName.Get("category", "http://www.w3.org/2005/Atom");
+                aXElementList = aXElementList.FindAll(x => x.Name == aName);
+                if (aXElementList != null)
+                    foreach (XElement aXElement in aXElementList)
+                    {
+                        List<XElement> aChildXElementList = aXElement.Elements().ToList();
+                        aName = XName.Get("scheme", "http://www.w3.org/2005/Atom");
 
-                            if (aChildXElementList != null && aChildXElementList.Find(x => x.Name == aName && x.Value == "std:oc1") != null)
-                            {
-                                aName = XName.Get("term", "http://www.w3.org/2005/Atom");
-                                XElement aChildXElement = aChildXElementList.Find(x => x.Name == aName);
-                                if (aChildXElement != null)
-                                    return aChildXElement.Value;
-                            }
+                        if (aChildXElementList != null && aChildXElementList.Find(x => x.Name == aName && x.Value == "std:oc1") != null)
+                        {
+                            aName = XName.Get("term", "http://www.w3.org/2005/Atom");
+                            XElement aChildXElement = aChildXElementList.Find(x => x.Name == aName);
+                            if (aChildXElement != null)
+                                return aChildXElement.Value;
                         }
-                }
+                    }
             }
+
             return null;
         }
 

--- a/Revit_Engine/Query/XDocument.cs
+++ b/Revit_Engine/Query/XDocument.cs
@@ -1,0 +1,151 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Text;
+using System.IO.Packaging;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+using System;
+using System.ComponentModel;
+using System.Xml.Linq;
+
+using BH.oM.Reflection.Attributes;
+using BH.oM.Adapters.Revit.Generic;
+
+
+namespace BH.Engine.Adapters.Revit
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Retrieves. XDocument from RevitFilePreview")]
+        [Input("revitFilePreview", "RevitFilePreview")]
+        [Output("XDocument")]
+        public static XDocument XDocument(this RevitFilePreview revitFilePreview)
+        {
+            if (revitFilePreview == null)
+                return null;
+
+            string aPath = revitFilePreview.Path;
+
+            if (string.IsNullOrWhiteSpace(revitFilePreview.Path) || File.Exists(revitFilePreview.Path))
+                return null;
+
+            if (File.Exists(revitFilePreview.Path))
+            {
+                StorageInfo aStorageInfo = (StorageInfo)InvokeStorageRootMethod(null, "Open", aPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+                if (aStorageInfo != null)
+                {
+                    XDocument aXDocument = null;
+                    StreamInfo[] aStreamInfoArray = aStorageInfo.GetStreams();
+                    List<string> aNames = aStreamInfoArray.ToList().ConvertAll(x => x.Name);
+                    foreach (StreamInfo aStreamInfo in aStreamInfoArray)
+                    {
+                        if (aStreamInfo.Name.Equals("PartAtom"))
+                        {
+                            byte[] aBytes = ParseStreamInfo(aStreamInfo);
+                            
+                            try
+                            {
+                                aXDocument = System.Xml.Linq.XDocument.Parse(Encoding.UTF8.GetString(aBytes));
+                            }
+                            catch
+                            {
+                                return null;
+                            }
+
+                            if (aXDocument == null)
+                            {
+                                try
+                                {
+                                    aXDocument = System.Xml.Linq.XDocument.Parse(Encoding.Default.GetString(aBytes));
+                                }
+                                catch
+                                {
+                                    return null;
+                                }
+                            }
+
+                            break;
+                        }
+                    }
+
+                    CloseStorageInfo(aStorageInfo);
+                    return aXDocument;
+                }
+            }
+
+            return null;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static object InvokeStorageRootMethod(StorageInfo storageInfoRoot, string methodName, params object[] methodArgs)
+        {
+            BindingFlags aBindingFlags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.InvokeMethod;
+            Type aStorageRootType = typeof(StorageInfo).Assembly.GetType("System.IO.Packaging.StorageRoot", true, false);
+            object aResult = aStorageRootType.InvokeMember(methodName, aBindingFlags, null, storageInfoRoot, methodArgs);
+            return aResult;
+        }
+
+        /***************************************************/
+
+        private static byte[] ParseStreamInfo(StreamInfo streamInfo)
+        {
+            byte[] aResult = null;
+            try
+            {
+                using (Stream aStream = streamInfo.GetStream(FileMode.Open, FileAccess.Read))
+                {
+                    aResult = new byte[aStream.Length];
+                    aStream.Read(aResult, 0, aResult.Length);
+                    return aResult;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+            finally
+            {
+                aResult = null;
+            }
+        }
+
+        /***************************************************/
+
+        private static void CloseStorageInfo(StorageInfo storageInfo)
+        {
+            InvokeStorageRootMethod(storageInfo, "Close");
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Query\FamilyPlacementTypeName.cs" />
     <Compile Include="Query\InnerPolyCurves.cs" />
     <Compile Include="Query\Family.cs" />
+    <Compile Include="Query\XDocument.cs" />
     <Compile Include="Query\RevitFilePreviews.cs" />
     <Compile Include="Query\RelatedFilterQuery.cs" />
     <Compile Include="Query\Value.cs" />

--- a/Revit_oM/Generic/RevitFilePreview.cs
+++ b/Revit_oM/Generic/RevitFilePreview.cs
@@ -21,7 +21,6 @@
  */
 
 using BH.oM.Base;
-using System.Xml.Linq;
 
 namespace BH.oM.Adapters.Revit.Generic
 {
@@ -32,7 +31,6 @@ namespace BH.oM.Adapters.Revit.Generic
         /***************************************************/
 
         public string Path { get; set; } = null;
-        public XDocument XDocument { get; set; } = null;
 
         /***************************************************/
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
N/A

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #311 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Test file can be found here: [link](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Revit_Toolkit/Revit_Toolkit-Issue311-ObjectSerialization?csf=1&e=7qw2Em)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- XDocument property removed from RevitFilePreview
- Static Query methods added for OmniClass, FamilyTypeNames and CategoryName of XDocument
- XDocument Query added for RevitFilePreview


### Additional comments
<!-- As required -->
N/A