### PR TITLE
Revit_Toolkit - #367 -Missing Ceiling Geometry

### DIFF
--- a/Engine_Revit_UI/Convert/Architecture/ToBHoM/Ceiling.cs
+++ b/Engine_Revit_UI/Convert/Architecture/ToBHoM/Ceiling.cs
@@ -56,7 +56,8 @@ namespace BH.UI.Revit.Engine
                 oM.Architecture.Elements.Ceiling aCeiling = new oM.Architecture.Elements.Ceiling()
                 {
                     Name = Query.FamilyTypeFullName(ceiling),
-                    Construction = aConstruction
+                    Construction = aConstruction,
+                    Surface = aPlanarSurface
                 };
 
                 ElementType aElementType = ceiling.Document.GetElement(ceiling.GetTypeId()) as ElementType;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
N/A

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #367 

<!-- Add short description of what has been fixed -->
Convert method for Ceiling updated to include geometry

### Test files
<!-- Link to test files to validate the proposed changes -->
To be provided by @michaldengusiak 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Convert.ToBHoMCeiling(this Ceiling ceiling, PullSettings pullSettings = null)` method updated to include geometry

### Additional comments
<!-- As required -->
N/A