### PR TITLE
Query.Discipline Cleaned Up

### DIFF
--- a/Adapter_Revit_UI/CRUD/Read.cs
+++ b/Adapter_Revit_UI/CRUD/Read.cs
@@ -167,7 +167,7 @@ namespace BH.UI.Revit.Adapter
                 if (aFilterRequests == null)
                     continue;
 
-                Discipline aDiscipline = Query.Discipline(aFilterRequests, aRevitSettings);
+                Discipline aDiscipline = BH.Engine.Adapters.Revit.Query.Discipline(aFilterRequests, aRevitSettings);
 
                 PullSettings aPullSettings = null;
                 if (!aDictionary_PullSettings.TryGetValue(aDiscipline, out aPullSettings))

--- a/Engine_Revit_UI/Query/Discipline.cs
+++ b/Engine_Revit_UI/Query/Discipline.cs
@@ -26,15 +26,17 @@ using System.Collections.Generic;
 using BH.oM.Adapters.Revit.Enums;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Data.Requests;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.UI.Revit.Engine
 {
     public static partial class Query
     {
         /***************************************************/
-        /****              Public methods               ****/
+        /****            Deprecated methods             ****/
         /***************************************************/
 
+        [Deprecated("3.0", "The method has been moved to BH.Engine.Adapters.Revit.Query", typeof(BH.Engine.Adapters.Revit.Query), "Discipline")]
         public static Discipline Discipline(this FilterRequest filterRequest, RevitSettings revitSettings)
         {
             Discipline? aDiscipline = null;
@@ -56,6 +58,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
+        [Deprecated("3.0", "The method has been moved to BH.Engine.Adapters.Revit.Query", typeof(BH.Engine.Adapters.Revit.Query), "Discipline")]
         public static Discipline Discipline(this IEnumerable<FilterRequest> filterRequest, RevitSettings revitSettings)
         {
             if (filterRequest == null || filterRequest.Count() == 0)

--- a/Revit_Engine/Query/DefaultDiscipline.cs
+++ b/Revit_Engine/Query/DefaultDiscipline.cs
@@ -38,12 +38,12 @@ namespace BH.Engine.Adapters.Revit
         [Description("Gets Default Discipline for given RevitSettings.")]
         [Input("revitSettings", "RevitSettings")]
         [Output("Discipline")]
-        public static Discipline? DefaultDiscipline(this RevitSettings revitSettings)
+        public static Discipline DefaultDiscipline(this RevitSettings revitSettings)
         {
             if (revitSettings == null || revitSettings.GeneralSettings == null)
-                return null;
-
-            return revitSettings.GeneralSettings.DefaultDiscipline;
+                return oM.Adapters.Revit.Enums.Discipline.Undefined;
+            else
+                return revitSettings.GeneralSettings.DefaultDiscipline;
         }
 
         /***************************************************/
@@ -51,15 +51,12 @@ namespace BH.Engine.Adapters.Revit
         [Description("Gets Default Discipline for given FilterRequest.")]
         [Input("filterRequest", "FilterRequest")]
         [Output("Discipline")]
-        public static Discipline? DefaultDiscipline(this FilterRequest filterRequest)
+        public static Discipline DefaultDiscipline(this FilterRequest filterRequest)
         {
-            if (filterRequest == null)
-                return null;
-
-            if (!filterRequest.Equalities.ContainsKey(Convert.FilterRequest.DefaultDiscipline))
-                return null;
-
-            return (Discipline)filterRequest.Equalities[Convert.FilterRequest.DefaultDiscipline];
+            if (filterRequest == null || !filterRequest.Equalities.ContainsKey(Convert.FilterRequest.DefaultDiscipline))
+                return oM.Adapters.Revit.Enums.Discipline.Undefined;
+            else
+                return (Discipline)filterRequest.Equalities[Convert.FilterRequest.DefaultDiscipline];
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #457 
Closes #468 

<!-- Add short description of what has been fixed -->
Changes as in the changelog + I made an (hopefully successful) attempt to simplify the code.


### Test files
<!-- Link to test files to validate the proposed changes -->
- [whole issue](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue457%2DDisciplineQueryCleanup) - file with suffix _master_ will work correctly on both master and PR branch, while the one with suffix _PR_ will work only on master (some stuff got exposed to the UI)
- [extracted infinite loop bug](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue468%2DInfiniteLoopInDisciplineQuery)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.UI.Revit.Engine.Query.Discipline` methods have been deprecated and moved to `BH.Engine.Adapters.Revit.Query`
- return type of `Query.Discipline` methods originally sitting in `BH.Engine.Adapters.Revit.Query` has been changed from a nullable to non-nullable enum (`Discipline.Undefined` is returned instead of `null` now)