### PR TITLE
Null check for familyLibrary in CategoryNames query method

### DIFF
--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Curve.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Curve.cs
@@ -68,10 +68,10 @@ namespace BH.UI.Revit.Engine
                 return Autodesk.Revit.DB.Ellipse.CreateCurve(ToRevit(aEllipse.Centre, pushSettings), aEllipse.Radius1, aEllipse.Radius2, ToRevit(aEllipse.Axis1, pushSettings), ToRevit(aEllipse.Axis2, pushSettings), 0, 1);
             }
 
-            if(curve is Polyline)
+            if (curve is Polyline)
             {
                 Polyline aPolyline = curve as Polyline;
-                if(aPolyline.ControlPoints.Count == 2)
+                if (aPolyline.ControlPoints.Count == 2)
                     return Autodesk.Revit.DB.Line.CreateBound(ToRevit(aPolyline.ControlPoints[0], pushSettings), ToRevit(aPolyline.ControlPoints[1], pushSettings));
             }
 

--- a/Revit_Engine/Query/CategoryNames.cs
+++ b/Revit_Engine/Query/CategoryNames.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Adapters.Revit
         [Output("CategoryNames")]
         public static List<string> CategoryNames(this FamilyLibrary familyLibrary, string familyName, string familyTypeName = null)
         {
-            if (familyLibrary == null)
+            if (familyLibrary == null || familyLibrary.Dictionary == null)
                 return null;
 
             List<string> aCategoryNameList = new List<string>();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #387 

<!-- Add short description of what has been fixed -->
Null catch to prevent the code from crashing - instead an informative error is returned.

### Test files
<!-- Link to test files to validate the proposed changes -->
Test file located [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&e=WVbMGt&cid=7e1be85d%2D59b2%2D45f4%2D8d1b%2Da30668a3a29a&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue387%2DCategoryNamesCrashOnNull).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Informative error given when requested family type does not exist in the Revit document.


### Additional comments
<!-- As required -->