### PR TITLE
Enable pushing surface-based ModelInstances

### DIFF
--- a/Engine_Revit_UI/Compute/Warnings.cs
+++ b/Engine_Revit_UI/Compute/Warnings.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -365,6 +365,18 @@ namespace BH.UI.Revit.Engine
         internal static void ElementTypeNotFoundWarning(this IBHoMObject iBHoMObject)
         {
             string aMessage = "Element type has not been found for given BHoM Object.";
+
+            if (iBHoMObject != null)
+                aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);
+
+            BH.Engine.Reflection.Compute.RecordError(aMessage);
+        }
+
+        /***************************************************/
+
+        internal static void GeometryConvertFailed(this IBHoMObject iBHoMObject)
+        {
+            string aMessage = "Conversion of the element geometry failed.";
 
             if (iBHoMObject != null)
                 aMessage = string.Format("{0} BHoM Guid: {1}", aMessage, iBHoMObject.BHoM_Guid);

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
@@ -115,7 +115,7 @@ namespace BH.UI.Revit.Engine
 
         private static bool TryAddSurface(this BRepBuilder brep, NurbsSurface ns, PushSettings pushSettings)
         {
-            if (ns.IsClosed() || ns.IsPeriodic())
+            if (ns.IsClosed())
             {
                 BH.Engine.Reflection.Compute.RecordError("Revit does not support closed or periodic nurbs surfaces, convert failed.");
                 return false;

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
@@ -161,10 +161,10 @@ namespace BH.UI.Revit.Engine
                 BRepBuilderSurfaceGeometry bbsg = BRepBuilderSurfaceGeometry.CreateNURBSSurface(ns.UDegree, ns.VDegree, uKnots, vKnots, pointList, weightList, false, null);
                 BRepBuilderGeometryId face = brep.AddFace(bbsg, false);
 
-                foreach (ICurve c in ns.ExternalBoundaries3d)
+                foreach (SurfaceTrim trim in ns.OuterTrims)
                 {
                     BRepBuilderGeometryId loop = brep.AddLoop(face);
-                    foreach (ICurve sp in c.ISubParts())
+                    foreach (ICurve sp in trim.Curve3d.ISubParts())
                     {
                         List<Curve> ccs = sp.ToRevitCurves(pushSettings);
                         foreach (Curve cc in ccs)
@@ -176,10 +176,10 @@ namespace BH.UI.Revit.Engine
                     brep.FinishLoop(loop);
                 }
 
-                foreach (ICurve c in ns.InternalBoundaries3d)
+                foreach (SurfaceTrim trim in ns.InnerTrims)
                 {
                     BRepBuilderGeometryId loop = brep.AddLoop(face);
-                    foreach (ICurve sp in c.ISubParts())
+                    foreach (ICurve sp in trim.Curve3d.ISubParts())
                     {
                         List<Curve> ccs = sp.ToRevitCurves(pushSettings);
                         foreach (Curve cc in ccs)

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
@@ -94,55 +94,10 @@ namespace BH.UI.Revit.Engine
                 BRepBuilderGeometryId face = brep.AddFace(bbsg, false);
 
                 brep.AddLoop(face, rp.Normal, ps.ExternalBoundary, true, pushSettings);
-                
-                //foreach (ICurve c in ps.ExternalBoundary)
-                //{
-                //    CurveLoop cl = new CurveLoop();
-                //    foreach (ICurve sp in c.ISubParts())
-                //    {
-                //        foreach (Curve cc in sp.ToRevitCurves(pushSettings))
-                //        {
-                //            cl.Append(cc);
-                //        }
-                //    }
-
-                //    if (!cl.IsCounterclockwise(rp.Normal))
-                //        cl.Flip();
-
-                //    BRepBuilderGeometryId loop = brep.AddLoop(face);
-                //    foreach (Curve cc in cl)
-                //    {
-                //        BRepBuilderGeometryId edge = brep.AddEdge(BRepBuilderEdgeGeometry.Create(cc));
-                //        brep.AddCoEdge(loop, edge, false);
-                //    }
-
-                //    brep.FinishLoop(loop);
-                //}
 
                 foreach (ICurve c in ps.InternalBoundaries)
                 {
                     brep.AddLoop(face, rp.Normal, c, false, pushSettings);
-
-                    //CurveLoop cl = new CurveLoop();
-                    //foreach (ICurve sp in c.ISubParts())
-                    //{
-                    //    foreach (Curve cc in sp.ToRevitCurves(pushSettings))
-                    //    {
-                    //        cl.Append(cc);
-                    //    }
-                    //}
-
-                    //if (cl.IsCounterclockwise(rp.Normal))
-                    //    cl.Flip();
-
-                    //BRepBuilderGeometryId loop = brep.AddLoop(face);
-                    //foreach (Curve cc in cl)
-                    //{
-                    //    BRepBuilderGeometryId edge = brep.AddEdge(BRepBuilderEdgeGeometry.Create(cc));
-                    //    brep.AddCoEdge(loop, edge, false);
-                    //}
-
-                    //brep.FinishLoop(loop);
                 }
 
                 brep.FinishFace(face);

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
@@ -1,0 +1,279 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.oM.Geometry;
+using BH.oM.Adapters.Revit.Settings;
+using BH.Engine.Geometry;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+namespace BH.UI.Revit.Engine
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        internal static BRepBuilder ToRevitBrep(this ISurface surface, PushSettings pushSettings = null)
+        {
+            pushSettings = pushSettings.DefaultIfNull();
+            BRepBuilder brep = new BRepBuilder(BRepType.OpenShell);
+
+            if (!TryAddSurface(brep, surface as dynamic, pushSettings))
+                return null;
+
+            brep.Finish();
+            return brep;
+        }
+
+        /***************************************************/
+
+        internal static BRepBuilder ToRevitBrep(this BoundaryRepresentation boundaryRepresentation, PushSettings pushSettings = null)
+        {
+            //TODO: allow creating void and solid?
+            pushSettings = pushSettings.DefaultIfNull();
+            BRepBuilder brep = new BRepBuilder(BRepType.OpenShell);
+            foreach (ISurface s in boundaryRepresentation.Surfaces)
+            {
+                if (!TryAddSurface(brep, s as dynamic, pushSettings))
+                    return null;
+            }
+
+            brep.Finish();
+            return brep;
+        }
+
+
+        /***************************************************/
+        /****              Private methods              ****/
+        /***************************************************/
+
+        private static bool TryAddSurface(this BRepBuilder brep, PolySurface ps, PushSettings pushSettings)
+        {
+            foreach (ISurface s in ps.Surfaces)
+            {
+                if (!TryAddSurface(brep, s as dynamic, pushSettings))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        private static bool TryAddSurface(this BRepBuilder brep, PlanarSurface ps, PushSettings pushSettings)
+        {
+            try
+            {
+                BH.oM.Geometry.Plane p = ps.ExternalBoundary.IFitPlane();
+                Autodesk.Revit.DB.Plane rp = p.ToRevitPlane(pushSettings);
+
+                BRepBuilderSurfaceGeometry bbsg = BRepBuilderSurfaceGeometry.Create(rp, null);
+                BRepBuilderGeometryId face = brep.AddFace(bbsg, false);
+
+                brep.AddLoop(face, rp.Normal, ps.ExternalBoundary, true, pushSettings);
+                
+                //foreach (ICurve c in ps.ExternalBoundary)
+                //{
+                //    CurveLoop cl = new CurveLoop();
+                //    foreach (ICurve sp in c.ISubParts())
+                //    {
+                //        foreach (Curve cc in sp.ToRevitCurves(pushSettings))
+                //        {
+                //            cl.Append(cc);
+                //        }
+                //    }
+
+                //    if (!cl.IsCounterclockwise(rp.Normal))
+                //        cl.Flip();
+
+                //    BRepBuilderGeometryId loop = brep.AddLoop(face);
+                //    foreach (Curve cc in cl)
+                //    {
+                //        BRepBuilderGeometryId edge = brep.AddEdge(BRepBuilderEdgeGeometry.Create(cc));
+                //        brep.AddCoEdge(loop, edge, false);
+                //    }
+
+                //    brep.FinishLoop(loop);
+                //}
+
+                foreach (ICurve c in ps.InternalBoundaries)
+                {
+                    brep.AddLoop(face, rp.Normal, c, false, pushSettings);
+
+                    //CurveLoop cl = new CurveLoop();
+                    //foreach (ICurve sp in c.ISubParts())
+                    //{
+                    //    foreach (Curve cc in sp.ToRevitCurves(pushSettings))
+                    //    {
+                    //        cl.Append(cc);
+                    //    }
+                    //}
+
+                    //if (cl.IsCounterclockwise(rp.Normal))
+                    //    cl.Flip();
+
+                    //BRepBuilderGeometryId loop = brep.AddLoop(face);
+                    //foreach (Curve cc in cl)
+                    //{
+                    //    BRepBuilderGeometryId edge = brep.AddEdge(BRepBuilderEdgeGeometry.Create(cc));
+                    //    brep.AddCoEdge(loop, edge, false);
+                    //}
+
+                    //brep.FinishLoop(loop);
+                }
+
+                brep.FinishFace(face);
+            }
+            catch
+            {
+                BH.Engine.Reflection.Compute.RecordError("An attempt to create a planar surface failed.");
+                return false;
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        private static bool TryAddSurface(this BRepBuilder brep, NurbsSurface ns, PushSettings pushSettings)
+        {
+            if (ns.IsClosed() || ns.IsPeriodic())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Revit does not support closed or periodic nurbs surfaces, convert failed.");
+                return false;
+            }
+            
+            try
+            {
+                List<int> uvCount = ns.UVCount(); // Align to Revit nurbs definition
+                double[][] weights = new double[uvCount[0]][];
+                XYZ[][] points = new XYZ[uvCount[0]][];
+
+                List<double> uKnots = new List<double>(ns.UKnots);
+                uKnots.Insert(0, uKnots.First());
+                uKnots.Add(uKnots.Last());
+
+                List<double> vKnots = new List<double>(ns.VKnots);
+                vKnots.Insert(0, vKnots.First());
+                vKnots.Add(vKnots.Last());
+
+                for (int i = 0; i < uvCount[0]; i++)
+                {
+                    points[i] = new XYZ[uvCount[1]];
+                    weights[i] = new double[uvCount[1]];
+                    for (int j = 0; j < uvCount[1]; j++)
+                    {
+                        points[i][j] = ns.ControlPoints[j + (uvCount[1] * i)].ToRevitXYZ(pushSettings);
+                        weights[i][j] = ns.Weights[j + (uvCount[1] * i)];
+                    }
+                }
+
+                List<XYZ> pointList = new List<XYZ>();
+                foreach (XYZ[] x in points)
+                {
+                    pointList.AddRange(x);
+                }
+
+                List<double> weightList = new List<double>();
+                foreach (double[] x in weights)
+                {
+                    weightList.AddRange(x);
+                }
+
+                BRepBuilderSurfaceGeometry bbsg = BRepBuilderSurfaceGeometry.CreateNURBSSurface(ns.UDegree, ns.VDegree, uKnots, vKnots, pointList, weightList, false, null);
+                BRepBuilderGeometryId face = brep.AddFace(bbsg, false);
+
+                foreach (ICurve c in ns.ExternalBoundaries3d)
+                {
+                    BRepBuilderGeometryId loop = brep.AddLoop(face);
+                    foreach (ICurve sp in c.ISubParts())
+                    {
+                        List<Curve> ccs = sp.ToRevitCurves(pushSettings);
+                        foreach (Curve cc in ccs)
+                        {
+                            BRepBuilderGeometryId edge = brep.AddEdge(BRepBuilderEdgeGeometry.Create(cc));
+                            brep.AddCoEdge(loop, edge, false);
+                        }
+                    }
+                    brep.FinishLoop(loop);
+                }
+
+                foreach (ICurve c in ns.InternalBoundaries3d)
+                {
+                    BRepBuilderGeometryId loop = brep.AddLoop(face);
+                    foreach (ICurve sp in c.ISubParts())
+                    {
+                        List<Curve> ccs = sp.ToRevitCurves(pushSettings);
+                        foreach (Curve cc in ccs)
+                        {
+                            BRepBuilderGeometryId edge = brep.AddEdge(BRepBuilderEdgeGeometry.Create(cc));
+                            brep.AddCoEdge(loop, edge, false);
+                        }
+                    }
+
+                    brep.FinishLoop(loop);
+                }
+
+                brep.FinishFace(face);
+            }
+            catch
+            {
+                BH.Engine.Reflection.Compute.RecordError("An attempt to create a nurbs surface failed.");
+                return false;
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        private static void AddLoop(this BRepBuilder brep, BRepBuilderGeometryId face, XYZ normal, ICurve curve, bool external, PushSettings pushSettings)
+        {
+            CurveLoop cl = new CurveLoop();
+            foreach (ICurve sp in curve.ISubParts())
+            {
+                foreach (Curve cc in sp.ToRevitCurves(pushSettings))
+                {
+                    cl.Append(cc);
+                }
+            }
+
+            if (external != cl.IsCounterclockwise(normal))
+                cl.Flip();
+
+            BRepBuilderGeometryId loop = brep.AddLoop(face);
+            foreach (Curve cc in cl)
+            {
+                BRepBuilderGeometryId edge = brep.AddEdge(BRepBuilderEdgeGeometry.Create(cc));
+                brep.AddCoEdge(loop, edge, false);
+            }
+
+            brep.FinishLoop(loop);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Engine_Revit_UI/Convert/Revit/ToRevit/CurveElement.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/CurveElement.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -53,6 +53,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (!BH.Engine.Geometry.Query.IsPlanar(aCurve_BHoM as dynamic))
+                //TODO: error that the nurbs nonplanar
                 return null;
 
             List<oM.Geometry.Point> aPointList = BH.Engine.Geometry.Query.ControlPoints(aCurve_BHoM as dynamic);
@@ -63,7 +64,7 @@ namespace BH.UI.Revit.Engine
             XYZ aPoint_2 = null;
             XYZ aPoint_3 = null;
 
-            if(aPointList.Count == 2)
+            if (BH.Engine.Geometry.Query.IsCollinear(aPointList, BH.oM.Geometry.Tolerance.Distance))
             {
                 aPoint_1 = aPointList[0].ToRevit(pushSettings);
                 aPoint_2 = aPointList[1].ToRevit(pushSettings);

--- a/Engine_Revit_UI/Convert/Revit/ToRevit/CurveElement.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/CurveElement.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -53,7 +53,6 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (!BH.Engine.Geometry.Query.IsPlanar(aCurve_BHoM as dynamic))
-                //TODO: error that the nurbs nonplanar
                 return null;
 
             List<oM.Geometry.Point> aPointList = BH.Engine.Geometry.Query.ControlPoints(aCurve_BHoM as dynamic);
@@ -64,7 +63,7 @@ namespace BH.UI.Revit.Engine
             XYZ aPoint_2 = null;
             XYZ aPoint_3 = null;
 
-            if (BH.Engine.Geometry.Query.IsCollinear(aPointList, BH.oM.Geometry.Tolerance.Distance))
+            if(aPointList.Count == 2)
             {
                 aPoint_1 = aPointList[0].ToRevit(pushSettings);
                 aPoint_2 = aPointList[1].ToRevit(pushSettings);

--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Convert\Environment\ToRevit\Space.cs" />
     <Compile Include="Convert\Geometry\ToBHoM\Grid.cs" />
     <Compile Include="Convert\Geometry\ToBHoM\Level.cs" />
+    <Compile Include="Convert\Geometry\ToRevit\Brep.cs" />
     <Compile Include="Convert\Geometry\ToRevit\Grid.cs" />
     <Compile Include="Convert\Geometry\ToRevit\Level.cs" />
     <Compile Include="Convert\Architecture\ToRevit\Ceiling.cs" />

--- a/Revit_Engine/Create/Elements/ModelInstance.cs
+++ b/Revit_Engine/Create/Elements/ModelInstance.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -177,6 +177,48 @@ namespace BH.Engine.Adapters.Revit
                 Properties = aInstanceProperties,
                 CustomData = new System.Collections.Generic.Dictionary<string, object>(bHoMObject.CustomData)
             };
+
+            return aModelInstance;
+        }
+
+        /***************************************************/
+
+        public static ModelInstance ModelInstance(string categoryName, ISurface location)
+        {
+            if (string.IsNullOrWhiteSpace(categoryName) || location == null)
+                return null;
+
+            InstanceProperties aInstanceProperties = new InstanceProperties();
+            aInstanceProperties.CustomData.Add(Convert.CategoryName, categoryName);
+
+            ModelInstance aModelInstance = new ModelInstance()
+            {
+                Properties = aInstanceProperties,
+                Name = "Surface",
+                Location = location
+            };
+            aModelInstance.CustomData.Add(Convert.CategoryName, categoryName);
+
+            return aModelInstance;
+        }
+
+        /***************************************************/
+
+        public static ModelInstance ModelInstance(string categoryName, ISolid location)
+        {
+            if (string.IsNullOrWhiteSpace(categoryName) || location == null)
+                return null;
+
+            InstanceProperties aInstanceProperties = new InstanceProperties();
+            aInstanceProperties.CustomData.Add(Convert.CategoryName, categoryName);
+
+            ModelInstance aModelInstance = new ModelInstance()
+            {
+                Properties = aInstanceProperties,
+                Name = "Solid",
+                Location = location
+            };
+            aModelInstance.CustomData.Add(Convert.CategoryName, categoryName);
 
             return aModelInstance;
         }


### PR DESCRIPTION
### NOTE: Depends on 
[#603](https://github.com/BHoM/BHoM/pull/603)
[#1319](https://github.com/BHoM/BHoM_Engine/pull/1319)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #408 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Test files are located on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%2FGeometry%5FoM%2DIssue425%2DCreationOfTrimmedNurbsSurfaceDefinition). To run it, please switch to the branches related to the following PRs:
- [#603 ](https://github.com/BHoM/BHoM/pull/603)
- [#1319](https://github.com/BHoM/BHoM_Engine/pull/1319)
- [#122](https://github.com/BHoM/Rhinoceros_Toolkit/pull/122)
- [#435](https://github.com/BHoM/Grasshopper_Toolkit/pull/435)
- [#435](https://github.com/BHoM/Revit_Toolkit/pull/435)
- [#183](https://github.com/BHoM/Dynamo_Toolkit/pull/183)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.Engine.Adapters.Revit.Create.ModelInstance()` methods were added for locations of type `ISurface` and `ISolid`
- A method converting `ModelInstance` with location of type `ISurface` or `ISolid` to a Brep-based DirectShape has been added together with necessary helper methods

### Additional comments
Please see [#603](https://github.com/BHoM/BHoM/pull/603).
Push does not work for closed or periodic surfaces because they are not supported by Revit.

Issues to be raised after merging this:
- combine `ToRevitCurves` and `ToRevitCurveArray` methods into one
- implement converts of BHoM primitives (`Sphere`, `Cone` etc.) to Revit
- implement converts from Revit Breps and Surfaces to BHoM
- add push support for Voids and Solids (watertight Breps) - this PR implements open shells only