### PR TITLE
Revit_Toolkit - Issue 336 - FamilyLibrary Load Error

### DIFF
--- a/Revit_Engine/Query/XDocument.cs
+++ b/Revit_Engine/Query/XDocument.cs
@@ -52,7 +52,7 @@ namespace BH.Engine.Adapters.Revit
 
             string aPath = revitFilePreview.Path;
 
-            if (string.IsNullOrWhiteSpace(revitFilePreview.Path) || File.Exists(revitFilePreview.Path))
+            if (string.IsNullOrWhiteSpace(revitFilePreview.Path) || !File.Exists(revitFilePreview.Path))
                 return null;
 
             if (File.Exists(revitFilePreview.Path))


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
N/A

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #336

<!-- Add short description of what has been fixed -->
RevirFilePreview could not be created due to invalid check on file path

### Test files
<!-- Link to test files to validate the proposed changes -->
[Test script](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Revit_Toolkit/Revit_Toolkit-Issue336-FamilyLibraryError?csf=1&e=Pzd13B)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
XDocument.cs updated


### Additional comments
<!-- As required -->
N/A