### PR TITLE
Update Profile.cs to fix channel section pull

### DIFF
--- a/Engine_Revit_UI/Convert/Structure/ToBHoM/Profile.cs
+++ b/Engine_Revit_UI/Convert/Structure/ToBHoM/Profile.cs
@@ -314,7 +314,7 @@ namespace BH.UI.Revit.Engine
                 if (double.IsNaN(rootRadius)) rootRadius = 0;
                 if (double.IsNaN(toeRadius)) toeRadius = 0;
 
-                if (!double.IsNaN(height) && !double.IsNaN(flangeWidth) && double.IsNaN(webThickness) && !double.IsNaN(flangeThickness))
+                if (!double.IsNaN(height) && !double.IsNaN(flangeWidth) && !double.IsNaN(webThickness) && !double.IsNaN(flangeThickness))
                 {
                     if (pullSettings.ConvertUnits)
                     {
@@ -556,7 +556,7 @@ namespace BH.UI.Revit.Engine
         private static string[] diameterNames = { "BHE_Diameter", "Diameter", "d", "D", "OD" };
         private static string[] radiusNames = { "BHE_Radius", "Radius", "r", "R" };
         private static string[] heightNames = { "BHE_Height", "BHE_Depth", "Height", "Depth", "d", "h", "D", "H", "Ht", "b" };
-        private static string[] widthNames = { "b", "BHE_Width", "Width", "w", "B", "W", "bf", "D" };
+        private static string[] widthNames = { "BHE_Width", "Width", "b", "B", "bf", "w", "W", "D" };
         private static string[] cornerRadiusNames = { "Corner Radius", "r", "r1" };
         private static string[] topFlangeWidthNames = { "Top Flange Width", "bt", "bf_t", "bft", "b1", "b", "B", "Bt" };
         private static string[] botFlangeWidthNames = { "Bottom Flange Width", "bb", "bf_b", "bfb", "b2", "b", "B", "Bb" };


### PR DESCRIPTION
  
### Issues addressed by this PR
Fixes #332 
Related to #333 

Added a missing '!' which caused channel sections to be pulled as freeform profiles
Re-ordered the search list for flange width to place b, B and bf before w, W, and D, as those are more likely to describe weight and depth of a section, respectively.

### Test files
Any Revit pull of UK or US C-Channel sections should yield expected results.