### PR TITLE
ConvertUnits Removed

### DIFF
--- a/Adapter_Revit_UI/CRUD/Create.cs
+++ b/Adapter_Revit_UI/CRUD/Create.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -97,7 +97,6 @@ namespace BH.UI.Revit.Adapter
             PushSettings aPushSettings = new PushSettings()
             {
                 AdapterMode = revitSettings.GeneralSettings.AdapterMode,
-                ConvertUnits = true,
                 CopyCustomData = true,
                 FamilyLoadSettings = revitSettings.FamilyLoadSettings
 

--- a/Adapter_Revit_UI/CRUD/Read.cs
+++ b/Adapter_Revit_UI/CRUD/Read.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -289,7 +289,7 @@ namespace BH.UI.Revit.Adapter
 
                         aIBHoMObject.Name = element.Name;
                         aIBHoMObject = Modify.SetIdentifiers(aIBHoMObject, element);
-                        aIBHoMObject = Modify.SetCustomData(aIBHoMObject, element, true);
+                        aIBHoMObject = Modify.SetCustomData(aIBHoMObject, element);
                         aObject = aIBHoMObject;
                     }
 

--- a/Engine_Revit_UI/Convert/Architecture/ToBHoM/Ceiling.cs
+++ b/Engine_Revit_UI/Convert/Architecture/ToBHoM/Ceiling.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -71,7 +71,7 @@ namespace BH.UI.Revit.Engine
 
                 aCeiling = Modify.SetIdentifiers(aCeiling, ceiling) as oM.Architecture.Elements.Ceiling;
                 if (pullSettings.CopyCustomData)
-                    aCeiling = Modify.SetCustomData(aCeiling, ceiling, pullSettings.ConvertUnits) as oM.Architecture.Elements.Ceiling;
+                    aCeiling = Modify.SetCustomData(aCeiling, ceiling) as oM.Architecture.Elements.Ceiling;
 
                 aCeiling = aCeiling.UpdateValues(pullSettings, ceiling) as oM.Architecture.Elements.Ceiling;
 

--- a/Engine_Revit_UI/Convert/Architecture/ToBHoM/Room.cs
+++ b/Engine_Revit_UI/Convert/Architecture/ToBHoM/Room.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -54,11 +54,11 @@ namespace BH.UI.Revit.Engine
             //Set custom data
             aRoom = Modify.SetIdentifiers(aRoom, spatialElement) as oM.Architecture.Elements.Room;
             if (pullSettings.CopyCustomData)
-                aRoom = Modify.SetCustomData(aRoom, spatialElement, pullSettings.ConvertUnits) as oM.Architecture.Elements.Room;
+                aRoom = Modify.SetCustomData(aRoom, spatialElement) as oM.Architecture.Elements.Room;
 
             //Set location
             if (spatialElement.Location != null && spatialElement.Location is LocationPoint)
-                aRoom.Location = ((LocationPoint)spatialElement.Location).ToBHoM(pullSettings);
+                aRoom.Location = ((LocationPoint)spatialElement.Location).ToBHoM();
 
             //Set ExtendedProperties
             OriginContextFragment aOriginContextFragment = new OriginContextFragment();
@@ -69,7 +69,7 @@ namespace BH.UI.Revit.Engine
 
             aRoom = Modify.SetIdentifiers(aRoom, spatialElement) as oM.Architecture.Elements.Room;
             if (pullSettings.CopyCustomData)
-                aRoom = Modify.SetCustomData(aRoom, spatialElement, pullSettings.ConvertUnits) as oM.Architecture.Elements.Room;
+                aRoom = Modify.SetCustomData(aRoom, spatialElement) as oM.Architecture.Elements.Room;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aRoom);
 

--- a/Engine_Revit_UI/Convert/Architecture/ToRevit/Ceiling.cs
+++ b/Engine_Revit_UI/Convert/Architecture/ToRevit/Ceiling.cs
@@ -87,20 +87,18 @@ namespace BH.UI.Revit.Engine
 
             double aLowElevation = aPlanarSurface.LowElevation();
 
-            Level aLevel = document.HighLevel(aLowElevation, true);
+            Level aLevel = document.HighLevel(aLowElevation);
 
-            double aElevation = aLevel.Elevation;
-            if (pushSettings.ConvertUnits)
-                aElevation = aElevation.ToSI(UnitType.UT_Length);
+            double aElevation = aLevel.Elevation.ToSI(UnitType.UT_Length);
 
             oM.Geometry.Plane aPlane = BH.Engine.Geometry.Create.Plane(BH.Engine.Geometry.Create.Point(0, 0, aLowElevation), BH.Engine.Geometry.Create.Vector(0, 0, 1));
             ICurve aCurve = BH.Engine.Geometry.Modify.Project(aPlanarSurface.ExternalBoundary as dynamic, aPlane) as ICurve;
 
             CurveArray aCurveArray = null;
             if (aCurve is PolyCurve)
-                aCurveArray = ((PolyCurve)aCurve).ToRevitCurveArray(pushSettings);
+                aCurveArray = ((PolyCurve)aCurve).ToRevitCurveArray();
             else if (aCurve is Polyline)
-                aCurveArray = ((Polyline)aCurve).ToRevitCurveArray(pushSettings);
+                aCurveArray = ((Polyline)aCurve).ToRevitCurveArray();
 
             if (aCurveArray == null)
                 return null;
@@ -112,7 +110,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aCeiling, ceiling, new BuiltInParameter[] { BuiltInParameter.LEVEL_PARAM }, pushSettings.ConvertUnits);
+                Modify.SetParameters(aCeiling, ceiling, new BuiltInParameter[] { BuiltInParameter.LEVEL_PARAM });
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(ceiling, aCeiling);
 

--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/Building.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/Building.cs
@@ -57,19 +57,12 @@ namespace BH.UI.Revit.Engine
 
                 if (aDocument.SiteLocation != null)
                 {
-                    aElevation = aDocument.SiteLocation.Elevation;
-                    aLongitude = aDocument.SiteLocation.Longitude;
-                    aLatitude = aDocument.SiteLocation.Latitude;
+                    aElevation = aDocument.SiteLocation.Elevation.ToSI(UnitType.UT_Length);
+                    aLongitude = aDocument.SiteLocation.Longitude.ToSI(UnitType.UT_Length);
+                    aLatitude = aDocument.SiteLocation.Latitude.ToSI(UnitType.UT_Length);
                     aTimeZone = aDocument.SiteLocation.TimeZone;
                     aPlaceName = aDocument.SiteLocation.PlaceName;
                     aWeatherStationName = aDocument.SiteLocation.WeatherStationName;
-
-                    if (pullSettings.ConvertUnits)
-                    {
-                        aElevation = aElevation.ToSI(UnitType.UT_Length);
-                        aLongitude = aLongitude.ToSI(UnitType.UT_Length);
-                        aLatitude = aLatitude.ToSI(UnitType.UT_Length);
-                    }
                 }
 
                 double aProjectAngle = 0;
@@ -122,7 +115,7 @@ namespace BH.UI.Revit.Engine
                     aBuilding = Modify.SetCustomData(aBuilding, "Project North/South Offset", aProjectNorthSouthOffset) as Building;
                     aBuilding = Modify.SetCustomData(aBuilding, "Project Elevation", aProjectElevation) as Building;
 
-                    aBuilding = Modify.SetCustomData(aBuilding, aDocument.ProjectInformation, pullSettings.ConvertUnits) as Building;
+                    aBuilding = Modify.SetCustomData(aBuilding, aDocument.ProjectInformation) as Building;
                 }
 
                 pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aBuilding);

--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/Opening.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/Opening.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -48,7 +48,7 @@ namespace BH.UI.Revit.Engine
                 if (aResult != null)
                     return aResult;
 
-                ICurve aCurve = energyAnalysisOpening.GetPolyloop().ToBHoM(pullSettings);
+                ICurve aCurve = energyAnalysisOpening.GetPolyloop().ToBHoM();
                 aResult = Create.Opening(externalEdges: aCurve.ToEdges());
 
                 OriginContextFragment aOriginContextFragment = new OriginContextFragment();
@@ -62,7 +62,7 @@ namespace BH.UI.Revit.Engine
 
                 aResult = Modify.SetIdentifiers(aResult, energyAnalysisOpening) as oM.Environment.Elements.Opening;
                 if (pullSettings.CopyCustomData)
-                    aResult = Modify.SetCustomData(aResult, energyAnalysisOpening, pullSettings.ConvertUnits) as oM.Environment.Elements.Opening;
+                    aResult = Modify.SetCustomData(aResult, energyAnalysisOpening) as oM.Environment.Elements.Opening;
 
                 pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aResult);
                 aResult = aResult.UpdateValues(pullSettings, energyAnalysisOpening) as oM.Environment.Elements.Opening;
@@ -76,7 +76,7 @@ namespace BH.UI.Revit.Engine
 
                 ElementType aElementType = aElement.Document.GetElement(aElement.GetTypeId()) as ElementType;
 
-                ICurve aCurve = energyAnalysisOpening.GetPolyloop().ToBHoM(pullSettings);
+                ICurve aCurve = energyAnalysisOpening.GetPolyloop().ToBHoM();
                 aResult = Create.Opening(externalEdges: aCurve.ToEdges());
                 aResult.Name = Query.FamilyTypeFullName(aElement);
 
@@ -97,10 +97,10 @@ namespace BH.UI.Revit.Engine
 
                 aResult = Modify.SetIdentifiers(aResult, aElement) as oM.Environment.Elements.Opening;
                 if (pullSettings.CopyCustomData)
-                    aResult = Modify.SetCustomData(aResult, aElement, pullSettings.ConvertUnits) as oM.Environment.Elements.Opening;
+                    aResult = Modify.SetCustomData(aResult, aElement) as oM.Environment.Elements.Opening;
 
                 if (aElementType != null)
-                    aResult = Modify.SetCustomData(aResult, aElementType, pullSettings.ConvertUnits, "Type ") as oM.Environment.Elements.Opening;
+                    aResult = Modify.SetCustomData(aResult, aElementType, "Type ") as oM.Environment.Elements.Opening;
 
 
 

--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/Panel.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/Panel.cs
@@ -83,7 +83,7 @@ namespace BH.UI.Revit.Engine
 
             aPanel = Modify.SetIdentifiers(aPanel, element) as oM.Environment.Elements.Panel;
             if (pullSettings.CopyCustomData)
-                aPanel = Modify.SetCustomData(aPanel, element, pullSettings.ConvertUnits) as oM.Environment.Elements.Panel;
+                aPanel = Modify.SetCustomData(aPanel, element) as oM.Environment.Elements.Panel;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aPanel);
 
@@ -142,7 +142,7 @@ namespace BH.UI.Revit.Engine
 
             aPanel = Modify.SetIdentifiers(aPanel, familyInstance) as oM.Environment.Elements.Panel;
             if (pullSettings.CopyCustomData)
-                aPanel = Modify.SetCustomData(aPanel, familyInstance, pullSettings.ConvertUnits) as oM.Environment.Elements.Panel;
+                aPanel = Modify.SetCustomData(aPanel, familyInstance) as oM.Environment.Elements.Panel;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aPanel);
 
@@ -165,7 +165,7 @@ namespace BH.UI.Revit.Engine
             //Get the geometry Curve
             ICurve aCurve = null;
             if (energyAnalysisSurface != null)
-                aCurve = energyAnalysisSurface.GetPolyloop().ToBHoM(pullSettings);
+                aCurve = energyAnalysisSurface.GetPolyloop().ToBHoM();
 
             //Get the name and element type
             Element aElement = Query.Element(energyAnalysisSurface.Document, energyAnalysisSurface.CADObjectUniqueId, energyAnalysisSurface.CADLinkUniqueId);
@@ -237,24 +237,20 @@ namespace BH.UI.Revit.Engine
             aPanel = Modify.SetIdentifiers(aPanel, aElement) as oM.Environment.Elements.Panel;
             if (pullSettings.CopyCustomData)
             {
-                aPanel = Modify.SetCustomData(aPanel, aElement, pullSettings.ConvertUnits) as oM.Environment.Elements.Panel;
-                double aHeight = energyAnalysisSurface.Height;
-                double aWidth = energyAnalysisSurface.Width;
+                aPanel = Modify.SetCustomData(aPanel, aElement) as oM.Environment.Elements.Panel;
+                double aHeight = energyAnalysisSurface.Height.ToSI(UnitType.UT_Length);
+                double aWidth = energyAnalysisSurface.Width.ToSI(UnitType.UT_Length);
                 double aAzimuth = energyAnalysisSurface.Azimuth;
-                if (pullSettings.ConvertUnits)
-                {
-                    aHeight = aHeight.ToSI(UnitType.UT_Length);
-                    aWidth = aWidth.ToSI(UnitType.UT_Length);
-                }
+
                 aPanel = Modify.SetCustomData(aPanel, "Height", aHeight) as oM.Environment.Elements.Panel;
                 aPanel = Modify.SetCustomData(aPanel, "Width", aWidth) as oM.Environment.Elements.Panel;
                 aPanel = Modify.SetCustomData(aPanel, "Azimuth", aAzimuth) as oM.Environment.Elements.Panel;
-                aPanel = Modify.SetCustomData(aPanel, aElementType, BuiltInParameter.ALL_MODEL_FAMILY_NAME, pullSettings.ConvertUnits) as oM.Environment.Elements.Panel;
+                aPanel = Modify.SetCustomData(aPanel, aElementType, BuiltInParameter.ALL_MODEL_FAMILY_NAME) as oM.Environment.Elements.Panel;
                 aPanel = Modify.AddSpaceId(aPanel, energyAnalysisSurface);
                 aPanel = Modify.AddAdjacentSpaceId(aPanel, energyAnalysisSurface);
 
                 if (aElementType != null)
-                    aPanel = Modify.SetCustomData(aPanel, aElementType, pullSettings.ConvertUnits, "Type ") as oM.Environment.Elements.Panel;
+                    aPanel = Modify.SetCustomData(aPanel, aElementType, "Type ") as oM.Environment.Elements.Panel;
             }
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aPanel);
@@ -320,7 +316,7 @@ namespace BH.UI.Revit.Engine
                 //Assign custom data
                 aPanel = Modify.SetIdentifiers(aPanel, ceiling) as oM.Environment.Elements.Panel;
                 if (pullSettings.CopyCustomData)
-                    aPanel = Modify.SetCustomData(aPanel, ceiling, pullSettings.ConvertUnits) as oM.Environment.Elements.Panel;
+                    aPanel = Modify.SetCustomData(aPanel, ceiling) as oM.Environment.Elements.Panel;
 
                 pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aPanel);
                 aPanel = aPanel.UpdateValues(pullSettings, aCeilingType) as oM.Environment.Elements.Panel;
@@ -388,7 +384,7 @@ namespace BH.UI.Revit.Engine
                 //Assign custom data
                 aPanel = Modify.SetIdentifiers(aPanel, floor) as oM.Environment.Elements.Panel;
                 if (pullSettings.CopyCustomData)
-                    aPanel = Modify.SetCustomData(aPanel, floor, pullSettings.ConvertUnits) as oM.Environment.Elements.Panel;
+                    aPanel = Modify.SetCustomData(aPanel, floor) as oM.Environment.Elements.Panel;
 
                 pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aPanel);
 
@@ -455,7 +451,7 @@ namespace BH.UI.Revit.Engine
                 //Assign custom data
                 aPanel = Modify.SetIdentifiers(aPanel, roofBase) as oM.Environment.Elements.Panel;
                 if (pullSettings.CopyCustomData)
-                    aPanel = Modify.SetCustomData(aPanel, roofBase, pullSettings.ConvertUnits) as oM.Environment.Elements.Panel;
+                    aPanel = Modify.SetCustomData(aPanel, roofBase) as oM.Environment.Elements.Panel;
 
                 pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aPanel);
 
@@ -520,7 +516,7 @@ namespace BH.UI.Revit.Engine
                 //Assign custom data
                 aPanel = Modify.SetIdentifiers(aPanel, wall) as oM.Environment.Elements.Panel;
                 if (pullSettings.CopyCustomData)
-                    aPanel = Modify.SetCustomData(aPanel, wall, pullSettings.ConvertUnits) as oM.Environment.Elements.Panel;
+                    aPanel = Modify.SetCustomData(aPanel, wall) as oM.Environment.Elements.Panel;
 
                 pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aPanel);
 

--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/SolidMaterial.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/SolidMaterial.cs
@@ -52,13 +52,7 @@ namespace BH.UI.Revit.Engine
                 aResult.Description = aParameter.AsString();
 
             Update(aResult, material, pullSettings);
-
             aResult = aResult.UpdateValues(pullSettings, material) as SolidMaterial;
-
-            //Set custom data
-            //aResult = Modify.SetIdentifiers(aResult, material) as SolidMaterial;
-            //if (pullSettings.CopyCustomData)
-            //    aResult = Modify.SetCustomData(aResult, material, pullSettings.ConvertUnits) as SolidMaterial;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aResult);
             return aResult;
@@ -102,9 +96,9 @@ namespace BH.UI.Revit.Engine
         {
             solidMaterial.Conductivity = thermalAsset.ThermalConductivity;
             solidMaterial.SpecificHeat = thermalAsset.SpecificHeat;
-            solidMaterial.Density = thermalAsset.Density;
-            if (pullSettings != null && pullSettings.ConvertUnits)
-                solidMaterial.Density = solidMaterial.Density.ToSI(UnitType.UT_MassDensity);
+            solidMaterial.Density = thermalAsset.Density.ToSI(UnitType.UT_MassDensity);
         }
+
+        /***************************************************/
     }
 }

--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/Space.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/Space.cs
@@ -79,7 +79,7 @@ namespace BH.UI.Revit.Engine
             aSpace = Create.Space(aName);
 
             if(spatialElement.Location != null && spatialElement.Location is LocationPoint)
-                aSpace.Location = ((LocationPoint)spatialElement.Location).ToBHoM(pullSettings);
+                aSpace.Location = ((LocationPoint)spatialElement.Location).ToBHoM();
 
             //Set ExtendedProperties
             OriginContextFragment aOriginContextFragment = new OriginContextFragment();
@@ -100,24 +100,11 @@ namespace BH.UI.Revit.Engine
             //Set custom data
             aSpace = Modify.SetIdentifiers(aSpace, spatialElement) as Space;
             if (pullSettings.CopyCustomData)
-                aSpace = Modify.SetCustomData(aSpace, spatialElement, pullSettings.ConvertUnits) as Space;
+                aSpace = Modify.SetCustomData(aSpace, spatialElement) as Space;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aSpace);
             aSpace = aSpace.UpdateValues(pullSettings, spatialElement) as Space;
             return aSpace;
-
-            //if (!SpatialElementGeometryCalculator.CanCalculateGeometry(spatialElement))
-            //{
-            //    //SpatialElementGeometryResults aSpatialElementGeometryResults = spatialElementGeometryCalculator.CalculateSpatialElementGeometry(spatialElement);
-            //    //foreach(SpatialElementBoundarySubface aSpatialElementBoundarySubface in  aSpatialElementGeometryResults.GetBoundaryFaceInfo())
-            //    //{
-            //    //    aSpatialElementBoundarySubface.
-            //    //}
-            //}
-            //else
-            //{
-
-            //}
         }
 
         /***************************************************/
@@ -139,7 +126,7 @@ namespace BH.UI.Revit.Engine
             aSpace = Create.Space(aName);
 
             if (aSpatialElement != null && aSpatialElement.Location != null)
-                aSpace.Location = (aSpatialElement.Location as LocationPoint).ToBHoM(pullSettings);
+                aSpace.Location = (aSpatialElement.Location as LocationPoint).ToBHoM();
 
             //Set ExtendedProperties
             OriginContextFragment aOriginContextFragment = new OriginContextFragment();
@@ -167,14 +154,9 @@ namespace BH.UI.Revit.Engine
             aSpace = Modify.SetIdentifiers(aSpace, aSpatialElement) as Space;
             if (pullSettings.CopyCustomData)
             {
-                aSpace = Modify.SetCustomData(aSpace, aSpatialElement, pullSettings.ConvertUnits) as Space;
-                double aInnerVolume = energyAnalysisSpace.InnerVolume;
-                double aAnalyticalVolume = energyAnalysisSpace.AnalyticalVolume;
-                if (pullSettings.ConvertUnits)
-                {
-                    aInnerVolume = aInnerVolume.ToSI(UnitType.UT_Volume);
-                    aAnalyticalVolume = aAnalyticalVolume.ToSI(UnitType.UT_Volume);
-                }
+                aSpace = Modify.SetCustomData(aSpace, aSpatialElement) as Space;
+                double aInnerVolume = energyAnalysisSpace.InnerVolume.ToSI(UnitType.UT_Volume);
+                double aAnalyticalVolume = energyAnalysisSpace.AnalyticalVolume.ToSI(UnitType.UT_Volume);
 
                 aSpace = Modify.SetCustomData(aSpace, "Inner Volume", aInnerVolume) as Space;
                 aSpace = Modify.SetCustomData(aSpace, "Analytical Volume", aAnalyticalVolume) as Space;

--- a/Engine_Revit_UI/Convert/Environment/ToRevit/Element.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToRevit/Element.cs
@@ -98,11 +98,11 @@ namespace BH.UI.Revit.Engine
             if (double.IsNaN(aLowElevation))
                 return null;
 
-            Level aLevel = document.LowLevel(aLowElevation, true);
+            Level aLevel = document.LowLevel(aLowElevation);
             if (aLevel == null)
                 return null;
 
-            aWall = Wall.Create(document, Convert.ToRevitCurveList(panel, pushSettings), aWallType.Id, aLevel.Id, false);
+            aWall = Wall.Create(document, panel.ToRevitCurveList(), aWallType.Id, aLevel.Id, false);
 
             Parameter aParameter = null;
 
@@ -116,19 +116,13 @@ namespace BH.UI.Revit.Engine
                 aParameter.Set(aHeight);
             }
 
-            double aElevation_Level = aLevel.Elevation;
-            if (pushSettings.ConvertUnits)
-                aElevation_Level = aElevation_Level.ToSI(UnitType.UT_Length);
-
+            double aElevation_Level = aLevel.Elevation.ToSI(UnitType.UT_Length);
             if (System.Math.Abs(aLowElevation - aElevation_Level) > oM.Geometry.Tolerance.MacroDistance)
             {
                 aParameter = aWall.get_Parameter(BuiltInParameter.WALL_BASE_OFFSET);
                 if (aParameter != null)
                 {
-                    double aOffset = aLowElevation - aElevation_Level;
-                    if (pushSettings.ConvertUnits)
-                        aOffset = aOffset.FromSI(UnitType.UT_Length);
-
+                    double aOffset = (aLowElevation - aElevation_Level).FromSI(UnitType.UT_Length);
                     aParameter.Set(aOffset);
                 }
             }
@@ -138,7 +132,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aWall, panel, new BuiltInParameter[] { BuiltInParameter.WALL_BASE_CONSTRAINT, BuiltInParameter.WALL_BASE_OFFSET }, pushSettings.ConvertUnits);
+                Modify.SetParameters(aWall, panel, new BuiltInParameter[] { BuiltInParameter.WALL_BASE_CONSTRAINT, BuiltInParameter.WALL_BASE_OFFSET });
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(panel, aWall);
 

--- a/Engine_Revit_UI/Convert/Environment/ToRevit/Space.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToRevit/Space.cs
@@ -42,15 +42,11 @@ namespace BH.UI.Revit.Engine
             if (aSpace != null)
                 return aSpace;
 
-            Level aLevel = Query.BottomLevel(space.Location.Z, document, pushSettings.ConvertUnits);
+            Level aLevel = Query.BottomLevel(space.Location.Z, document);
             if (aLevel == null)
                 return null;
 
-            UV aUV = new UV(space.Location.X, space.Location.Y);
-
-            if (pushSettings.ConvertUnits)
-                aUV = new UV(aUV.U.FromSI(UnitType.UT_Length), aUV.V.FromSI(UnitType.UT_Length));
-
+            UV aUV = new UV(space.Location.X.FromSI(UnitType.UT_Length), space.Location.Y.FromSI(UnitType.UT_Length));
             aSpace = document.Create.NewSpace(aLevel, aUV);
 
             aSpace.CheckIfNullPush(space);
@@ -60,7 +56,7 @@ namespace BH.UI.Revit.Engine
             aSpace.Name = space.Name;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aSpace, space, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aSpace, space, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(space, aSpace);
 

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/CoordinateSystem.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/CoordinateSystem.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -32,14 +32,12 @@ namespace BH.UI.Revit.Engine
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static oM.Geometry.CoordinateSystem.Cartesian ToBHoM(this Plane plane, PullSettings pullSettings = null)
+        public static oM.Geometry.CoordinateSystem.Cartesian ToBHoM(this Plane plane)
         {
             if (plane == null)
                 return null;
 
-            pullSettings = pullSettings.DefaultIfNull();
-
-            return BH.Engine.Geometry.Create.CartesianCoordinateSystem(ToBHoM(plane.Origin, pullSettings), ToBHoMVector(plane.XVec, pullSettings), ToBHoMVector(plane.YVec, pullSettings));
+            return BH.Engine.Geometry.Create.CartesianCoordinateSystem(ToBHoM(plane.Origin), ToBHoMVector(plane.XVec), ToBHoMVector(plane.YVec));
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/Grid.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/Grid.cs
@@ -41,12 +41,12 @@ namespace BH.UI.Revit.Engine
             if (aGrid != null)
                 return aGrid;
 
-            aGrid = BH.Engine.Geometry.SettingOut.Create.Grid(grid.Curve.ToBHoM(pullSettings));
+            aGrid = BH.Engine.Geometry.SettingOut.Create.Grid(grid.Curve.ToBHoM());
             aGrid.Name = grid.Name;
 
             aGrid = Modify.SetIdentifiers(aGrid, grid) as oM.Geometry.SettingOut.Grid;
             if (pullSettings.CopyCustomData)
-                aGrid = Modify.SetCustomData(aGrid, grid, pullSettings.ConvertUnits) as oM.Geometry.SettingOut.Grid;
+                aGrid = Modify.SetCustomData(aGrid, grid) as oM.Geometry.SettingOut.Grid;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aGrid);
 

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/ICurve.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/ICurve.cs
@@ -36,20 +36,18 @@ namespace BH.UI.Revit.Engine
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static oM.Geometry.ICurve ToBHoM(this Curve curve, PullSettings pullSettings = null)
+        public static oM.Geometry.ICurve ToBHoM(this Curve curve)
         {
             if (curve == null)
                 return null;
 
-            pullSettings = pullSettings.DefaultIfNull();
-
             if (curve is Line)
-                return BH.Engine.Geometry.Create.Line(ToBHoM(curve.GetEndPoint(0), pullSettings), ToBHoM(curve.GetEndPoint(1), pullSettings));
+                return BH.Engine.Geometry.Create.Line(curve.GetEndPoint(0).ToBHoM(), curve.GetEndPoint(1).ToBHoM());
 
             if (curve is Arc)
             {
                 Arc aArc = curve as Arc;
-                double radius = pullSettings.ConvertUnits ? aArc.Radius.ToSI(UnitType.UT_Length) : aArc.Radius;
+                double radius = aArc.Radius.ToSI(UnitType.UT_Length);
                 Plane plane = Plane.CreateByOriginAndBasis(aArc.Center, aArc.XDirection, aArc.YDirection);
                 double startAngle = aArc.XDirection.AngleOnPlaneTo(aArc.GetEndPoint(0) - aArc.Center, aArc.Normal);
                 double endAngle = aArc.XDirection.AngleOnPlaneTo(aArc.GetEndPoint(1) - aArc.Center, aArc.Normal);
@@ -57,7 +55,7 @@ namespace BH.UI.Revit.Engine
                 {
                     startAngle -= 2 * Math.PI;
                 }
-                return BH.Engine.Geometry.Create.Arc(ToBHoM(plane, pullSettings), radius, startAngle, endAngle);
+                return BH.Engine.Geometry.Create.Arc(plane.ToBHoM(), radius, startAngle, endAngle);
             }
             if (curve is NurbSpline)
             {
@@ -69,7 +67,7 @@ namespace BH.UI.Revit.Engine
 
                 return new BH.oM.Geometry.NurbsCurve
                 {
-                    ControlPoints = nurbs.CtrlPoints.Select(x => x.ToBHoM(pullSettings)).ToList(),
+                    ControlPoints = nurbs.CtrlPoints.Select(x => x.ToBHoM()).ToList(),
                     Knots = knots,
                     Weights = nurbs.Weights.Cast<double>().ToList()
 
@@ -80,28 +78,24 @@ namespace BH.UI.Revit.Engine
             if (aXYZs == null || aXYZs.Count < 2)
                 return null;
 
-            return BH.Engine.Geometry.Create.Polyline(aXYZs.ToList().ConvertAll(x => ToBHoM(x, pullSettings)));
+            return BH.Engine.Geometry.Create.Polyline(aXYZs.ToList().ConvertAll(x => x.ToBHoM()));
         }
 
         /***************************************************/
 
-        public static oM.Geometry.ICurve ToBHoM(this LocationCurve locationCurve, PullSettings pullSettings = null)
+        public static oM.Geometry.ICurve ToBHoM(this LocationCurve locationCurve)
         {
             if (locationCurve == null)
                 return null;
 
-            pullSettings = pullSettings.DefaultIfNull();
-
-            return ToBHoM(locationCurve.Curve, pullSettings);
+            return locationCurve.Curve.ToBHoM();
         }
 
         /***************************************************/
 
-        public static oM.Geometry.ICurve ToBHoM(this Edge edge, PullSettings pullSettings = null)
+        public static oM.Geometry.ICurve ToBHoM(this Edge edge)
         {
-            pullSettings = pullSettings.DefaultIfNull();
-
-            return ToBHoM(edge.AsCurve(), pullSettings);
+            return edge.AsCurve().ToBHoM();
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/ICurveList.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/ICurveList.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -36,43 +36,37 @@ namespace BH.UI.Revit.Engine
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static List<oM.Geometry.ICurve> ToBHoM(this List<Curve> curves, PullSettings pullSettings = null)
+        public static List<oM.Geometry.ICurve> ToBHoM(this List<Curve> curves)
         {
             if (curves == null)
                 return null;
 
-            pullSettings = pullSettings.DefaultIfNull();
-
-            return curves.Select(c => c.ToBHoM(pullSettings)).ToList();
+            return curves.Select(c => c.ToBHoM()).ToList();
         }
 
         /***************************************************/
 
-        public static List<oM.Geometry.ICurve> ToBHoM(this CurveArray curveArray, PullSettings pullSettings = null)
+        public static List<oM.Geometry.ICurve> ToBHoM(this CurveArray curveArray)
         {
             if (curveArray == null)
                 return null;
 
-            pullSettings = pullSettings.DefaultIfNull();
-
             List<oM.Geometry.ICurve> result = new List<oM.Geometry.ICurve>();
             for (int i = 0; i < curveArray.Size; i++)
             {
-                result.Add(curveArray.get_Item(i).ToBHoM(pullSettings));
+                result.Add(curveArray.get_Item(i).ToBHoM());
             }
             return result;
         }
 
         /***************************************************/
 
-        public static List<oM.Geometry.ICurve> ToBHoM(this EdgeArray edgeArray, PullSettings pullSettings = null)
+        public static List<oM.Geometry.ICurve> ToBHoM(this EdgeArray edgeArray)
         {
-            pullSettings = pullSettings.DefaultIfNull();
-
             List<oM.Geometry.ICurve> result = new List<oM.Geometry.ICurve>();
             foreach (Edge aEdge in edgeArray)
             {
-                result.Add(aEdge.ToBHoM(pullSettings));
+                result.Add(aEdge.ToBHoM());
             }
 
             return result;

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/Level.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/Level.cs
@@ -41,12 +41,12 @@ namespace BH.UI.Revit.Engine
             if (aLevel != null)
                 return aLevel;
 
-            aLevel = BH.Engine.Geometry.Create.Level(ToSI(level.ProjectElevation, UnitType.UT_Length));
+            aLevel = BH.Engine.Geometry.Create.Level(level.ProjectElevation.ToSI(UnitType.UT_Length));
             aLevel.Name = level.Name;
 
             aLevel = Modify.SetIdentifiers(aLevel, level) as oM.Geometry.SettingOut.Level;
             if (pullSettings.CopyCustomData)
-                aLevel = Modify.SetCustomData(aLevel, level, pullSettings.ConvertUnits) as oM.Geometry.SettingOut.Level;
+                aLevel = Modify.SetCustomData(aLevel, level) as oM.Geometry.SettingOut.Level;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aLevel);
 

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/Point.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/Point.cs
@@ -32,29 +32,22 @@ namespace BH.UI.Revit.Engine
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static oM.Geometry.Point ToBHoM(this LocationPoint locationPoint, PullSettings pullSettings = null)
+        public static oM.Geometry.Point ToBHoM(this LocationPoint locationPoint)
         {
             if (locationPoint == null)
                 return null;
 
-            pullSettings = pullSettings.DefaultIfNull();
-
-            return ToBHoM(locationPoint.Point, pullSettings);
+            return locationPoint.Point.ToBHoM();
         }
 
         /***************************************************/
 
-        public static oM.Geometry.Point ToBHoM(this XYZ xyz, PullSettings pullSettings = null)
+        public static oM.Geometry.Point ToBHoM(this XYZ xyz)
         {
             if (xyz == null)
                 return null;
 
-            pullSettings = pullSettings.DefaultIfNull();
-
-            if (pullSettings.ConvertUnits)
-                return BH.Engine.Geometry.Create.Point(xyz.X.ToSI(UnitType.UT_Length), xyz.Y.ToSI(UnitType.UT_Length), xyz.Z.ToSI(UnitType.UT_Length));
-            else
-                return BH.Engine.Geometry.Create.Point(xyz.X, xyz.Y, xyz.Z);
+            return BH.Engine.Geometry.Create.Point(xyz.X.ToSI(UnitType.UT_Length), xyz.Y.ToSI(UnitType.UT_Length), xyz.Z.ToSI(UnitType.UT_Length));
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/PolyCurve.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/PolyCurve.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -36,16 +36,14 @@ namespace BH.UI.Revit.Engine
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static oM.Geometry.PolyCurve ToBHoM(this CurveLoop curveLoop, PullSettings pullSettings = null)
+        public static oM.Geometry.PolyCurve ToBHoM(this CurveLoop curveLoop)
         {
             if (curveLoop == null)
                 return null;
 
-            pullSettings = pullSettings.DefaultIfNull();
-
             List<oM.Geometry.ICurve> aICurveList = new List<oM.Geometry.ICurve>();
             foreach (Curve aCurve in curveLoop)
-                aICurveList.Add(aCurve.ToBHoM(pullSettings));
+                aICurveList.Add(aCurve.ToBHoM());
 
             return BH.Engine.Geometry.Create.PolyCurve(aICurveList);
         }

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/PolyCurveList.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/PolyCurveList.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -35,10 +35,8 @@ namespace BH.UI.Revit.Engine
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static List<PolyCurve> ToBHoM(this Sketch sketch, PullSettings pullSettings = null)
+        public static List<PolyCurve> ToBHoM(this Sketch sketch)
         {
-            pullSettings = pullSettings.DefaultIfNull();
-
             SketchPlane aSketchPlane = sketch.SketchPlane;
             //oM.Geometry.CoordinateSystem.Cartesian aCartesian = ToBHoM(aSketchPlane.GetPlane(), pullSettings);
 
@@ -49,7 +47,7 @@ namespace BH.UI.Revit.Engine
             List<PolyCurve> aResult = new List<PolyCurve>();
             foreach (CurveArray aCurveArray in sketch.Profile)
             {
-                PolyCurve aPolyCurve = BH.Engine.Geometry.Create.PolyCurve(ToBHoM(aCurveArray, pullSettings));
+                PolyCurve aPolyCurve = BH.Engine.Geometry.Create.PolyCurve(aCurveArray.ToBHoM());
 
                //aPolyCurve = BH.Engine.Geometry.Modify.Translate(aPolyCurve, -aVector);
 
@@ -61,27 +59,23 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static List<PolyCurve> ToBHoM(this CurveArrArray curveArrArray, PullSettings pullSettings = null)
+        public static List<PolyCurve> ToBHoM(this CurveArrArray curveArrArray)
         {
-            pullSettings = pullSettings.DefaultIfNull();
-
             List<PolyCurve> aResult = new List<PolyCurve>();
             foreach (CurveArray aCurveArray in curveArrArray)
-                aResult.Add(BH.Engine.Geometry.Create.PolyCurve(ToBHoM(aCurveArray, pullSettings)));
+                aResult.Add(BH.Engine.Geometry.Create.PolyCurve(aCurveArray.ToBHoM()));
 
             return aResult;
         }
 
         /***************************************************/
 
-        public static List<PolyCurve> ToBHoM(this EdgeArrayArray edgeArray, PullSettings pullSettings = null)
+        public static List<PolyCurve> ToBHoM(this EdgeArrayArray edgeArray)
         {
-            pullSettings = pullSettings.DefaultIfNull();
-
             List<PolyCurve> aResult = new List<PolyCurve>();
             foreach (EdgeArray ea in edgeArray)
             {
-                aResult.Add(BH.Engine.Geometry.Create.PolyCurve(ea.ToBHoM(pullSettings)));
+                aResult.Add(BH.Engine.Geometry.Create.PolyCurve(ea.ToBHoM()));
             }
             return aResult;
         }

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/Polyline.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/Polyline.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -35,10 +35,8 @@ namespace BH.UI.Revit.Engine
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static oM.Geometry.Polyline ToBHoM(this Polyloop polyloop, PullSettings pullSettings = null)
+        public static oM.Geometry.Polyline ToBHoM(this Polyloop polyloop)
         {
-            pullSettings = pullSettings.DefaultIfNull();
-
             IList<XYZ> aXYZs = polyloop.GetPoints();
             if (aXYZs == null)
                 return null;
@@ -47,9 +45,9 @@ namespace BH.UI.Revit.Engine
             if (aXYZs.Count > 0)
             {
                 foreach (XYZ aXYZ in aXYZs)
-                    aPointList.Add(aXYZ.ToBHoM(pullSettings));
+                    aPointList.Add(aXYZ.ToBHoM());
 
-                aPointList.Add(aXYZs[0].ToBHoM(pullSettings));
+                aPointList.Add(aXYZs[0].ToBHoM());
             }
 
             return BH.Engine.Geometry.Create.Polyline(aPointList);

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/Vector.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/Vector.cs
@@ -34,17 +34,12 @@ namespace BH.UI.Revit.Engine
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static oM.Geometry.Vector ToBHoMVector(this XYZ xyz, PullSettings pullSettings = null)
+        public static oM.Geometry.Vector ToBHoMVector(this XYZ xyz)
         {
             if (xyz == null)
                 return null;
 
-            pullSettings = pullSettings.DefaultIfNull();
-
-            if (pullSettings.ConvertUnits)
-                return Create.Vector(xyz.X.ToSI(UnitType.UT_Length), xyz.Y.ToSI(UnitType.UT_Length), xyz.Z.ToSI(UnitType.UT_Length));
-            else
-                return Create.Vector(xyz.X, xyz.Y, xyz.Z);
+            return Create.Vector(xyz.X.ToSI(UnitType.UT_Length), xyz.Y.ToSI(UnitType.UT_Length), xyz.Z.ToSI(UnitType.UT_Length));
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Brep.cs
@@ -36,12 +36,11 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static BRepBuilder ToRevitBrep(this ISurface surface, PushSettings pushSettings = null)
+        public static BRepBuilder ToRevitBrep(this ISurface surface)
         {
-            pushSettings = pushSettings.DefaultIfNull();
             BRepBuilder brep = new BRepBuilder(BRepType.OpenShell);
 
-            if (!TryAddSurface(brep, surface as dynamic, pushSettings))
+            if (!TryAddSurface(brep, surface as dynamic))
                 return null;
 
             brep.Finish();
@@ -50,14 +49,13 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static BRepBuilder ToRevitBrep(this BoundaryRepresentation boundaryRepresentation, PushSettings pushSettings = null)
+        public static BRepBuilder ToRevitBrep(this BoundaryRepresentation boundaryRepresentation)
         {
             //TODO: allow creating void and solid?
-            pushSettings = pushSettings.DefaultIfNull();
             BRepBuilder brep = new BRepBuilder(BRepType.OpenShell);
             foreach (ISurface s in boundaryRepresentation.Surfaces)
             {
-                if (!TryAddSurface(brep, s as dynamic, pushSettings))
+                if (!TryAddSurface(brep, s as dynamic))
                     return null;
             }
 
@@ -70,11 +68,11 @@ namespace BH.UI.Revit.Engine
         /****              Private methods              ****/
         /***************************************************/
 
-        private static bool TryAddSurface(this BRepBuilder brep, PolySurface ps, PushSettings pushSettings)
+        private static bool TryAddSurface(this BRepBuilder brep, PolySurface ps)
         {
             foreach (ISurface s in ps.Surfaces)
             {
-                if (!TryAddSurface(brep, s as dynamic, pushSettings))
+                if (!TryAddSurface(brep, s as dynamic))
                     return false;
             }
 
@@ -83,21 +81,21 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        private static bool TryAddSurface(this BRepBuilder brep, PlanarSurface ps, PushSettings pushSettings)
+        private static bool TryAddSurface(this BRepBuilder brep, PlanarSurface ps)
         {
             try
             {
                 BH.oM.Geometry.Plane p = ps.ExternalBoundary.IFitPlane();
-                Autodesk.Revit.DB.Plane rp = p.ToRevitPlane(pushSettings);
+                Autodesk.Revit.DB.Plane rp = p.ToRevitPlane();
 
                 BRepBuilderSurfaceGeometry bbsg = BRepBuilderSurfaceGeometry.Create(rp, null);
                 BRepBuilderGeometryId face = brep.AddFace(bbsg, false);
 
-                brep.AddLoop(face, rp.Normal, ps.ExternalBoundary, true, pushSettings);
+                brep.AddLoop(face, rp.Normal, ps.ExternalBoundary, true);
 
                 foreach (ICurve c in ps.InternalBoundaries)
                 {
-                    brep.AddLoop(face, rp.Normal, c, false, pushSettings);
+                    brep.AddLoop(face, rp.Normal, c, false);
                 }
 
                 brep.FinishFace(face);
@@ -113,7 +111,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        private static bool TryAddSurface(this BRepBuilder brep, NurbsSurface ns, PushSettings pushSettings)
+        private static bool TryAddSurface(this BRepBuilder brep, NurbsSurface ns)
         {
             if (ns.IsClosed())
             {
@@ -141,7 +139,7 @@ namespace BH.UI.Revit.Engine
                     weights[i] = new double[uvCount[1]];
                     for (int j = 0; j < uvCount[1]; j++)
                     {
-                        points[i][j] = ns.ControlPoints[j + (uvCount[1] * i)].ToRevitXYZ(pushSettings);
+                        points[i][j] = ns.ControlPoints[j + (uvCount[1] * i)].ToRevitXYZ();
                         weights[i][j] = ns.Weights[j + (uvCount[1] * i)];
                     }
                 }
@@ -166,7 +164,7 @@ namespace BH.UI.Revit.Engine
                     BRepBuilderGeometryId loop = brep.AddLoop(face);
                     foreach (ICurve sp in trim.Curve3d.ISubParts())
                     {
-                        List<Curve> ccs = sp.ToRevitCurves(pushSettings);
+                        List<Curve> ccs = sp.ToRevitCurves();
                         foreach (Curve cc in ccs)
                         {
                             BRepBuilderGeometryId edge = brep.AddEdge(BRepBuilderEdgeGeometry.Create(cc));
@@ -181,7 +179,7 @@ namespace BH.UI.Revit.Engine
                     BRepBuilderGeometryId loop = brep.AddLoop(face);
                     foreach (ICurve sp in trim.Curve3d.ISubParts())
                     {
-                        List<Curve> ccs = sp.ToRevitCurves(pushSettings);
+                        List<Curve> ccs = sp.ToRevitCurves();
                         foreach (Curve cc in ccs)
                         {
                             BRepBuilderGeometryId edge = brep.AddEdge(BRepBuilderEdgeGeometry.Create(cc));
@@ -205,12 +203,12 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        private static void AddLoop(this BRepBuilder brep, BRepBuilderGeometryId face, XYZ normal, ICurve curve, bool external, PushSettings pushSettings)
+        private static void AddLoop(this BRepBuilder brep, BRepBuilderGeometryId face, XYZ normal, ICurve curve, bool external)
         {
             CurveLoop cl = new CurveLoop();
             foreach (ICurve sp in curve.ISubParts())
             {
-                foreach (Curve cc in sp.ToRevitCurves(pushSettings))
+                foreach (Curve cc in sp.ToRevitCurves())
                 {
                     cl.Append(cc);
                 }

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/CoordinateSystem.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/CoordinateSystem.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -33,13 +33,11 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static Plane ToRevitPlane(this Cartesian coordinateSystem, PushSettings pushSettings = null)
+        public static Plane ToRevitPlane(this Cartesian coordinateSystem)
         {
-            pushSettings = pushSettings.DefaultIfNull();
-
-            XYZ origin = coordinateSystem.Origin.ToRevit(pushSettings);
-            XYZ X = coordinateSystem.X.ToRevit(pushSettings).Normalize();
-            XYZ Y = coordinateSystem.Y.ToRevit(pushSettings).Normalize();
+            XYZ origin = coordinateSystem.Origin.ToRevit();
+            XYZ X = coordinateSystem.X.ToRevit().Normalize();
+            XYZ Y = coordinateSystem.Y.ToRevit().Normalize();
             return Plane.CreateByOriginAndBasis(origin, X, Y);
         }
 

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/CurveArray.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/CurveArray.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -33,17 +33,15 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static CurveArray ToRevitCurveArray(this PolyCurve polyCurve, PushSettings pushSettings = null)
+        public static CurveArray ToRevitCurveArray(this PolyCurve polyCurve)
         {
             if (polyCurve == null)
                 return null;
 
-            pushSettings = pushSettings.DefaultIfNull();
-
             CurveArray aCurveArray = new CurveArray();
             foreach (ICurve aICurve in polyCurve.Curves)
             {
-                List<Curve> aCurveList = aICurve.ToRevitCurveList(pushSettings);
+                List<Curve> aCurveList = aICurve.ToRevitCurveList();
                 if (aCurveList == null || aCurveList.Count == 0)
                     continue;
 
@@ -55,19 +53,17 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static CurveArray ToRevitCurveArray(this Polyline polyline, PushSettings pushSettings = null)
+        public static CurveArray ToRevitCurveArray(this Polyline polyline)
         {
             if (polyline == null)
                 return null;
-
-            pushSettings = pushSettings.DefaultIfNull();
 
             List<ICurve> aCureList = Query.Curves(polyline);
             if (aCureList == null)
                 return null;
 
             CurveArray aCurveArray = new CurveArray();
-            aCureList.ForEach(x => aCurveArray.Append(x.ToRevit(pushSettings)));
+            aCureList.ForEach(x => aCurveArray.Append(x.ToRevit()));
             return aCurveArray;
         }
 

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/CurveList.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/CurveList.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -34,7 +34,7 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static List<Curve> ToRevitCurveList(this oM.Environment.Elements.Panel panel, PushSettings pushSettings = null)
+        public static List<Curve> ToRevitCurveList(this oM.Environment.Elements.Panel panel)
         {
             if (panel == null || panel.ExternalEdges == null)
                 return null;
@@ -42,39 +42,38 @@ namespace BH.UI.Revit.Engine
             List<Curve> aResult = new List<Curve>();
             foreach (oM.Environment.Elements.Edge aEdge in panel.ExternalEdges)
             {
-                List<Curve> aCurveList = ToRevitCurveList(aEdge.Curve, pushSettings);
+                List<Curve> aCurveList = aEdge.Curve.ToRevitCurveList();
                 if (aCurveList != null && aCurveList.Count > 0)
                     aResult.AddRange(aCurveList);
             }
             return aResult;
         }
 
+        /***************************************************/
 
-        public static List<Curve> ToRevitCurveList(this ICurve curve, PushSettings pushSettings = null)
+        public static List<Curve> ToRevitCurveList(this ICurve curve)
         {
             if (curve == null)
                 return null;
 
-            pushSettings = pushSettings.DefaultIfNull();
-
             List<Curve> aResult = new List<Curve>();
             if (curve is oM.Geometry.Arc)
-                aResult.Add(curve.ToRevit(pushSettings));
+                aResult.Add(curve.ToRevit());
             if (curve is oM.Geometry.Ellipse)
-                aResult.Add(curve.ToRevit(pushSettings));
+                aResult.Add(curve.ToRevit());
             else if (curve is Circle)
-                aResult.Add(curve.ToRevit(pushSettings));
+                aResult.Add(curve.ToRevit());
             else if (curve is oM.Geometry.Line)
-                aResult.Add(curve.ToRevit(pushSettings));
+                aResult.Add(curve.ToRevit());
             else if (curve is NurbsCurve)
-                aResult.Add(curve.ToRevit(pushSettings));
+                aResult.Add(curve.ToRevit());
             else if (curve is Polyline)
             {
                 List<ICurve> aCureList = Query.Curves((Polyline)curve);
                 if (aCureList == null)
                     return null;
 
-                aCureList.ForEach(x => aResult.Add(x.ToRevit(pushSettings)));
+                aCureList.ForEach(x => aResult.Add(x.ToRevit()));
             }
             else if (curve is PolyCurve)
             {
@@ -84,7 +83,7 @@ namespace BH.UI.Revit.Engine
 
                 foreach (ICurve aCurve in aPolyCurve.Curves)
                 {
-                    List<Curve> aCurveList = aCurve.ToRevitCurveList(pushSettings);
+                    List<Curve> aCurveList = aCurve.ToRevitCurveList();
                     if (aCurveList != null && aCurveList.Count > 0)
                     {
                         aResult.AddRange(aCurveList);

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Grid.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Grid.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -39,7 +39,7 @@ namespace BH.UI.Revit.Engine
 
             pushSettings.DefaultIfNull();
 
-            Curve aCurve = Convert.ToRevitCurve(grid.Curve, pushSettings);
+            Curve aCurve = grid.Curve.ToRevitCurve();
 
             if (aCurve is Line)
                 aGrid = Grid.Create(document, (Line)aCurve);
@@ -51,7 +51,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aGrid, grid, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aGrid, grid, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(grid, aGrid);
 

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Level.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Level.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -50,10 +50,7 @@ namespace BH.UI.Revit.Engine
 
             if (aLevel == null)
             {
-                double aElevation = level.Elevation;
-                if (pushSettings.ConvertUnits)
-                    aElevation = Convert.FromSI(aElevation, UnitType.UT_Length);
-
+                double aElevation = level.Elevation.FromSI(UnitType.UT_Length);
                 aLevel = Level.Create(document, aElevation);
                 aLevel.Name = level.Name;
             }
@@ -63,7 +60,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aLevel, level, new BuiltInParameter[] { BuiltInParameter.DATUM_TEXT, BuiltInParameter.LEVEL_ELEV }, pushSettings.ConvertUnits);
+                Modify.SetParameters(aLevel, level, new BuiltInParameter[] { BuiltInParameter.DATUM_TEXT, BuiltInParameter.LEVEL_ELEV });
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(level, aLevel);
 

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Plane.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Plane.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -31,11 +31,9 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static Plane ToRevitPlane(this oM.Geometry.Plane plane, PushSettings pushSettings = null)
+        public static Plane ToRevitPlane(this oM.Geometry.Plane plane)
         {
-            pushSettings = pushSettings.DefaultIfNull();
-
-            return Plane.CreateByNormalAndOrigin(plane.Normal.ToRevitXYZ(pushSettings), plane.Origin.ToRevitXYZ(pushSettings));
+            return Plane.CreateByNormalAndOrigin(plane.Normal.ToRevitXYZ(), plane.Origin.ToRevitXYZ());
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/PolyLine.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/PolyLine.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -32,11 +32,9 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static PolyLine ToRevitPolyLine(this oM.Geometry.Polyline polyline, PushSettings pushSettings = null)
+        public static PolyLine ToRevitPolyLine(this oM.Geometry.Polyline polyline)
         {
-            pushSettings = pushSettings.DefaultIfNull();
-
-            return PolyLine.Create(polyline.ControlPoints.ToList().ConvertAll(x => x.ToRevitXYZ(pushSettings)));
+            return PolyLine.Create(polyline.ControlPoints.ConvertAll(x => x.ToRevitXYZ()));
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/Vector.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/Vector.cs
@@ -32,14 +32,9 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static XYZ ToRevit(this Vector vector, PushSettings pushSettings = null)
+        public static XYZ ToRevit(this Vector vector)
         {
-            pushSettings = pushSettings.DefaultIfNull();
-
-            if (pushSettings.ConvertUnits)
-                return new XYZ(vector.X.FromSI(UnitType.UT_Length), vector.Y.FromSI(UnitType.UT_Length), vector.Z.FromSI(UnitType.UT_Length));
-            else
-                return new XYZ(vector.X, vector.Y, vector.Z);
+            return new XYZ(vector.X.FromSI(UnitType.UT_Length), vector.Y.FromSI(UnitType.UT_Length), vector.Z.FromSI(UnitType.UT_Length));
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Geometry/ToRevit/XYZ.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToRevit/XYZ.cs
@@ -31,26 +31,16 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static XYZ ToRevitXYZ(this oM.Geometry.Point point, PushSettings pushSettings = null)
+        public static XYZ ToRevitXYZ(this oM.Geometry.Point point)
         {
-            pushSettings = pushSettings.DefaultIfNull();
-
-            if (pushSettings.ConvertUnits)
-                return new XYZ(point.X.FromSI(UnitType.UT_Length), point.Y.FromSI(UnitType.UT_Length), point.Z.FromSI(UnitType.UT_Length));
-            else
-                return new XYZ(point.X, point.Y, point.Z);
+            return new XYZ(point.X.FromSI(UnitType.UT_Length), point.Y.FromSI(UnitType.UT_Length), point.Z.FromSI(UnitType.UT_Length));
         }
 
         /***************************************************/
 
-        public static XYZ ToRevitXYZ(this oM.Geometry.Vector vector, PushSettings pushSettings = null)
+        public static XYZ ToRevitXYZ(this oM.Geometry.Vector vector)
         {
-            pushSettings = pushSettings.DefaultIfNull();
-
-            if (pushSettings.ConvertUnits)
-                return new XYZ(vector.X.FromSI(UnitType.UT_Length), vector.Y.FromSI(UnitType.UT_Length), vector.Z.FromSI(UnitType.UT_Length));
-            else
-                return new XYZ(vector.X, vector.Y, vector.Z);
+            return new XYZ(vector.X.FromSI(UnitType.UT_Length), vector.Y.FromSI(UnitType.UT_Length), vector.Z.FromSI(UnitType.UT_Length));
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Physical/ToBHoM/Construction.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToBHoM/Construction.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -96,7 +96,7 @@ namespace BH.UI.Revit.Engine
 
             aConstruction = Modify.SetIdentifiers(aConstruction, hostObjAttributes) as oM.Physical.Constructions.Construction;
             if (pullSettings.CopyCustomData)
-                aConstruction = Modify.SetCustomData(aConstruction, hostObjAttributes, pullSettings.ConvertUnits) as oM.Physical.Constructions.Construction;
+                aConstruction = Modify.SetCustomData(aConstruction, hostObjAttributes) as oM.Physical.Constructions.Construction;
 
             aConstruction = aConstruction.UpdateValues(pullSettings, hostObjAttributes) as oM.Physical.Constructions.Construction;
 

--- a/Engine_Revit_UI/Convert/Physical/ToBHoM/Door.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToBHoM/Door.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -64,7 +64,7 @@ namespace BH.UI.Revit.Engine
 
             aDoor = Modify.SetIdentifiers(aDoor, familyInstance) as Door;
             if (pullSettings.CopyCustomData)
-                aDoor = Modify.SetCustomData(aDoor, familyInstance, pullSettings.ConvertUnits) as Door;
+                aDoor = Modify.SetCustomData(aDoor, familyInstance) as Door;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aDoor);
 

--- a/Engine_Revit_UI/Convert/Physical/ToBHoM/FramingElement.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToBHoM/FramingElement.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -136,7 +136,7 @@ namespace BH.UI.Revit.Engine
             
             framingElement = Modify.SetIdentifiers(framingElement, familyInstance) as IFramingElement;
             if (pullSettings.CopyCustomData)
-                framingElement = Modify.SetCustomData(framingElement, familyInstance, pullSettings.ConvertUnits) as IFramingElement;
+                framingElement = Modify.SetCustomData(framingElement, familyInstance) as IFramingElement;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(framingElement);
 
@@ -154,7 +154,7 @@ namespace BH.UI.Revit.Engine
                 rotation = Math.PI * 0.5 + (location as LocationPoint).Rotation;
             else if (location is LocationCurve)
             {
-                BH.oM.Geometry.ICurve locationCurve = (location as LocationCurve).Curve.ToBHoM(pullSettings);
+                BH.oM.Geometry.ICurve locationCurve = (location as LocationCurve).Curve.ToBHoM();
                 if (locationCurve is BH.oM.Geometry.Line)
                 {
                     Transform transform = familyInstance.GetTotalTransform();
@@ -176,9 +176,9 @@ namespace BH.UI.Revit.Engine
                 else
                 {
                     if (IsVerticalNonLinearCurve((location as LocationCurve).Curve))
-                        rotation = Math.PI * 0.5 - familyInstance.LookupDouble(BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE, false);
+                        rotation = Math.PI * 0.5 - familyInstance.LookupDouble(BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE);
                     else
-                        rotation = -familyInstance.LookupDouble(BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE, false);
+                        rotation = -familyInstance.LookupDouble(BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE);
 
                     if (familyInstance.Mirrored)
                         rotation *= -1;
@@ -216,12 +216,12 @@ namespace BH.UI.Revit.Engine
                     double topOffset = topOffsetParam.AsDouble();
                     XYZ baseNode = new XYZ(loc.X, loc.Y, baseLevel + baseOffset);
                     XYZ topNode = new XYZ(loc.X, loc.Y, topLevel + topOffset);
-                    locationCurve = new oM.Geometry.Line { Start = baseNode.ToBHoM(pullSettings), End = topNode.ToBHoM(pullSettings) };
+                    locationCurve = new oM.Geometry.Line { Start = baseNode.ToBHoM(), End = topNode.ToBHoM() };
                 }
             }
             else if (location is LocationCurve)
             {
-                locationCurve = (location as LocationCurve).Curve.ToBHoM(pullSettings);
+                locationCurve = (location as LocationCurve).Curve.ToBHoM();
                 double startExtension = 0;
                 double endExtension = 0;
 
@@ -240,10 +240,10 @@ namespace BH.UI.Revit.Engine
                             BH.Engine.Reflection.Compute.RecordWarning(string.Format("A slanted column is attached at base or top, this may cause wrong length on pull to BHoM. Element Id: {0}", familyInstance.Id.IntegerValue));
 
                         if (attachedBase == 1)
-                            startExtension = -familyInstance.LookupDouble(BuiltInParameter.COLUMN_BASE_ATTACHMENT_OFFSET_PARAM, pullSettings.ConvertUnits);
+                            startExtension = -familyInstance.LookupDouble(BuiltInParameter.COLUMN_BASE_ATTACHMENT_OFFSET_PARAM);
                         else
                         {
-                            double baseExtensionValue = familyInstance.LookupDouble(BuiltInParameter.SLANTED_COLUMN_BASE_EXTENSION, pullSettings.ConvertUnits);
+                            double baseExtensionValue = familyInstance.LookupDouble(BuiltInParameter.SLANTED_COLUMN_BASE_EXTENSION);
                             if (!double.IsNaN(baseExtensionValue) && Math.Abs(baseExtensionValue) > BH.oM.Geometry.Tolerance.Distance)
                             {
                                 int baseCutStyle = familyInstance.LookupInteger(BuiltInParameter.SLANTED_COLUMN_BASE_CUT_STYLE);
@@ -263,10 +263,10 @@ namespace BH.UI.Revit.Engine
                         }
 
                         if (attachedTop == 1)
-                            endExtension = -familyInstance.LookupDouble(BuiltInParameter.COLUMN_TOP_ATTACHMENT_OFFSET_PARAM, pullSettings.ConvertUnits);
+                            endExtension = -familyInstance.LookupDouble(BuiltInParameter.COLUMN_TOP_ATTACHMENT_OFFSET_PARAM);
                         else
                         {
-                            double topExtensionValue = familyInstance.LookupDouble(BuiltInParameter.SLANTED_COLUMN_TOP_EXTENSION, pullSettings.ConvertUnits);
+                            double topExtensionValue = familyInstance.LookupDouble(BuiltInParameter.SLANTED_COLUMN_TOP_EXTENSION);
                             if (!double.IsNaN(topExtensionValue) && Math.Abs(topExtensionValue) > BH.oM.Geometry.Tolerance.Distance)
                             {
                                 int topCutStyle = familyInstance.LookupInteger(BuiltInParameter.SLANTED_COLUMN_TOP_CUT_STYLE);
@@ -296,8 +296,8 @@ namespace BH.UI.Revit.Engine
                 int yzJustification = familyInstance.LookupInteger(BuiltInParameter.YZ_JUSTIFICATION);
                 if (yzJustification == 0)
                 {
-                    double yOffset = familyInstance.LookupDouble(BuiltInParameter.Y_OFFSET_VALUE, false);
-                    double zOffset = -familyInstance.LookupDouble(BuiltInParameter.Z_OFFSET_VALUE, false);
+                    double yOffset = familyInstance.LookupDouble(BuiltInParameter.Y_OFFSET_VALUE);
+                    double zOffset = -familyInstance.LookupDouble(BuiltInParameter.Z_OFFSET_VALUE);
                     if (double.IsNaN(yOffset))
                         yOffset = 0;
                     if (double.IsNaN(zOffset))
@@ -323,15 +323,15 @@ namespace BH.UI.Revit.Engine
                         }
                     }
 
-                    startOffset = (new XYZ(0, yOffset, zOffset)).ToBHoMVector(pullSettings);
-                    endOffset = (new XYZ(0, yOffset, zOffset)).ToBHoMVector(pullSettings);
+                    startOffset = (new XYZ(0, yOffset, zOffset)).ToBHoMVector();
+                    endOffset = (new XYZ(0, yOffset, zOffset)).ToBHoMVector();
                 }
                 else if (yzJustification == 1)
                 {
-                    double yOffsetStart = familyInstance.LookupDouble(BuiltInParameter.START_Y_OFFSET_VALUE, false);
-                    double yOffsetEnd = familyInstance.LookupDouble(BuiltInParameter.END_Y_OFFSET_VALUE, false);
-                    double zOffsetStart = -familyInstance.LookupDouble(BuiltInParameter.START_Z_OFFSET_VALUE, false);
-                    double zOffsetEnd = -familyInstance.LookupDouble(BuiltInParameter.END_Z_OFFSET_VALUE, false);
+                    double yOffsetStart = familyInstance.LookupDouble(BuiltInParameter.START_Y_OFFSET_VALUE);
+                    double yOffsetEnd = familyInstance.LookupDouble(BuiltInParameter.END_Y_OFFSET_VALUE);
+                    double zOffsetStart = -familyInstance.LookupDouble(BuiltInParameter.START_Z_OFFSET_VALUE);
+                    double zOffsetEnd = -familyInstance.LookupDouble(BuiltInParameter.END_Z_OFFSET_VALUE);
                     if (double.IsNaN(yOffsetStart))
                         yOffsetStart = 0;
                     if (double.IsNaN(yOffsetEnd))
@@ -373,8 +373,8 @@ namespace BH.UI.Revit.Engine
                         }
                     }
 
-                    startOffset = (new XYZ(0, yOffsetStart, zOffsetStart)).ToBHoMVector(pullSettings);
-                    endOffset = (new XYZ(0, yOffsetEnd, zOffsetEnd)).ToBHoMVector(pullSettings);
+                    startOffset = (new XYZ(0, yOffsetStart, zOffsetStart)).ToBHoMVector();
+                    endOffset = (new XYZ(0, yOffsetEnd, zOffsetEnd)).ToBHoMVector();
                 }
             }
         }

--- a/Engine_Revit_UI/Convert/Physical/ToBHoM/ISurface.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToBHoM/ISurface.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -105,7 +105,7 @@ namespace BH.UI.Revit.Engine
 
                 aISurface = Modify.SetIdentifiers(aISurface, hostObject) as oM.Physical.Elements.ISurface;
                 if (pullSettings.CopyCustomData)
-                    aISurface = Modify.SetCustomData(aISurface, hostObject, pullSettings.ConvertUnits) as oM.Physical.Elements.ISurface;
+                    aISurface = Modify.SetCustomData(aISurface, hostObject) as oM.Physical.Elements.ISurface;
 
                 aISurface = aISurface.UpdateValues(pullSettings, hostObject) as oM.Physical.Elements.ISurface;
 

--- a/Engine_Revit_UI/Convert/Physical/ToBHoM/Material.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToBHoM/Material.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -53,7 +53,7 @@ namespace BH.UI.Revit.Engine
             
             aMaterial = Modify.SetIdentifiers(aMaterial, material) as oM.Physical.Materials.Material;
             if (pullSettings.CopyCustomData)
-                aMaterial = Modify.SetCustomData(aMaterial, material, pullSettings.ConvertUnits) as oM.Physical.Materials.Material;
+                aMaterial = Modify.SetCustomData(aMaterial, material) as oM.Physical.Materials.Material;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aMaterial);
 

--- a/Engine_Revit_UI/Convert/Physical/ToBHoM/Window.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToBHoM/Window.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -69,7 +69,7 @@ namespace BH.UI.Revit.Engine
 
             aWindow = Modify.SetIdentifiers(aWindow, familyInstance) as Window;
             if (pullSettings.CopyCustomData)
-                aWindow = Modify.SetCustomData(aWindow, familyInstance, pullSettings.ConvertUnits) as Window;
+                aWindow = Modify.SetCustomData(aWindow, familyInstance) as Window;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aWindow);
 
@@ -83,18 +83,6 @@ namespace BH.UI.Revit.Engine
             Window aWindow = pullSettings.FindRefObject<Window>(panel.Id.IntegerValue);
             if (aWindow != null)
                 return aWindow;
-
-            //ElementId aElementId = panel.FindHostPanel(); ;
-            //if (aElementId == null || aElementId == ElementId.InvalidElementId)
-            //    return null;
-
-            //List<PolyCurve> aPolyCurveList = Query.Profiles_Wall(panel.Document.GetElement(aElementId) as dynamic, pullSettings);
-            //if (aPolyCurveList == null || aPolyCurveList.Count == 0)
-            //    return null;
-
-            //PlanarSurface aPlanarSurface = BH.Engine.Geometry.Create.PlanarSurface(aPolyCurveList.First());
-
-            //List<ICurve> aCurveList = Query.Curves(panel, new Options(), pullSettings);
 
             PolyCurve aPolyCurve = Query.PolyCurve(panel, pullSettings);
             if (aPolyCurve == null)
@@ -119,7 +107,7 @@ namespace BH.UI.Revit.Engine
 
             aWindow = Modify.SetIdentifiers(aWindow, panel) as Window;
             if (pullSettings.CopyCustomData)
-                aWindow = Modify.SetCustomData(aWindow, panel, pullSettings.ConvertUnits) as Window;
+                aWindow = Modify.SetCustomData(aWindow, panel) as Window;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aWindow);
 

--- a/Engine_Revit_UI/Convert/Physical/ToRevit/FamilyInstance.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToRevit/FamilyInstance.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -87,7 +87,7 @@ namespace BH.UI.Revit.Engine
             if (!CheckLocationCurveColumns(framingElement))
                 return null;
             
-            Line columnLine = framingElement.Location.ToRevitCurve(pushSettings) as Line;
+            Line columnLine = framingElement.Location.ToRevitCurve() as Line;
             Level aLevel = null;
 
             aCustomDataValue = framingElement.CustomDataValue("Base Level");
@@ -98,7 +98,7 @@ namespace BH.UI.Revit.Engine
             }
 
             if (aLevel == null)
-                aLevel = Query.BottomLevel(framingElement.Location, document, pushSettings.ConvertUnits);
+                aLevel = Query.BottomLevel(framingElement.Location, document);
 
             FamilySymbol aFamilySymbol = framingElement.Property.ToRevitFamilySymbol_Column(document, pushSettings);
 
@@ -193,7 +193,7 @@ namespace BH.UI.Revit.Engine
                     BuiltInParameter.SLANTED_COLUMN_TOP_CUT_STYLE,
                     BuiltInParameter.STRUCTURAL_MATERIAL_PARAM
                 };
-                Modify.SetParameters(aFamilyInstance, framingElement, paramsToIgnore, pushSettings.ConvertUnits);
+                Modify.SetParameters(aFamilyInstance, framingElement, paramsToIgnore);
             }
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(framingElement, aFamilyInstance);
@@ -258,7 +258,7 @@ namespace BH.UI.Revit.Engine
             //Update justification based on custom data
             BH.oM.Geometry.ICurve adjustedLocation;
             bool adjusted = framingElement.AdjustLocation(out adjustedLocation);
-            Curve revitCurve = adjustedLocation.ToRevitCurve(pushSettings);
+            Curve revitCurve = adjustedLocation.ToRevitCurve();
 
             bool isVertical, isLinear;
             //Check if curve is planar, and if so, if it is vertical. This is used to determine if the orientation angle needs
@@ -276,7 +276,7 @@ namespace BH.UI.Revit.Engine
             }
 
             if (aLevel == null)
-                aLevel = Query.BottomLevel(framingElement.Location, document, pushSettings.ConvertUnits);
+                aLevel = Query.BottomLevel(framingElement.Location, document);
 
             FamilySymbol aFamilySymbol = framingElement.Property.ToRevitFamilySymbol_Framing(document, pushSettings);
 
@@ -388,7 +388,7 @@ namespace BH.UI.Revit.Engine
                 }
 
 
-                Modify.SetParameters(aFamilyInstance, framingElement, paramsToIgnore, pushSettings.ConvertUnits);
+                Modify.SetParameters(aFamilyInstance, framingElement, paramsToIgnore);
             }
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(framingElement, aFamilyInstance);

--- a/Engine_Revit_UI/Convert/Physical/ToRevit/FamilySymbol.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToRevit/FamilySymbol.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -51,7 +51,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aFamilySymbol, framingElementProperty, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aFamilySymbol, framingElementProperty, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(framingElementProperty, aFamilySymbol);
 
@@ -78,7 +78,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aFamilySymbol, framingElementProperty, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aFamilySymbol, framingElementProperty, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(framingElementProperty, aFamilySymbol);
 

--- a/Engine_Revit_UI/Convert/Physical/ToRevit/Floor.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToRevit/Floor.cs
@@ -84,20 +84,15 @@ namespace BH.UI.Revit.Engine
 
             double aLowElevation = floor.LowElevation();
 
-            Level aLevel = document.HighLevel(aLowElevation, true);
-
-            double aElevation = aLevel.Elevation;
-            if (pushSettings.ConvertUnits)
-                aElevation = aElevation.ToSI(UnitType.UT_Length);
-
+            Level aLevel = document.HighLevel(aLowElevation);
             oM.Geometry.Plane aPlane = BH.Engine.Geometry.Create.Plane(BH.Engine.Geometry.Create.Point(0, 0, aLowElevation), BH.Engine.Geometry.Create.Vector(0, 0, 1));
             ICurve aCurve = BH.Engine.Geometry.Modify.Project(aPlanarSurface.ExternalBoundary as dynamic, aPlane) as ICurve;
 
             CurveArray aCurveArray = null;
             if (aCurve is PolyCurve)
-                aCurveArray = ((PolyCurve)aCurve).ToRevitCurveArray(pushSettings);
+                aCurveArray = ((PolyCurve)aCurve).ToRevitCurveArray();
             else if (aCurve is Polyline)
-                aCurveArray = ((Polyline)aCurve).ToRevitCurveArray(pushSettings);
+                aCurveArray = ((Polyline)aCurve).ToRevitCurveArray();
 
             if (aCurveArray == null)
                 return null;
@@ -109,7 +104,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aFloor, floor, new BuiltInParameter[] { BuiltInParameter.LEVEL_PARAM }, pushSettings.ConvertUnits);
+                Modify.SetParameters(aFloor, floor, new BuiltInParameter[] { BuiltInParameter.LEVEL_PARAM });
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(floor, aFloor);
 

--- a/Engine_Revit_UI/Convert/Physical/ToRevit/HostObjAttributes.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToRevit/HostObjAttributes.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -63,7 +63,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aElementType, construction, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aElementType, construction, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(construction, aElementType);
 

--- a/Engine_Revit_UI/Convert/Physical/ToRevit/RoofBase.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToRevit/RoofBase.cs
@@ -87,23 +87,20 @@ namespace BH.UI.Revit.Engine
             if (double.IsNaN(aLowElevation))
                 return null;
 
-            Level aLevel = document.HighLevel(aLowElevation, true);
+            Level aLevel = document.HighLevel(aLowElevation);
             if (aLevel == null)
                 return null;
 
-            double aElevation = aLevel.Elevation;
-            if (pushSettings.ConvertUnits)
-                aElevation = aElevation.ToSI(UnitType.UT_Length);
-            
+            double aElevation = aLevel.Elevation.ToSI(UnitType.UT_Length);
             oM.Geometry.Plane aPlane = BH.Engine.Geometry.Create.Plane(BH.Engine.Geometry.Create.Point(0, 0, aElevation), BH.Engine.Geometry.Create.Vector(0, 0, 1));
 
             ICurve aCurve = BH.Engine.Geometry.Modify.Project(aPlanarSurface.ExternalBoundary as dynamic, aPlane) as ICurve;
 
             CurveArray aCurveArray = null;
             if (aCurve is PolyCurve)
-                aCurveArray = ((PolyCurve)aCurve).ToRevitCurveArray(pushSettings);
+                aCurveArray = ((PolyCurve)aCurve).ToRevitCurveArray();
             else if (aCurve is Polyline)
-                aCurveArray = ((Polyline)aCurve).ToRevitCurveArray(pushSettings);
+                aCurveArray = ((Polyline)aCurve).ToRevitCurveArray();
 
             if (aCurveArray == null)
                 return null;
@@ -146,7 +143,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aRoofBase, roof, new BuiltInParameter[] { BuiltInParameter.ROOF_LEVEL_OFFSET_PARAM, BuiltInParameter.ROOF_BASE_LEVEL_PARAM, BuiltInParameter.ROOF_UPTO_LEVEL_PARAM }, pushSettings.ConvertUnits);
+                Modify.SetParameters(aRoofBase, roof, new BuiltInParameter[] { BuiltInParameter.ROOF_LEVEL_OFFSET_PARAM, BuiltInParameter.ROOF_BASE_LEVEL_PARAM, BuiltInParameter.ROOF_UPTO_LEVEL_PARAM });
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(roof, aRoofBase);
 

--- a/Engine_Revit_UI/Convert/Physical/ToRevit/Wall.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToRevit/Wall.cs
@@ -84,11 +84,11 @@ namespace BH.UI.Revit.Engine
             if (double.IsNaN(aLowElevation))
                 return null;
 
-            Level aLevel = document.LowLevel(aLowElevation, true);
+            Level aLevel = document.LowLevel(aLowElevation);
             if (aLevel == null)
                 return null;
 
-            aWall = Wall.Create(document, Convert.ToRevitCurveList(aPlanarSurface.ExternalBoundary, pushSettings), aWallType.Id, aLevel.Id, false);
+            aWall = Wall.Create(document, aPlanarSurface.ExternalBoundary.ToRevitCurveList(), aWallType.Id, aLevel.Id, false);
 
             Parameter aParameter = null;
 
@@ -102,19 +102,13 @@ namespace BH.UI.Revit.Engine
                 aParameter.Set(aHeight);
             }
 
-            double aElevation_Level = aLevel.Elevation;
-            if (pushSettings.ConvertUnits)
-                aElevation_Level = aElevation_Level.ToSI(UnitType.UT_Length);
-
+            double aElevation_Level = aLevel.Elevation.ToSI(UnitType.UT_Length);
             if (System.Math.Abs(aLowElevation - aElevation_Level) > Tolerance.MacroDistance)
             {
                 aParameter = aWall.get_Parameter(BuiltInParameter.WALL_BASE_OFFSET);
                 if (aParameter != null)
                 {
-                    double aOffset = aLowElevation - aElevation_Level;
-                    if (pushSettings.ConvertUnits)
-                        aOffset = aOffset.FromSI(UnitType.UT_Length);
-
+                    double aOffset = (aLowElevation - aElevation_Level).FromSI(UnitType.UT_Length);
                     aParameter.Set(aOffset);
                 }
             }
@@ -124,7 +118,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aWall, wall, new BuiltInParameter[] { BuiltInParameter.WALL_BASE_CONSTRAINT, BuiltInParameter.WALL_BASE_OFFSET, BuiltInParameter.WALL_HEIGHT_TYPE, BuiltInParameter.WALL_USER_HEIGHT_PARAM }, pushSettings.ConvertUnits);
+                Modify.SetParameters(aWall, wall, new BuiltInParameter[] { BuiltInParameter.WALL_BASE_CONSTRAINT, BuiltInParameter.WALL_BASE_OFFSET, BuiltInParameter.WALL_HEIGHT_TYPE, BuiltInParameter.WALL_USER_HEIGHT_PARAM });
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(wall, aWall);
 

--- a/Engine_Revit_UI/Convert/Revit/ToBHoM/DraftingInstance.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToBHoM/DraftingInstance.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -43,12 +43,12 @@ namespace BH.UI.Revit.Engine
 
             oM.Adapters.Revit.Properties.InstanceProperties aInstanceProperties = ToBHoMInstanceProperties(curveElement.LineStyle as GraphicsStyle, pullSettings) as oM.Adapters.Revit.Properties.InstanceProperties;
 
-            aDraftingInstance = BH.Engine.Adapters.Revit.Create.DraftingInstance(aInstanceProperties, aView.Name, curveElement.GeometryCurve.ToBHoM(pullSettings));
+            aDraftingInstance = BH.Engine.Adapters.Revit.Create.DraftingInstance(aInstanceProperties, aView.Name, curveElement.GeometryCurve.ToBHoM());
 
             aDraftingInstance.Name = curveElement.Name;
             aDraftingInstance = Modify.SetIdentifiers(aDraftingInstance, curveElement) as oM.Adapters.Revit.Elements.DraftingInstance;
             if (pullSettings.CopyCustomData)
-                aDraftingInstance = Modify.SetCustomData(aDraftingInstance, curveElement, true) as oM.Adapters.Revit.Elements.DraftingInstance;
+                aDraftingInstance = Modify.SetCustomData(aDraftingInstance, curveElement) as oM.Adapters.Revit.Elements.DraftingInstance;
 
             aDraftingInstance = aDraftingInstance.UpdateValues(pullSettings, curveElement) as oM.Adapters.Revit.Elements.DraftingInstance;
 

--- a/Engine_Revit_UI/Convert/Revit/ToBHoM/Family.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToBHoM/Family.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -73,7 +73,7 @@ namespace BH.UI.Revit.Engine
 
             aFamily = Modify.SetIdentifiers(aFamily, family) as oM.Adapters.Revit.Elements.Family;
             if (pullSettings.CopyCustomData)
-                aFamily = Modify.SetCustomData(aFamily, family, pullSettings.ConvertUnits) as oM.Adapters.Revit.Elements.Family;
+                aFamily = Modify.SetCustomData(aFamily, family) as oM.Adapters.Revit.Elements.Family;
 
             aFamily = aFamily.UpdateValues(pullSettings, family) as oM.Adapters.Revit.Elements.Family;
 

--- a/Engine_Revit_UI/Convert/Revit/ToBHoM/InstanceProperties.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToBHoM/InstanceProperties.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -43,7 +43,7 @@ namespace BH.UI.Revit.Engine
 
             aInstanceProperties = Modify.SetIdentifiers(aInstanceProperties, elementType) as InstanceProperties;
             if (pullSettings.CopyCustomData)
-                aInstanceProperties = Modify.SetCustomData(aInstanceProperties, elementType, pullSettings.ConvertUnits) as InstanceProperties;
+                aInstanceProperties = Modify.SetCustomData(aInstanceProperties, elementType) as InstanceProperties;
 
             aInstanceProperties.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyName] = elementType.FamilyName;
             aInstanceProperties.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyTypeName] = elementType.Name;
@@ -70,7 +70,7 @@ namespace BH.UI.Revit.Engine
 
             aInstanceProperties = Modify.SetIdentifiers(aInstanceProperties, graphicStyle) as InstanceProperties;
             if (pullSettings.CopyCustomData)
-                aInstanceProperties = Modify.SetCustomData(aInstanceProperties, graphicStyle, pullSettings.ConvertUnits) as InstanceProperties;
+                aInstanceProperties = Modify.SetCustomData(aInstanceProperties, graphicStyle) as InstanceProperties;
 
             aInstanceProperties.CustomData[BH.Engine.Adapters.Revit.Convert.CategoryName] = graphicStyle.GraphicsStyleCategory.Parent.Name;
 

--- a/Engine_Revit_UI/Convert/Revit/ToBHoM/ModelInstance.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToBHoM/ModelInstance.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -39,12 +39,12 @@ namespace BH.UI.Revit.Engine
 
             oM.Adapters.Revit.Properties.InstanceProperties aInstanceProperties = ToBHoMInstanceProperties(curveElement.LineStyle as GraphicsStyle, pullSettings) as oM.Adapters.Revit.Properties.InstanceProperties;
 
-            aModelInstance = BH.Engine.Adapters.Revit.Create.ModelInstance(aInstanceProperties, curveElement.GeometryCurve.ToBHoM(pullSettings));
+            aModelInstance = BH.Engine.Adapters.Revit.Create.ModelInstance(aInstanceProperties, curveElement.GeometryCurve.ToBHoM());
 
             aModelInstance.Name = curveElement.Name;
             aModelInstance = Modify.SetIdentifiers(aModelInstance, curveElement) as oM.Adapters.Revit.Elements.ModelInstance;
             if (pullSettings.CopyCustomData)
-                aModelInstance = Modify.SetCustomData(aModelInstance, curveElement, true) as oM.Adapters.Revit.Elements.ModelInstance;
+                aModelInstance = Modify.SetCustomData(aModelInstance, curveElement) as oM.Adapters.Revit.Elements.ModelInstance;
 
             aModelInstance = aModelInstance.UpdateValues(pullSettings, curveElement) as oM.Adapters.Revit.Elements.ModelInstance;
 

--- a/Engine_Revit_UI/Convert/Revit/ToBHoM/Sheet.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToBHoM/Sheet.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -51,7 +51,7 @@ namespace BH.UI.Revit.Engine
 
             aSheet = Modify.SetIdentifiers(aSheet, viewSheet) as Sheet;
             if (pullSettings.CopyCustomData)
-                aSheet = Modify.SetCustomData(aSheet, viewSheet, pullSettings.ConvertUnits) as Sheet;
+                aSheet = Modify.SetCustomData(aSheet, viewSheet) as Sheet;
 
             aSheet = aSheet.UpdateValues(pullSettings, viewSheet) as Sheet;
 

--- a/Engine_Revit_UI/Convert/Revit/ToBHoM/ViewPlan.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToBHoM/ViewPlan.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -51,7 +51,7 @@ namespace BH.UI.Revit.Engine
             aViewPlan.Name = viewPlan.Name;
             aViewPlan = Modify.SetIdentifiers(aViewPlan, viewPlan) as oM.Adapters.Revit.Elements.ViewPlan;
             if (pullSettings.CopyCustomData)
-                aViewPlan = Modify.SetCustomData(aViewPlan, viewPlan, true) as oM.Adapters.Revit.Elements.ViewPlan;
+                aViewPlan = Modify.SetCustomData(aViewPlan, viewPlan) as oM.Adapters.Revit.Elements.ViewPlan;
 
             aViewPlan = aViewPlan.UpdateValues(pullSettings, viewPlan) as oM.Adapters.Revit.Elements.ViewPlan;
 

--- a/Engine_Revit_UI/Convert/Revit/ToBHoM/Viewport.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToBHoM/Viewport.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -40,7 +40,7 @@ namespace BH.UI.Revit.Engine
             if (aViewport != null)
                 return aViewport;
 
-            oM.Geometry.Point aLocation = viewport.GetBoxCenter().ToBHoM(pullSettings);
+            oM.Geometry.Point aLocation = viewport.GetBoxCenter().ToBHoM();
             string aViewName = viewport.get_Parameter(BuiltInParameter.VIEW_NAME).AsString();
             string aSheetNumber = viewport.get_Parameter(BuiltInParameter.VIEWPORT_SHEET_NUMBER).AsString();
 
@@ -54,7 +54,7 @@ namespace BH.UI.Revit.Engine
 
             aViewport = Modify.SetIdentifiers(aViewport, viewport) as oM.Adapters.Revit.Elements.Viewport;
             if (pullSettings.CopyCustomData)
-                aViewport = Modify.SetCustomData(aViewport, viewport, pullSettings.ConvertUnits) as oM.Adapters.Revit.Elements.Viewport;
+                aViewport = Modify.SetCustomData(aViewport, viewport) as oM.Adapters.Revit.Elements.Viewport;
 
             aViewport = aViewport.UpdateValues(pullSettings, viewport) as oM.Adapters.Revit.Elements.Viewport;
 

--- a/Engine_Revit_UI/Convert/Revit/ToRevit/Element.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/Element.cs
@@ -54,7 +54,7 @@ namespace BH.UI.Revit.Engine
 
             if (modelInstance.Location is ISurface || modelInstance.Location is ISolid)
             {
-                BRepBuilder brep = ToRevitBrep(modelInstance.Location as dynamic, pushSettings);
+                BRepBuilder brep = ToRevitBrep(modelInstance.Location as dynamic);
                 if (brep == null || !brep.IsResultAvailable())
                 {
                     Compute.GeometryConvertFailed(modelInstance);
@@ -119,7 +119,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aElement, modelInstance, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aElement, modelInstance, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(modelInstance, aElement);
 
@@ -191,7 +191,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (aElement != null && pushSettings.CopyCustomData)
-                Modify.SetParameters(aElement, draftingInstance, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aElement, draftingInstance, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(draftingInstance, aElement);
 
@@ -213,13 +213,13 @@ namespace BH.UI.Revit.Engine
 
             Document aDocument = familySymbol.Document;
 
-            ICurve Curve = (ICurve)modelInstance.Location;
+            ICurve curve = (ICurve)modelInstance.Location;
 
-            Level aLevel = Curve.BottomLevel(familySymbol.Document, pushSettings.ConvertUnits);
+            Level aLevel = curve.BottomLevel(familySymbol.Document);
             if (aLevel == null)
                 return null;
 
-            Curve aCurve = ToRevitCurve(Curve, pushSettings);
+            Curve aCurve = curve.ToRevitCurve();
             return aDocument.Create.NewFamilyInstance(aCurve, familySymbol, aLevel, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
         }
 
@@ -240,11 +240,11 @@ namespace BH.UI.Revit.Engine
 
             oM.Geometry.Point aPoint = (oM.Geometry.Point)modelInstance.Location;
 
-            Level aLevel = aPoint.BottomLevel(aDocument, pushSettings.ConvertUnits);
+            Level aLevel = aPoint.BottomLevel(aDocument);
             if (aLevel == null)
                 return null;
 
-            XYZ aXYZ = ToRevitXYZ(aPoint, pushSettings);
+            XYZ aXYZ = aPoint.ToRevitXYZ();
             return aDocument.Create.NewFamilyInstance(aXYZ, familySymbol, aLevel, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
         }
 
@@ -279,13 +279,13 @@ namespace BH.UI.Revit.Engine
 
             Document aDocument = familySymbol.Document;
 
-            ICurve Curve = (ICurve)modelInstance.Location;
+            ICurve curve = (ICurve)modelInstance.Location;
 
-            Level aLevel = Curve.BottomLevel(aDocument, pushSettings.ConvertUnits);
+            Level aLevel = curve.BottomLevel(aDocument);
             if (aLevel == null)
                 return null;
 
-            Curve aCurve = ToRevitCurve(Curve, pushSettings);
+            Curve aCurve = curve.ToRevitCurve();
             return aDocument.Create.NewFamilyInstance(aCurve, familySymbol, aLevel, aStructuralType);
         }
 
@@ -318,11 +318,11 @@ namespace BH.UI.Revit.Engine
             {
                 oM.Geometry.Point aPoint = (oM.Geometry.Point)modelInstance.Location;
 
-                Level aLevel = aPoint.BottomLevel(aDocument, pushSettings.ConvertUnits);
+                Level aLevel = aPoint.BottomLevel(aDocument);
                 if (aLevel == null)
                     return null;
 
-                XYZ aXYZ = ToRevitXYZ(aPoint, pushSettings);
+                XYZ aXYZ = aPoint.ToRevitXYZ();
                 return aDocument.Create.NewFamilyInstance(aXYZ, familySymbol, aLevel, aStructuralType);
             }
             else if (modelInstance.Location is oM.Geometry.Line)
@@ -334,11 +334,11 @@ namespace BH.UI.Revit.Engine
                     return null;
                 }
 
-                Level aLevel = line.Start.BottomLevel(aDocument, pushSettings.ConvertUnits);
+                Level aLevel = line.Start.BottomLevel(aDocument);
                 if (aLevel == null)
                     return null;
 
-                Curve curve = line.ToRevitCurve(pushSettings);
+                Curve curve = line.ToRevitCurve();
                 return aDocument.Create.NewFamilyInstance(curve, familySymbol, aLevel, aStructuralType);
             }
             else
@@ -363,13 +363,13 @@ namespace BH.UI.Revit.Engine
 
             Document aDocument = wallType.Document;
 
-            ICurve Curve = (ICurve)modelInstance.Location;
+            ICurve curve = (ICurve)modelInstance.Location;
 
-            Level aLevel = Curve.BottomLevel(wallType.Document, pushSettings.ConvertUnits);
+            Level aLevel = curve.BottomLevel(wallType.Document);
             if (aLevel == null)
                 return null;
 
-            Curve aCurve = ToRevitCurve(Curve, pushSettings);
+            Curve aCurve = curve.ToRevitCurve();
             return Wall.Create(aDocument, aCurve, aLevel.Id, false);
         }
 

--- a/Engine_Revit_UI/Convert/Revit/ToRevit/ElementType.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/ElementType.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -50,7 +50,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aElementType, instanceProperties, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aElementType, instanceProperties, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(instanceProperties, aElementType);
 

--- a/Engine_Revit_UI/Convert/Revit/ToRevit/Family.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/Family.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -56,7 +56,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aFamily, family, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aFamily, family, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(family, aFamily);
 

--- a/Engine_Revit_UI/Convert/Revit/ToRevit/ViewPlan.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/ViewPlan.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -88,7 +88,7 @@ namespace BH.UI.Revit.Engine
 
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aViewPlan, viewPlan, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aViewPlan, viewPlan, null);
 
             object aValue = null;
             if(viewPlan.CustomData.TryGetValue(BH.Engine.Adapters.Revit.Convert.ViewTemplate, out aValue))

--- a/Engine_Revit_UI/Convert/Revit/ToRevit/ViewSheet.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/ViewSheet.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -48,7 +48,7 @@ namespace BH.UI.Revit.Engine
             aViewSheet = ViewSheet.Create(document, ElementId.InvalidElementId);
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aViewSheet, sheet, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aViewSheet, sheet, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(sheet, aViewSheet);
 

--- a/Engine_Revit_UI/Convert/Revit/ToRevit/Viewport.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/Viewport.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -73,7 +73,7 @@ namespace BH.UI.Revit.Engine
             aViewport = Viewport.Create(document, aViewSheet.Id, aView.Id, ToRevit(viewport.Location, pushSettings));
 
             if (pushSettings.CopyCustomData)
-                Modify.SetParameters(aViewport, viewport, null, pushSettings.ConvertUnits);
+                Modify.SetParameters(aViewport, viewport, null);
 
             pushSettings.RefObjects = pushSettings.RefObjects.AppendRefObjects(viewport, aViewport);
 

--- a/Engine_Revit_UI/Convert/Structure/ToBHoM/Bar.cs
+++ b/Engine_Revit_UI/Convert/Structure/ToBHoM/Bar.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -201,7 +201,7 @@ namespace BH.UI.Revit.Engine
 
                 bars[i] = Modify.SetIdentifiers(bars[i], familyInstance) as Bar;
                 if (pullSettings.CopyCustomData)
-                    bars[i] = Modify.SetCustomData(bars[i], familyInstance, pullSettings.ConvertUnits) as Bar;
+                    bars[i] = Modify.SetCustomData(bars[i], familyInstance) as Bar;
 
                 pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(bars[i]);
             }
@@ -219,7 +219,7 @@ namespace BH.UI.Revit.Engine
             if (curve == null)
                 return;
 
-            locationCurve = curve.ToBHoM(pullSettings);
+            locationCurve = curve.ToBHoM();
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Structure/ToBHoM/Panel.cs
+++ b/Engine_Revit_UI/Convert/Structure/ToBHoM/Panel.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -92,7 +92,7 @@ namespace BH.UI.Revit.Engine
 
                 panel = Modify.SetIdentifiers(panel, hostObject) as oM.Structure.Elements.Panel;
                 if (pullSettings.CopyCustomData)
-                    panel = Modify.SetCustomData(panel, hostObject, pullSettings.ConvertUnits) as oM.Structure.Elements.Panel;
+                    panel = Modify.SetCustomData(panel, hostObject) as oM.Structure.Elements.Panel;
 
                 pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(panel);
 

--- a/Engine_Revit_UI/Convert/Structure/ToBHoM/Profile.cs
+++ b/Engine_Revit_UI/Convert/Structure/ToBHoM/Profile.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -61,18 +61,20 @@ namespace BH.UI.Revit.Engine
             {
                 double diameter;
                 StructuralSection section = familySymbol.GetStructuralSection();
-                if (section is StructuralSectionConcreteRound) diameter = (section as StructuralSectionConcreteRound).Diameter;
-                else if (section is StructuralSectionConcreteRound) diameter = (section as StructuralSectionConcreteRound).Diameter;
-                else diameter = familySymbol.LookupDouble(diameterNames, false);
+                if (section is StructuralSectionConcreteRound)
+                    diameter = (section as StructuralSectionConcreteRound).Diameter.ToSI(UnitType.UT_Section_Dimension);
+                else if (section is StructuralSectionConcreteRound)
+                    diameter = (section as StructuralSectionConcreteRound).Diameter.ToSI(UnitType.UT_Section_Dimension);
+                else
+                    diameter = familySymbol.LookupDouble(diameterNames);
 
                 if (!double.IsNaN(diameter))
                 {
-                    if (pullSettings.ConvertUnits) diameter = diameter.ToSI(UnitType.UT_Section_Dimension);
                     aProfile = BHG.Create.CircleProfile(diameter);
                 }
                 else
                 {
-                    double radius = familySymbol.LookupDouble(radiusNames, pullSettings.ConvertUnits);
+                    double radius = familySymbol.LookupDouble(radiusNames);
                     if (!double.IsNaN(radius))
                     {
                         aProfile = BHG.Create.CircleProfile(radius * 2);
@@ -87,28 +89,28 @@ namespace BH.UI.Revit.Engine
                 if (section is StructuralSectionIWelded)
                 {
                     StructuralSectionIWelded sectionType = section as StructuralSectionIWelded;
-                    height = sectionType.Height;
-                    topFlangeWidth = sectionType.TopFlangeWidth;
-                    botFlangeWidth = sectionType.BottomFlangeWidth;
-                    webThickness = sectionType.WebThickness;
-                    topFlangeThickness = sectionType.TopFlangeThickness;
-                    botFlangeThickness = sectionType.BottomFlangeThickness;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    topFlangeWidth = sectionType.TopFlangeWidth.ToSI(UnitType.UT_Section_Dimension);
+                    botFlangeWidth = sectionType.BottomFlangeWidth.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WebThickness.ToSI(UnitType.UT_Section_Dimension);
+                    topFlangeThickness = sectionType.TopFlangeThickness.ToSI(UnitType.UT_Section_Dimension);
+                    botFlangeThickness = sectionType.BottomFlangeThickness.ToSI(UnitType.UT_Section_Dimension);
                     weldSize = 0;
                 }
                 else
                 {
-                    height = familySymbol.LookupDouble(heightNames, false);
-                    topFlangeWidth = familySymbol.LookupDouble(topFlangeWidthNames, false);
-                    botFlangeWidth = familySymbol.LookupDouble(botFlangeWidthNames, false);
-                    webThickness = familySymbol.LookupDouble(webThicknessNames, false);
-                    topFlangeThickness = familySymbol.LookupDouble(topFlangeThicknessNames, false);
-                    botFlangeThickness = familySymbol.LookupDouble(botFlangeThicknessNames, false);
-                    weldSize = familySymbol.LookupDouble(weldSizeNames1, false);
+                    height = familySymbol.LookupDouble(heightNames);
+                    topFlangeWidth = familySymbol.LookupDouble(topFlangeWidthNames);
+                    botFlangeWidth = familySymbol.LookupDouble(botFlangeWidthNames);
+                    webThickness = familySymbol.LookupDouble(webThicknessNames);
+                    topFlangeThickness = familySymbol.LookupDouble(topFlangeThicknessNames);
+                    botFlangeThickness = familySymbol.LookupDouble(botFlangeThicknessNames);
+                    weldSize = familySymbol.LookupDouble(weldSizeNames1);
                 }
 
                 if (double.IsNaN(weldSize))
                 {
-                    weldSize = familySymbol.LookupDouble(weldSizeNames2, false);
+                    weldSize = familySymbol.LookupDouble(weldSizeNames2);
                     if (!double.IsNaN(weldSize) && !double.IsNaN(webThickness))
                     {
                         weldSize = (weldSize - webThickness) / (Math.Sqrt(2));
@@ -121,17 +123,6 @@ namespace BH.UI.Revit.Engine
 
                 if (!double.IsNaN(height) && !double.IsNaN(topFlangeWidth) && !double.IsNaN(botFlangeWidth) && !double.IsNaN(webThickness) && !double.IsNaN(topFlangeThickness) && !double.IsNaN(botFlangeThickness))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        height = height.ToSI(UnitType.UT_Section_Dimension);
-                        topFlangeWidth = topFlangeWidth.ToSI(UnitType.UT_Section_Dimension);
-                        botFlangeWidth = botFlangeWidth.ToSI(UnitType.UT_Section_Dimension);
-                        webThickness = webThickness.ToSI(UnitType.UT_Section_Dimension);
-                        topFlangeThickness = topFlangeThickness.ToSI(UnitType.UT_Section_Dimension);
-                        botFlangeThickness = botFlangeThickness.ToSI(UnitType.UT_Section_Dimension);
-                        weldSize = weldSize.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.FabricatedISectionProfile(height, topFlangeWidth, botFlangeWidth, webThickness, topFlangeThickness, botFlangeThickness, weldSize);
                 }
             }
@@ -143,42 +134,35 @@ namespace BH.UI.Revit.Engine
                 if (section is StructuralSectionConcreteRectangle)
                 {
                     StructuralSectionConcreteRectangle sectionType = section as StructuralSectionConcreteRectangle;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
                     cornerRadius = 0;
                 }
                 else if (section is StructuralSectionRectangularBar)
                 {
                     StructuralSectionRectangularBar sectionType = section as StructuralSectionRectangularBar;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
                     cornerRadius = 0;
                 }
                 else if (section is StructuralSectionRectangleParameterized)
                 {
                     StructuralSectionRectangleParameterized sectionType = section as StructuralSectionRectangleParameterized;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
                     cornerRadius = 0;
                 }
                 else
                 {
-                    height = familySymbol.LookupDouble(heightNames, false);
-                    width = familySymbol.LookupDouble(widthNames, false);
-                    cornerRadius = familySymbol.LookupDouble(cornerRadiusNames, false);
+                    height = familySymbol.LookupDouble(heightNames);
+                    width = familySymbol.LookupDouble(widthNames);
+                    cornerRadius = familySymbol.LookupDouble(cornerRadiusNames);
                 }
 
                 if (double.IsNaN(cornerRadius)) cornerRadius = 0;
 
                 if (!double.IsNaN(height) && !double.IsNaN(width))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        height = height.ToSI(UnitType.UT_Section_Dimension);
-                        width = width.ToSI(UnitType.UT_Section_Dimension);
-                        cornerRadius = cornerRadius.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.RectangleProfile(height, width, cornerRadius);
                 }
             }
@@ -190,32 +174,32 @@ namespace BH.UI.Revit.Engine
                 if (section is StructuralSectionLAngle)
                 {
                     StructuralSectionLAngle sectionType = section as StructuralSectionLAngle;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
-                    webThickness = sectionType.WebThickness;
-                    flangeThickness = sectionType.FlangeThickness;
-                    rootRadius = sectionType.WebFillet;
-                    toeRadius = sectionType.FlangeFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WebThickness.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.FlangeThickness.ToSI(UnitType.UT_Section_Dimension);
+                    rootRadius = sectionType.WebFillet.ToSI(UnitType.UT_Section_Dimension);
+                    toeRadius = sectionType.FlangeFillet.ToSI(UnitType.UT_Section_Dimension);
                 }
                 else if (section is StructuralSectionLProfile)
                 {
                     //TODO: Implement cold-formed profiles?
                     StructuralSectionLProfile sectionType = section as StructuralSectionLProfile;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
-                    webThickness = sectionType.WallNominalThickness;
-                    flangeThickness = sectionType.WallNominalThickness;
-                    rootRadius = sectionType.InnerFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WallNominalThickness.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.WallNominalThickness.ToSI(UnitType.UT_Section_Dimension);
+                    rootRadius = sectionType.InnerFillet.ToSI(UnitType.UT_Section_Dimension);
                     toeRadius = 0;
                 }
                 else
                 {
-                    height = familySymbol.LookupDouble(heightNames, false);
-                    width = familySymbol.LookupDouble(widthNames, false);
-                    webThickness = familySymbol.LookupDouble(webThicknessNames, false);
-                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames, false);
-                    rootRadius = familySymbol.LookupDouble(rootRadiusNames, false);
-                    toeRadius = familySymbol.LookupDouble(toeRadiusNames, false);
+                    height = familySymbol.LookupDouble(heightNames);
+                    width = familySymbol.LookupDouble(widthNames);
+                    webThickness = familySymbol.LookupDouble(webThicknessNames);
+                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames);
+                    rootRadius = familySymbol.LookupDouble(rootRadiusNames);
+                    toeRadius = familySymbol.LookupDouble(toeRadiusNames);
                 }
 
                 if (double.IsNaN(rootRadius)) rootRadius = 0;
@@ -223,16 +207,6 @@ namespace BH.UI.Revit.Engine
 
                 if (!double.IsNaN(height) && !double.IsNaN(width) && !double.IsNaN(webThickness) && !double.IsNaN(flangeThickness))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        height = height.ToSI(UnitType.UT_Section_Dimension);
-                        width = width.ToSI(UnitType.UT_Section_Dimension);
-                        webThickness = webThickness.ToSI(UnitType.UT_Section_Dimension);
-                        flangeThickness = flangeThickness.ToSI(UnitType.UT_Section_Dimension);
-                        rootRadius = rootRadius.ToSI(UnitType.UT_Section_Dimension);
-                        toeRadius = toeRadius.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.AngleProfile(height, width, webThickness, flangeThickness, rootRadius, toeRadius);
                 }
             }
@@ -244,19 +218,19 @@ namespace BH.UI.Revit.Engine
                 if (section is StructuralSectionRectangleHSS)
                 {
                     StructuralSectionRectangleHSS sectionType = section as StructuralSectionRectangleHSS;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
-                    thickness = sectionType.WallNominalThickness;
-                    outerRadius = sectionType.OuterFillet;
-                    innerRadius = sectionType.InnerFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    thickness = sectionType.WallNominalThickness.ToSI(UnitType.UT_Section_Dimension);
+                    outerRadius = sectionType.OuterFillet.ToSI(UnitType.UT_Section_Dimension);
+                    innerRadius = sectionType.InnerFillet.ToSI(UnitType.UT_Section_Dimension);
                 }
                 else
                 {
-                    height = familySymbol.LookupDouble(heightNames, false);
-                    width = familySymbol.LookupDouble(widthNames, false);
-                    thickness = familySymbol.LookupDouble(wallThicknessNames, false);
-                    outerRadius = familySymbol.LookupDouble(outerRadiusNames, false);
-                    innerRadius = familySymbol.LookupDouble(innerRadiusNames, false);
+                    height = familySymbol.LookupDouble(heightNames);
+                    width = familySymbol.LookupDouble(widthNames);
+                    thickness = familySymbol.LookupDouble(wallThicknessNames);
+                    outerRadius = familySymbol.LookupDouble(outerRadiusNames);
+                    innerRadius = familySymbol.LookupDouble(innerRadiusNames);
                 }
 
                 if (double.IsNaN(outerRadius)) outerRadius = 0;
@@ -264,15 +238,6 @@ namespace BH.UI.Revit.Engine
 
                 if (!double.IsNaN(height) && !double.IsNaN(width) && !double.IsNaN(thickness))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        height = height.ToSI(UnitType.UT_Section_Dimension);
-                        width = width.ToSI(UnitType.UT_Section_Dimension);
-                        thickness = thickness.ToSI(UnitType.UT_Section_Dimension);
-                        outerRadius = outerRadius.ToSI(UnitType.UT_Section_Dimension);
-                        innerRadius = innerRadius.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.BoxProfile(height, width, thickness, outerRadius, innerRadius);
                 }
             }
@@ -284,32 +249,32 @@ namespace BH.UI.Revit.Engine
                 if (section is StructuralSectionCParallelFlange)
                 {
                     StructuralSectionCParallelFlange sectionType = section as StructuralSectionCParallelFlange;
-                    height = sectionType.Height;
-                    flangeWidth = sectionType.Width;
-                    webThickness = sectionType.WebThickness;
-                    flangeThickness = sectionType.FlangeThickness;
-                    rootRadius = sectionType.WebFillet;
-                    toeRadius = sectionType.FlangeFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    flangeWidth = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WebThickness.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.FlangeThickness.ToSI(UnitType.UT_Section_Dimension);
+                    rootRadius = sectionType.WebFillet.ToSI(UnitType.UT_Section_Dimension);
+                    toeRadius = sectionType.FlangeFillet.ToSI(UnitType.UT_Section_Dimension);
                 }
                 else if (section is StructuralSectionCProfile)
                 {
                     //TODO: Implement cold-formed profiles?
                     StructuralSectionCProfile sectionType = section as StructuralSectionCProfile;
-                    height = sectionType.Height;
-                    flangeWidth = sectionType.Width;
-                    webThickness = sectionType.WallNominalThickness;
-                    flangeThickness = sectionType.WallNominalThickness;
-                    rootRadius = sectionType.InnerFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    flangeWidth = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WallNominalThickness.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.WallNominalThickness.ToSI(UnitType.UT_Section_Dimension);
+                    rootRadius = sectionType.InnerFillet.ToSI(UnitType.UT_Section_Dimension);
                     toeRadius = 0;
                 }
                 else
                 {
-                    height = familySymbol.LookupDouble(heightNames, false);
-                    flangeWidth = familySymbol.LookupDouble(widthNames, false);
-                    webThickness = familySymbol.LookupDouble(webThicknessNames, false);
-                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames, false);
-                    rootRadius = familySymbol.LookupDouble(rootRadiusNames, false);
-                    toeRadius = familySymbol.LookupDouble(toeRadiusNames, false);
+                    height = familySymbol.LookupDouble(heightNames);
+                    flangeWidth = familySymbol.LookupDouble(widthNames);
+                    webThickness = familySymbol.LookupDouble(webThicknessNames);
+                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames);
+                    rootRadius = familySymbol.LookupDouble(rootRadiusNames);
+                    toeRadius = familySymbol.LookupDouble(toeRadiusNames);
                 }
 
                 if (double.IsNaN(rootRadius)) rootRadius = 0;
@@ -317,16 +282,6 @@ namespace BH.UI.Revit.Engine
 
                 if (!double.IsNaN(height) && !double.IsNaN(flangeWidth) && !double.IsNaN(webThickness) && !double.IsNaN(flangeThickness))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        height = height.ToSI(UnitType.UT_Section_Dimension);
-                        flangeWidth = flangeWidth.ToSI(UnitType.UT_Section_Dimension);
-                        webThickness = webThickness.ToSI(UnitType.UT_Section_Dimension);
-                        flangeThickness = flangeThickness.ToSI(UnitType.UT_Section_Dimension);
-                        rootRadius = rootRadius.ToSI(UnitType.UT_Section_Dimension);
-                        toeRadius = toeRadius.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.ChannelProfile(height, flangeWidth, webThickness, flangeThickness, rootRadius, toeRadius);
                 }
             }
@@ -338,31 +293,31 @@ namespace BH.UI.Revit.Engine
                 if (section is StructuralSectionIParallelFlange)
                 {
                     StructuralSectionIParallelFlange sectionType = section as StructuralSectionIParallelFlange;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
-                    webThickness = sectionType.WebThickness;
-                    flangeThickness = sectionType.FlangeThickness;
-                    rootRadius = sectionType.WebFillet;
-                    toeRadius = sectionType.FlangeFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WebThickness.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.FlangeThickness.ToSI(UnitType.UT_Section_Dimension);
+                    rootRadius = sectionType.WebFillet.ToSI(UnitType.UT_Section_Dimension);
+                    toeRadius = sectionType.FlangeFillet.ToSI(UnitType.UT_Section_Dimension);
                 }
                 else if (section is StructuralSectionIWideFlange)
                 {
                     StructuralSectionIWideFlange sectionType = section as StructuralSectionIWideFlange;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
-                    webThickness = sectionType.WebThickness;
-                    flangeThickness = sectionType.FlangeThickness;
-                    rootRadius = sectionType.WebFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WebThickness.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.FlangeThickness.ToSI(UnitType.UT_Section_Dimension);
+                    rootRadius = sectionType.WebFillet.ToSI(UnitType.UT_Section_Dimension);
                     toeRadius = 0;
                 }
                 else
                 {
-                    height = familySymbol.LookupDouble(heightNames, false);
-                    width = familySymbol.LookupDouble(widthNames, false);
-                    webThickness = familySymbol.LookupDouble(webThicknessNames, false);
-                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames, false);
-                    rootRadius = familySymbol.LookupDouble(rootRadiusNames, false);
-                    toeRadius = familySymbol.LookupDouble(toeRadiusNames, false);
+                    height = familySymbol.LookupDouble(heightNames);
+                    width = familySymbol.LookupDouble(widthNames);
+                    webThickness = familySymbol.LookupDouble(webThicknessNames);
+                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames);
+                    rootRadius = familySymbol.LookupDouble(rootRadiusNames);
+                    toeRadius = familySymbol.LookupDouble(toeRadiusNames);
                 }
 
                 if (double.IsNaN(rootRadius)) rootRadius = 0;
@@ -370,16 +325,6 @@ namespace BH.UI.Revit.Engine
 
                 if (!double.IsNaN(height) && !double.IsNaN(width) && !double.IsNaN(webThickness) && !double.IsNaN(flangeThickness))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        height = height.ToSI(UnitType.UT_Section_Dimension);
-                        width = width.ToSI(UnitType.UT_Section_Dimension);
-                        webThickness = webThickness.ToSI(UnitType.UT_Section_Dimension);
-                        flangeThickness = flangeThickness.ToSI(UnitType.UT_Section_Dimension);
-                        rootRadius = rootRadius.ToSI(UnitType.UT_Section_Dimension);
-                        toeRadius = toeRadius.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.ISectionProfile(height, width, webThickness, flangeThickness, rootRadius, toeRadius);
                 }
             }
@@ -392,41 +337,41 @@ namespace BH.UI.Revit.Engine
                 if (section is StructuralSectionISplitParallelFlange)
                 {
                     StructuralSectionISplitParallelFlange sectionType = section as StructuralSectionISplitParallelFlange;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
-                    webThickness = sectionType.WebThickness;
-                    flangeThickness = sectionType.FlangeThickness;
-                    rootRadius = sectionType.WebFillet;
-                    toeRadius = sectionType.FlangeFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WebThickness.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.FlangeThickness.ToSI(UnitType.UT_Section_Dimension);
+                    rootRadius = sectionType.WebFillet.ToSI(UnitType.UT_Section_Dimension);
+                    toeRadius = sectionType.FlangeFillet.ToSI(UnitType.UT_Section_Dimension);
                 }
                 else if (section is StructuralSectionStructuralTees)
                 {
                     StructuralSectionStructuralTees sectionType = section as StructuralSectionStructuralTees;
-                    height = sectionType.Height;
-                    width = sectionType.Width;
-                    webThickness = sectionType.WebThickness;
-                    flangeThickness = sectionType.FlangeThickness;
-                    rootRadius = sectionType.WebFillet;
-                    toeRadius = sectionType.FlangeFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WebThickness.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.FlangeThickness.ToSI(UnitType.UT_Section_Dimension);
+                    rootRadius = sectionType.WebFillet.ToSI(UnitType.UT_Section_Dimension);
+                    toeRadius = sectionType.FlangeFillet.ToSI(UnitType.UT_Section_Dimension);
                 }
                 else if (section is StructuralSectionConcreteT)
                 {
                     StructuralSectionConcreteT sectionType = section as StructuralSectionConcreteT;
-                    height = sectionType.Height;
-                    width = (sectionType.Width + 2 * sectionType.CantileverLength);
-                    webThickness = sectionType.Width;
-                    flangeThickness = sectionType.CantileverHeight;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    width = (sectionType.Width + 2 * sectionType.CantileverLength).ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.Width.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.CantileverHeight.ToSI(UnitType.UT_Section_Dimension);
                     rootRadius = 0;
                     toeRadius = 0;
                 }
                 else
                 {
-                    height = familySymbol.LookupDouble(heightNames, false);
-                    width = familySymbol.LookupDouble(widthNames, false);
-                    webThickness = familySymbol.LookupDouble(webThicknessNames, false);
-                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames, false);
-                    rootRadius = familySymbol.LookupDouble(rootRadiusNames, false);
-                    toeRadius = familySymbol.LookupDouble(toeRadiusNames, false);
+                    height = familySymbol.LookupDouble(heightNames);
+                    width = familySymbol.LookupDouble(widthNames);
+                    webThickness = familySymbol.LookupDouble(webThicknessNames);
+                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames);
+                    rootRadius = familySymbol.LookupDouble(rootRadiusNames);
+                    toeRadius = familySymbol.LookupDouble(toeRadiusNames);
                 }
 
                 if (double.IsNaN(rootRadius)) rootRadius = 0;
@@ -434,16 +379,6 @@ namespace BH.UI.Revit.Engine
 
                 if (!double.IsNaN(height) && !double.IsNaN(width) && !double.IsNaN(webThickness) && !double.IsNaN(flangeThickness))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        height = height.ToSI(UnitType.UT_Section_Dimension);
-                        width = width.ToSI(UnitType.UT_Section_Dimension);
-                        webThickness = webThickness.ToSI(UnitType.UT_Section_Dimension);
-                        flangeThickness = flangeThickness.ToSI(UnitType.UT_Section_Dimension);
-                        rootRadius = rootRadius.ToSI(UnitType.UT_Section_Dimension);
-                        toeRadius = toeRadius.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.TSectionProfile(height, width, webThickness, flangeThickness, rootRadius, toeRadius);
                 }
             }
@@ -455,21 +390,21 @@ namespace BH.UI.Revit.Engine
                 if (section is StructuralSectionZProfile)
                 {
                     StructuralSectionZProfile sectionType = section as StructuralSectionZProfile;
-                    height = sectionType.Height;
-                    flangeWidth = sectionType.BottomFlangeLength;
-                    webThickness = sectionType.WallNominalThickness;
-                    flangeThickness = sectionType.WallNominalThickness;
-                    rootRadius = sectionType.InnerFillet;
+                    height = sectionType.Height.ToSI(UnitType.UT_Section_Dimension);
+                    flangeWidth = sectionType.BottomFlangeLength.ToSI(UnitType.UT_Section_Dimension);
+                    webThickness = sectionType.WallNominalThickness.ToSI(UnitType.UT_Section_Dimension);
+                    flangeThickness = sectionType.WallNominalThickness.ToSI(UnitType.UT_Section_Dimension);
+                    rootRadius = sectionType.InnerFillet.ToSI(UnitType.UT_Section_Dimension);
                     toeRadius = 0;
                 }
                 else
                 {
-                    height = familySymbol.LookupDouble(heightNames, false);
-                    flangeWidth = familySymbol.LookupDouble(widthNames, false);
-                    webThickness = familySymbol.LookupDouble(webThicknessNames, false);
-                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames, false);
-                    rootRadius = familySymbol.LookupDouble(rootRadiusNames, false);
-                    toeRadius = familySymbol.LookupDouble(toeRadiusNames, false);
+                    height = familySymbol.LookupDouble(heightNames);
+                    flangeWidth = familySymbol.LookupDouble(widthNames);
+                    webThickness = familySymbol.LookupDouble(webThicknessNames);
+                    flangeThickness = familySymbol.LookupDouble(flangeThicknessNames);
+                    rootRadius = familySymbol.LookupDouble(rootRadiusNames);
+                    toeRadius = familySymbol.LookupDouble(toeRadiusNames);
                 }
 
                 if (double.IsNaN(rootRadius)) rootRadius = 0;
@@ -477,16 +412,6 @@ namespace BH.UI.Revit.Engine
 
                 if (!double.IsNaN(height) && !double.IsNaN(flangeWidth) && !double.IsNaN(webThickness) && !double.IsNaN(flangeThickness))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        height = height.ToSI(UnitType.UT_Section_Dimension);
-                        flangeWidth = flangeWidth.ToSI(UnitType.UT_Section_Dimension);
-                        webThickness = webThickness.ToSI(UnitType.UT_Section_Dimension);
-                        flangeThickness = flangeThickness.ToSI(UnitType.UT_Section_Dimension);
-                        rootRadius = rootRadius.ToSI(UnitType.UT_Section_Dimension);
-                        toeRadius = toeRadius.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.ZSectionProfile(height, flangeWidth, webThickness, flangeThickness, rootRadius, toeRadius);
                 }
             }
@@ -498,41 +423,29 @@ namespace BH.UI.Revit.Engine
                 if (section is StructuralSectionPipeStandard)
                 {
                     StructuralSectionPipeStandard sectionType = section as StructuralSectionPipeStandard;
-                    thickness = sectionType.WallNominalThickness;
-                    diameter = sectionType.Diameter;
+                    thickness = sectionType.WallNominalThickness.ToSI(UnitType.UT_Section_Dimension);
+                    diameter = sectionType.Diameter.ToSI(UnitType.UT_Section_Dimension);
                 }
                 else if (section is StructuralSectionRoundHSS)
                 {
                     StructuralSectionRoundHSS sectionType = section as StructuralSectionRoundHSS;
-                    thickness = sectionType.WallNominalThickness;
-                    diameter = sectionType.Diameter;
+                    thickness = sectionType.WallNominalThickness.ToSI(UnitType.UT_Section_Dimension);
+                    diameter = sectionType.Diameter.ToSI(UnitType.UT_Section_Dimension);
                 }
                 else
                 {
-                    thickness = familySymbol.LookupDouble(wallThicknessNames, false);
-                    diameter = familySymbol.LookupDouble(diameterNames, false);
+                    thickness = familySymbol.LookupDouble(wallThicknessNames);
+                    diameter = familySymbol.LookupDouble(diameterNames);
                 }
 
                 if (!double.IsNaN(diameter) && !double.IsNaN(thickness))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        diameter = diameter.ToSI(UnitType.UT_Section_Dimension);
-                        thickness = thickness.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.TubeProfile(diameter, thickness);
                 }
 
-                double radius = familySymbol.LookupDouble(radiusNames, false);
+                double radius = familySymbol.LookupDouble(radiusNames);
                 if (!double.IsNaN(radius) && !double.IsNaN(thickness))
                 {
-                    if (pullSettings.ConvertUnits)
-                    {
-                        radius = radius.ToSI(UnitType.UT_Section_Dimension);
-                        thickness = thickness.ToSI(UnitType.UT_Section_Dimension);
-                    }
-
                     aProfile = BHG.Create.TubeProfile(radius * 2, thickness);
                 }
             }
@@ -542,7 +455,7 @@ namespace BH.UI.Revit.Engine
 
             aProfile = Modify.SetIdentifiers(aProfile, familySymbol) as IProfile;
             if (pullSettings.CopyCustomData)
-                aProfile = Modify.SetCustomData(aProfile, familySymbol, pullSettings.ConvertUnits) as IProfile;
+                aProfile = Modify.SetCustomData(aProfile, familySymbol) as IProfile;
 
             aProfile.Name = familySymbol.Name;
 
@@ -593,7 +506,7 @@ namespace BH.UI.Revit.Engine
 
             //TODO: direction should be driven based on the relation between GetTotalTransform(), handOrientation and facingOrientation?
 
-            BH.oM.Geometry.Point centroid = solid.ComputeCentroid().ToBHoM(pullSettings);
+            BH.oM.Geometry.Point centroid = solid.ComputeCentroid().ToBHoM();
 
             XYZ direction;
             if (familyInstance.Symbol.Family.FamilyPlacementType == FamilyPlacementType.CurveDrivenStructural)
@@ -631,7 +544,7 @@ namespace BH.UI.Revit.Engine
             {
                 foreach (Edge c in curveArray)
                 {
-                    BH.oM.Geometry.ICurve curve = c.AsCurve().ToBHoM(pullSettings);
+                    BH.oM.Geometry.ICurve curve = c.AsCurve().ToBHoM();
                     if (curve == null)
                     {
                         BH.Engine.Reflection.Compute.RecordWarning("The profile of an element could not be converted due to curve conversion issues. ElementId: " + familyInstance.Id.IntegerValue.ToString());
@@ -644,7 +557,7 @@ namespace BH.UI.Revit.Engine
             if (profileCurves.Count != 0)
             {
                 // Checking if the curves are in the horizontal plane, if not rotating them.
-                BH.oM.Geometry.Vector tan = direction.ToBHoMVector(pullSettings);
+                BH.oM.Geometry.Vector tan = direction.ToBHoMVector();
 
                 double angle = BH.Engine.Geometry.Query.Angle(tan, BH.oM.Geometry.Vector.ZAxis);
                 BH.oM.Geometry.Vector rotAxis = BH.Engine.Geometry.Query.CrossProduct(tan, BH.oM.Geometry.Vector.ZAxis);
@@ -667,7 +580,7 @@ namespace BH.UI.Revit.Engine
 
             profile = Modify.SetIdentifiers(profile, familyInstance.Symbol) as IProfile;
             if (pullSettings.CopyCustomData)
-                profile = Modify.SetCustomData(profile, familyInstance.Symbol, pullSettings.ConvertUnits) as IProfile;
+                profile = Modify.SetCustomData(profile, familyInstance.Symbol) as IProfile;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(profile);
 

--- a/Engine_Revit_UI/Convert/Structure/ToBHoM/SurfaceProperty.cs
+++ b/Engine_Revit_UI/Convert/Structure/ToBHoM/SurfaceProperty.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -64,9 +64,7 @@ namespace BH.UI.Revit.Engine
                         break;
                     }
 
-                    aThickness = csl.Width;
-                    if (pullSettings.ConvertUnits)
-                        aThickness = aThickness.ToSI(UnitType.UT_Section_Dimension);
+                    aThickness = csl.Width.ToSI(UnitType.UT_Section_Dimension);
 
                     Material revitMaterial = document.GetElement(csl.MaterialId) as Material;
                     if (revitMaterial == null)
@@ -119,7 +117,7 @@ namespace BH.UI.Revit.Engine
 
             aProperty2D = Modify.SetIdentifiers(aProperty2D, hostObjAttributes) as ConstantThickness;
             if (pullSettings.CopyCustomData)
-                aProperty2D = Modify.SetCustomData(aProperty2D, hostObjAttributes, pullSettings.ConvertUnits) as ConstantThickness;
+                aProperty2D = Modify.SetCustomData(aProperty2D, hostObjAttributes) as ConstantThickness;
 
             pullSettings.RefObjects = pullSettings.RefObjects.AppendRefObjects(aProperty2D);
 

--- a/Engine_Revit_UI/Convert/ToRevit.cs
+++ b/Engine_Revit_UI/Convert/ToRevit.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -185,7 +185,7 @@ namespace BH.UI.Revit.Engine
         {
             pushSettings = pushSettings.DefaultIfNull();
 
-            return ToRevitPlane(coordinateSystem, pushSettings);
+            return coordinateSystem.ToRevitPlane();
         }
 
         /***************************************************/
@@ -194,7 +194,7 @@ namespace BH.UI.Revit.Engine
         {
             pushSettings = pushSettings.DefaultIfNull();
 
-            return ToRevitCurve(curve, pushSettings);
+            return curve.ToRevitCurve();
         }
 
         /***************************************************/
@@ -203,7 +203,7 @@ namespace BH.UI.Revit.Engine
         {
             pushSettings = pushSettings.DefaultIfNull();
 
-            return ToRevitCurveArray(polyCurve, pushSettings);
+            return polyCurve.ToRevitCurveArray();
         }
 
         /***************************************************/
@@ -212,7 +212,7 @@ namespace BH.UI.Revit.Engine
         {
             pushSettings = pushSettings.DefaultIfNull();
 
-            return ToRevitXYZ(point, pushSettings);
+            return point.ToRevitXYZ();
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Modify/Move.cs
+++ b/Engine_Revit_UI/Modify/Move.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -43,7 +43,7 @@ namespace BH.UI.Revit.Engine
             if (location.IsReadOnly)
                 return null;
 
-            XYZ aXYZ = vector.ToRevit(pushSettings);
+            XYZ aXYZ = vector.ToRevit();
             if (aXYZ.GetLength() < Tolerance.MicroDistance)
                 return location;
 
@@ -82,7 +82,7 @@ namespace BH.UI.Revit.Engine
             if (locationCurve.IsReadOnly)
                 return null;
 
-            Curve aCurve = iCurve.ToRevitCurve(pushSettings);
+            Curve aCurve = iCurve.ToRevitCurve();
             if (Query.IsSimilar(aCurve, locationCurve.Curve))
                 return locationCurve;
 
@@ -151,13 +151,11 @@ namespace BH.UI.Revit.Engine
             if (element == null || space == null)
                 return null;
 
-            Level aLevel = Query.BottomLevel(space.Location.Z, element.Document, pullSettings.ConvertUnits);
+            Level aLevel = Query.BottomLevel(space.Location.Z, element.Document);
             if (aLevel == null)
                 return null;
 
             oM.Geometry.Point aPoint = BH.Engine.Geometry.Create.Point(space.Location.X, space.Location.Y, aLevel.Elevation);
-
-            //Parameter aParameter = Modify.SetParameter(element.get_Parameter(BuiltInParameter.), aLevel.Id, element.Document, pullSettings.ConvertUnits);
 
             return Move(element.Location, aPoint, pullSettings);
         }

--- a/Engine_Revit_UI/Modify/SetCustomData.cs
+++ b/Engine_Revit_UI/Modify/SetCustomData.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -31,7 +31,7 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
         
-        public static IBHoMObject SetCustomData(this IBHoMObject bHoMObject, Element element, bool convertUnits = true, string namePrefix = null)
+        public static IBHoMObject SetCustomData(this IBHoMObject bHoMObject, Element element, string namePrefix = null)
         {
             if (bHoMObject == null || element == null)
                 return bHoMObject;
@@ -39,21 +39,21 @@ namespace BH.UI.Revit.Engine
             IBHoMObject aBHoMObject = bHoMObject.GetShallowClone() as IBHoMObject;
 
             foreach (Parameter aParameter in element.ParametersMap)
-                aBHoMObject = SetCustomData(aBHoMObject, aParameter, convertUnits, namePrefix);
+                aBHoMObject = SetCustomData(aBHoMObject, aParameter, namePrefix);
 
             return aBHoMObject;
         }
 
         /***************************************************/
         
-        public static IBHoMObject SetCustomData(this IBHoMObject bHoMObject, Element element, BuiltInParameter builtInParameter,  bool convertUnits = true)
+        public static IBHoMObject SetCustomData(this IBHoMObject bHoMObject, Element element, BuiltInParameter builtInParameter)
         {
             if (bHoMObject == null || element == null)
                 return bHoMObject;
 
             IBHoMObject aBHoMObject = bHoMObject.GetShallowClone() as IBHoMObject;
 
-            aBHoMObject = SetCustomData(aBHoMObject, element.get_Parameter(builtInParameter), convertUnits);
+            aBHoMObject = SetCustomData(aBHoMObject, element.get_Parameter(builtInParameter));
                 
 
             return aBHoMObject;
@@ -61,7 +61,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static IBHoMObject SetCustomData(this IBHoMObject bHoMObject, Parameter parameter, bool convertUnits = true, string namePrefix = null)
+        public static IBHoMObject SetCustomData(this IBHoMObject bHoMObject, Parameter parameter, string namePrefix = null)
         {
             if (bHoMObject == null || parameter == null)
                 return bHoMObject;
@@ -73,8 +73,6 @@ namespace BH.UI.Revit.Engine
             {
                 case StorageType.Double:
                     aValue = parameter.AsDouble();
-                    if (convertUnits)
-                        aValue = Convert.ToSI((double)aValue, parameter.Definition.UnitType);
                     break;
                 case StorageType.ElementId:
                     ElementId aElementId = parameter.AsElementId();

--- a/Engine_Revit_UI/Modify/SetParameter.cs
+++ b/Engine_Revit_UI/Modify/SetParameter.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -30,7 +30,7 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static Parameter SetParameter(this Parameter parameter, object value, Document document = null, bool convertUnits = true)
+        public static Parameter SetParameter(this Parameter parameter, object value, Document document = null)
         {
             if (parameter == null || parameter.IsReadOnly)
                 return null;
@@ -62,19 +62,16 @@ namespace BH.UI.Revit.Engine
 
                     if (!double.IsNaN(aDouble))
                     {
-                        if(convertUnits)
+                        try
                         {
-                            try
-                            {
-                                aDouble = Convert.FromSI(aDouble, parameter.Definition.UnitType);
-                            }
-                            catch
-                            {
-                                aDouble = double.NaN;
-                            }
+                            aDouble = Convert.FromSI(aDouble, parameter.Definition.UnitType);
+                        }
+                        catch
+                        {
+                            aDouble = double.NaN;
                         }
 
-                        if(!double.IsNaN(aDouble))
+                        if (!double.IsNaN(aDouble))
                         {
                             parameter.Set(aDouble);
                             return parameter;

--- a/Engine_Revit_UI/Modify/SetParameters.cs
+++ b/Engine_Revit_UI/Modify/SetParameters.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -33,7 +33,7 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
         
-        public static Element SetParameters(this Element element, IBHoMObject bHoMObject, IEnumerable<BuiltInParameter> builtInParametersIgnore = null, bool convertUnits = true)
+        public static Element SetParameters(this Element element, IBHoMObject bHoMObject, IEnumerable<BuiltInParameter> builtInParametersIgnore = null)
         {
             if (bHoMObject == null || element == null)
                 return null;
@@ -52,7 +52,7 @@ namespace BH.UI.Revit.Engine
                     if (builtInParametersIgnore != null && aParameter.Id.IntegerValue < 0 && builtInParametersIgnore.Contains((BuiltInParameter)aParameter.Id.IntegerValue))
                         continue;
 
-                    SetParameter(aParameter, aKeyValuePair.Value, element.Document, convertUnits);
+                    SetParameter(aParameter, aKeyValuePair.Value, element.Document);
                 }
             }
 

--- a/Engine_Revit_UI/Modify/UpdateValues.cs
+++ b/Engine_Revit_UI/Modify/UpdateValues.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -69,10 +69,7 @@ namespace BH.UI.Revit.Engine
                 }
                 else if (aType_PropertyInfo == typeof(double))
                 {
-                    double aValue = aParameter.AsDouble();
-                    if (pullSettings.ConvertUnits)
-                        aValue = aValue.ToSI(aParameter.Definition.UnitType);
-
+                    double aValue = aParameter.AsDouble().ToSI(aParameter.Definition.UnitType);
                     aPropertyInfo.SetValue(iObject, aValue);
                 }
                     

--- a/Engine_Revit_UI/Query/BottomLevel.cs
+++ b/Engine_Revit_UI/Query/BottomLevel.cs
@@ -32,34 +32,30 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
         
-        public static Level BottomLevel(this oM.Geometry.ICurve curve, Document document, bool convertUnits = true)
+        public static Level BottomLevel(this oM.Geometry.ICurve curve, Document document)
         {
             if (curve == null)
                 return null;
 
             double aMinElevation = MinElevation(curve);
 
-            //double aMinElevation = BH.Engine.Geometry.Query.Bounds(curve as dynamic).Min.Z;
-            //if (convertUnits)
-            //    aMinElevation = aMinElevation.FromSI(UnitType.UT_Length);
-
-            return BottomLevel(aMinElevation, document, convertUnits);
+            return BottomLevel(aMinElevation, document);
         }
 
 
         /***************************************************/
 
-        public static Level BottomLevel(this oM.Geometry.Point point, Document document, bool convertUnits = true)
+        public static Level BottomLevel(this oM.Geometry.Point point, Document document)
         {
             if (point == null)
                 return null;
 
-            return BottomLevel(point.Z, document, convertUnits);
+            return BottomLevel(point.Z, document);
         }
 
         /***************************************************/
 
-        public static Level BottomLevel(this double elevation, Document document, bool convertUnits = true, double tolerance = oM.Geometry.Tolerance.Distance)
+        public static Level BottomLevel(this double elevation, Document document, double tolerance = oM.Geometry.Tolerance.Distance)
         {
             if (double.IsNaN(elevation) || double.IsNegativeInfinity(elevation) || double.IsPositiveInfinity(elevation))
                 return null;
@@ -67,9 +63,7 @@ namespace BH.UI.Revit.Engine
             List<Level> aLevelList = new FilteredElementCollector(document).OfClass(typeof(Level)).Cast<Level>().ToList();
             aLevelList.Sort((x, y) => x.Elevation.CompareTo(y.Elevation));
 
-            double aElevation = elevation;
-            if (convertUnits)
-                aElevation = aElevation.FromSI(UnitType.UT_Length);
+            double aElevation = elevation.FromSI(UnitType.UT_Length);
 
             if (aElevation <= aLevelList.First().Elevation)
                 return aLevelList.First();

--- a/Engine_Revit_UI/Query/Curves.cs
+++ b/Engine_Revit_UI/Query/Curves.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -72,13 +72,13 @@ namespace BH.UI.Revit.Engine
                     if (aEdgeArray == null)
                         continue;
 
-                    List<oM.Geometry.ICurve> aCurveList = aEdgeArray.ToBHoM(pullSettings);
+                    List<oM.Geometry.ICurve> aCurveList = aEdgeArray.ToBHoM();
                     if (aCurveList != null && aCurveList.Count != 0)
                         aResult.AddRange(aCurveList);                        
                 }
                 else if(aGeometryObject is Curve)
                 {
-                    oM.Geometry.ICurve aCurve = ((Curve)aGeometryObject).ToBHoM(pullSettings);
+                    oM.Geometry.ICurve aCurve = ((Curve)aGeometryObject).ToBHoM();
                     if (aCurve != null)
                         aResult.Add(aCurve);
                 }

--- a/Engine_Revit_UI/Query/ElementIds.cs
+++ b/Engine_Revit_UI/Query/ElementIds.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -536,7 +536,7 @@ namespace BH.UI.Revit.Engine
                                 foreach (ElementId aElementId in aDictionary.Keys)
                                 {
                                     Element aElement = aDocument.GetElement(aElementId);
-                                    if (Query.IsValid(aElement, aParameterName, aComparisonRule, aValue, true))
+                                    if (Query.IsValid(aElement, aParameterName, aComparisonRule, aValue))
                                         aResult.Add(aElementId);
                                 }
 

--- a/Engine_Revit_UI/Query/HighLevel.cs
+++ b/Engine_Revit_UI/Query/HighLevel.cs
@@ -35,7 +35,7 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static Level HighLevel(this Document document, double elevation, bool convertUnits = true)
+        public static Level HighLevel(this Document document, double elevation)
         {
             List<Level> aLevelList = new FilteredElementCollector(document).OfClass(typeof(Level)).Cast<Level>().ToList();
             if (aLevelList == null || aLevelList.Count == 0)
@@ -43,18 +43,14 @@ namespace BH.UI.Revit.Engine
 
             aLevelList.Sort((x, y) => x.Elevation.CompareTo(y.Elevation));
 
-            double aElevation = aLevelList.First().Elevation;
-            if (convertUnits)
-                aElevation = aElevation.ToSI(UnitType.UT_Length);
+            double aElevation = aLevelList.First().Elevation.ToSI(UnitType.UT_Length);
 
             if (Math.Abs(elevation - aElevation) < oM.Geometry.Tolerance.MacroDistance)
                 return aLevelList.First();
 
             for (int i = 1; i < aLevelList.Count; i++)
             {
-                aElevation = aLevelList[i].Elevation;
-                if (convertUnits)
-                    aElevation = aElevation.ToSI(UnitType.UT_Length);
+                aElevation = aLevelList[i].Elevation.ToSI(UnitType.UT_Length);
 
                 //if (Elevation) <= Math.Round(aElevation, 3, MidpointRounding.AwayFromZero))
                 if (Math.Round(elevation, 3, MidpointRounding.AwayFromZero) <= Math.Round(aElevation, 3, MidpointRounding.AwayFromZero))
@@ -67,20 +63,20 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static Level HighLevel(this Document document, oM.Geometry.ICurve curve, bool convertUnits = true)
+        public static Level HighLevel(this Document document, oM.Geometry.ICurve curve)
         {
             double aElevation = HighElevation(curve);
 
-            return HighLevel(document, aElevation, convertUnits);
+            return HighLevel(document, aElevation);
         }
 
         /***************************************************/
 
-        public static Level HighLevel(this Document document, IObject2D object2D, bool convertUnits = true)
+        public static Level HighLevel(this Document document, IObject2D object2D)
         {
             double aElevation = HighElevation(object2D);
 
-            return HighLevel(document, aElevation, convertUnits);
+            return HighLevel(document, aElevation);
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Query/HostedBuildingElements.cs
+++ b/Engine_Revit_UI/Query/HostedBuildingElements.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -83,11 +83,11 @@ namespace BH.UI.Revit.Engine
                         continue;
 
                     List<oM.Geometry.Point> aPointList = new List<oM.Geometry.Point>();
-                    aPointList.Add(aXYZ_Max.ToBHoM(pullSettings));
-                    aPointList.Add(aXYZ_U.ToBHoM(pullSettings));
-                    aPointList.Add(aXYZ_Min.ToBHoM(pullSettings));
-                    aPointList.Add(aXYZ_V.ToBHoM(pullSettings));
-                    aPointList.Add(aXYZ_Max.ToBHoM(pullSettings));
+                    aPointList.Add(aXYZ_Max.ToBHoM());
+                    aPointList.Add(aXYZ_U.ToBHoM());
+                    aPointList.Add(aXYZ_Min.ToBHoM());
+                    aPointList.Add(aXYZ_V.ToBHoM());
+                    aPointList.Add(aXYZ_Max.ToBHoM());
 
                     oM.Environment.Elements.Panel aPanel = Convert.ToBHoMEnvironmentPanel(aElement_Hosted, BH.Engine.Geometry.Create.Polyline(aPointList), pullSettings);
                     if (aPanel != null)

--- a/Engine_Revit_UI/Query/IsValid.cs
+++ b/Engine_Revit_UI/Query/IsValid.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -37,7 +37,7 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static bool IsValid(this Element element, string parameterName, IComparisonRule comparisonRule, object value = null, bool convertUnits = true)
+        public static bool IsValid(this Element element, string parameterName, IComparisonRule comparisonRule, object value = null)
         {
             if (element == null || string.IsNullOrWhiteSpace(parameterName) || comparisonRule == null)
                 return false;
@@ -47,7 +47,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static bool IsValid(this Parameter parameter, IComparisonRule comparisonRule, object value, bool convertUnits = true)
+        public static bool IsValid(this Parameter parameter, IComparisonRule comparisonRule, object value)
         {
             if (comparisonRule == null)
                 return false;
@@ -86,9 +86,7 @@ namespace BH.UI.Revit.Engine
                 switch (parameter.StorageType)
                 {
                     case StorageType.Double:
-                        aValue = parameter.AsDouble();
-                        if (convertUnits)
-                            aValue = Convert.ToSI((double)aValue, parameter.Definition.UnitType);
+                        aValue = Convert.ToSI(parameter.AsDouble(), parameter.Definition.UnitType);
                         break;
                     case StorageType.Integer:
                         aValue = parameter.AsInteger();

--- a/Engine_Revit_UI/Query/Layer.cs
+++ b/Engine_Revit_UI/Query/Layer.cs
@@ -41,12 +41,7 @@ namespace BH.UI.Revit.Engine
             pullSettings = pullSettings.DefaultIfNull();
 
             oM.Physical.Constructions.Layer aLayer = new oM.Physical.Constructions.Layer();
-
-            double aThickness = compoundStructureLayer.Width;
-            if (pullSettings.ConvertUnits)
-                aThickness = aThickness.ToSI(UnitType.UT_Length);
-
-            aLayer.Thickness = aThickness;
+            aLayer.Thickness = compoundStructureLayer.Width.ToSI(UnitType.UT_Length);
 
             Autodesk.Revit.DB.Material revitMaterial = doc.GetElement(compoundStructureLayer.MaterialId) as Autodesk.Revit.DB.Material;
             aLayer.Material = revitMaterial.ToBHoMEmptyMaterial(pullSettings);

--- a/Engine_Revit_UI/Query/Location.cs
+++ b/Engine_Revit_UI/Query/Location.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -41,7 +41,7 @@ namespace BH.UI.Revit.Engine
             if (pullSettings == null)
                 pullSettings = PullSettings.Default;
 
-            return (wall.Location as LocationCurve).ToBHoM(pullSettings);
+            return (wall.Location as LocationCurve).ToBHoM();
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Query/LookupDouble.cs
+++ b/Engine_Revit_UI/Query/LookupDouble.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -33,31 +33,27 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static double LookupDouble(this Element element, string parameterName, bool convertUnits = true)
+        public static double LookupDouble(this Element element, string parameterName)
         {
             double value = double.NaN;
+
             Parameter p = element.LookupParameter(parameterName);
-            if (p != null && p.HasValue)
-            {
-                value = p.AsDouble();
-                if (convertUnits)
-                    value = Convert.ToSI(value, p.Definition.UnitType);
-            }
+            if (p != null)
+                value = Convert.ToSI(p.AsDouble(), p.Definition.UnitType);
+
             return value;
         }
 
         /***************************************************/
 
-        public static double LookupDouble(this Element element, BuiltInParameter builtInParameter, bool convertUnits = true)
+        public static double LookupDouble(this Element element, BuiltInParameter builtInParameter)
         {
             double value = double.NaN;
+
             Parameter p = element.get_Parameter(builtInParameter);
-            if (p != null && p.HasValue)
-            {
-                value = p.AsDouble();
-                if (convertUnits)
-                    value = Convert.ToSI(value, p.Definition.UnitType);
-            }
+            if (p != null)
+                value = Convert.ToSI(p.AsDouble(), p.Definition.UnitType);
+
             return value;
         }
 
@@ -89,16 +85,14 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static double LookupDouble(this Element element, IEnumerable<string> parameterNames, bool convertUnits = true)
+        public static double LookupDouble(this Element element, IEnumerable<string> parameterNames)
         {
             double value = double.NaN;
+
             Parameter p = element.LookupParameter(parameterNames);
             if (p != null)
-            {
-                value = p.AsDouble();
-                if (convertUnits)
-                    value = Convert.ToSI(value, p.Definition.UnitType);
-            }
+                value = Convert.ToSI(p.AsDouble(), p.Definition.UnitType);
+
             return value;
         }
 

--- a/Engine_Revit_UI/Query/LowLevel.cs
+++ b/Engine_Revit_UI/Query/LowLevel.cs
@@ -35,7 +35,7 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static Level LowLevel(this Document document, double elevation, bool convertUnits = true)
+        public static Level LowLevel(this Document document, double elevation)
         {
             List<Level> aLevelList = new FilteredElementCollector(document).OfClass(typeof(Level)).Cast<Level>().ToList();
             if (aLevelList == null || aLevelList.Count == 0)
@@ -43,9 +43,7 @@ namespace BH.UI.Revit.Engine
 
             aLevelList.Sort((x, y) => y.Elevation.CompareTo(x.Elevation));
 
-            double aElevation = elevation;
-            if (convertUnits)
-                aElevation = aElevation.FromSI(UnitType.UT_Length);
+            double aElevation = elevation.FromSI(UnitType.UT_Length);
 
             if (Math.Abs(aElevation - aLevelList.First().Elevation) < oM.Geometry.Tolerance.MacroDistance)
                 return aLevelList.First();
@@ -59,20 +57,20 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static Level LowLevel(this Document document, oM.Geometry.ICurve curve, bool convertUnits = true)
+        public static Level LowLevel(this Document document, oM.Geometry.ICurve curve)
         {
             double aElevation = LowElevation(curve);
 
-            return LowLevel(document, aElevation, convertUnits);
+            return LowLevel(document, aElevation);
         }
 
         /***************************************************/
 
-        public static Level LowLevel(this Document document, IObject2D object2D, bool convertUnits = true)
+        public static Level LowLevel(this Document document, IObject2D object2D)
         {
             double aElevation = LowElevation(object2D);
 
-            return LowLevel(document, aElevation, convertUnits);
+            return LowLevel(document, aElevation);
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Query/Outlines.cs
+++ b/Engine_Revit_UI/Query/Outlines.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -49,7 +49,7 @@ namespace BH.UI.Revit.Engine
 
             pullSettings = pullSettings.DefaultIfNull();
             
-            List<ICurve> wallCurves = analyticalModel.GetCurves(AnalyticalCurveType.RawCurves).ToList().ToBHoM(pullSettings);
+            List<ICurve> wallCurves = analyticalModel.GetCurves(AnalyticalCurveType.RawCurves).ToList().ToBHoM();
             if (wallCurves.Any(x => x == null))
             {
                 hostObject.UnsupportedOutlineCurveWarning();

--- a/Engine_Revit_UI/Query/PolyCurve.cs
+++ b/Engine_Revit_UI/Query/PolyCurve.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -43,9 +43,9 @@ namespace BH.UI.Revit.Engine
             if (meshTriangle == null)
                 return null;
 
-            oM.Geometry.Point aPoint_1 = meshTriangle.get_Vertex(0).ToBHoM(pullSettings);
-            oM.Geometry.Point aPoint_2 = meshTriangle.get_Vertex(1).ToBHoM(pullSettings);
-            oM.Geometry.Point aPoint_3 = meshTriangle.get_Vertex(2).ToBHoM(pullSettings);
+            oM.Geometry.Point aPoint_1 = meshTriangle.get_Vertex(0).ToBHoM();
+            oM.Geometry.Point aPoint_2 = meshTriangle.get_Vertex(1).ToBHoM();
+            oM.Geometry.Point aPoint_3 = meshTriangle.get_Vertex(2).ToBHoM();
 
             return Create.PolyCurve(new ICurve[] { Create.Line(aPoint_1, aPoint_2), Create.Line(aPoint_2, aPoint_3), Create.Line(aPoint_3, aPoint_1) });
         }
@@ -252,11 +252,11 @@ namespace BH.UI.Revit.Engine
                 if (aPlane == null)
                     continue;
 
-                Autodesk.Revit.DB.Plane aPlane_Revit = Convert.ToRevitPlane(aPlane, new PushSettings() { ConvertUnits = true });
+                Autodesk.Revit.DB.Plane aPlane_Revit = Convert.ToRevitPlane(aPlane);
                 if (aPlane_Revit == null)
                     continue;
 
-                XYZ aNormal_Temp = aPlane.Normal.ToRevitXYZ(new PushSettings() { ConvertUnits = true });
+                XYZ aNormal_Temp = aPlane.Normal.ToRevitXYZ();
                 aNormal_Temp = aNormal_Temp.Normalize();
 
                 BoundingBoxXYZ aBoundingBoxXYZ = familyInstance.get_BoundingBox(null);
@@ -294,7 +294,7 @@ namespace BH.UI.Revit.Engine
                                     continue;
 
                                 if (IsContaining(aBoundingBoxXYZ, aCurve.GetEndPoint(0), true) && IsContaining(aBoundingBoxXYZ, aCurve.GetEndPoint(1), true))
-                                    aCurveList_Temp.Add(aCurve.ToBHoM(pullSettings));
+                                    aCurveList_Temp.Add(aCurve.ToBHoM());
                             }
                         }
                     }

--- a/Engine_Revit_UI/Query/PolyCurves.cs
+++ b/Engine_Revit_UI/Query/PolyCurves.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -51,9 +51,9 @@ namespace BH.UI.Revit.Engine
                     ICurve aICurve = null;
 
                     if (transform != null)
-                        aICurve = Convert.ToBHoM(aCurve.CreateTransformed(transform), pullSettings);
+                        aICurve = aCurve.CreateTransformed(transform).ToBHoM();
                     else
-                        aICurve = Convert.ToBHoM(aCurve, pullSettings);
+                        aICurve = aCurve.ToBHoM();
 
                     aCurveList.Add(aICurve);
                 }

--- a/Engine_Revit_UI/Query/Profiles.cs
+++ b/Engine_Revit_UI/Query/Profiles.cs
@@ -111,7 +111,7 @@ namespace BH.UI.Revit.Engine
                         if (aSketch.Profile == null)
                             continue;
 
-                        List<PolyCurve> aPolyCurveList = Convert.ToBHoM(aSketch, pullSettings);
+                        List<PolyCurve> aPolyCurveList = aSketch.ToBHoM();
                         if (aPolyCurveList == null)
                             continue;
 
@@ -120,27 +120,6 @@ namespace BH.UI.Revit.Engine
                                 aResult.Add(aPolyCurve);
                     }
                 }
-
-                //if (aLevel != null && aResult.Count > 0)
-                //{
-                //    //double aElevation = aLevel.Elevation;
-                //    //if (pullSettings.ConvertUnits)
-                //    //    aElevation = aElevation.ToSI(UnitType.UnitType.UT_Length);
-
-                //    //Parameter aParameter = hostObject.get_Parameter(BuiltInParameter.WALL_TOP_OFFSET);
-                //    //if (aParameter != null)
-                //    //{
-                //    //    double aOffset = aParameter.AsDouble().ToSI(UnitType.UnitType.UT_Length);
-                //    //    aElevation = aElevation + aOffset;
-                //    //}
-
-                //    //Vector aVector = BH.Engine.Geometry.Create.Vector(0, 0, aElevation);
-                //    BoundingBoxXYZ aBoundingBoxXYZ = hostObject.get_BoundingBox(null);
-
-                //    //Vector aVector = BH.Engine.Geometry.Create.Vector(0, 0, aBoundingBoxXYZ.Min.Z);
-                //    //for (int i = 0; i < aResult.Count; i++)
-                //    //    aResult[i] = BH.Engine.Geometry.Modify.Translate(aResult[i], -aVector);
-                //}
             }
 
             if (hostObject is Wall && aResult.Count == 0)
@@ -166,7 +145,7 @@ namespace BH.UI.Revit.Engine
                 List<BH.oM.Geometry.ICurve> aCurveList = new List<ICurve>();
                 foreach (BoundarySegment aboundarySegment in boundarySegments_List)
                 {
-                    aCurveList.Add(Convert.ToBHoM(aboundarySegment.GetCurve(), pullSettings));
+                    aCurveList.Add(aboundarySegment.GetCurve().ToBHoM());
                 }
                 aResults.Add(BH.Engine.Geometry.Create.PolyCurve(aCurveList));
             }
@@ -189,22 +168,16 @@ namespace BH.UI.Revit.Engine
                 LocationCurve aLocationCurve = wall.Location as LocationCurve;
                 if (aLocationCurve != null)
                 {
-                    ICurve aCurve = Convert.ToBHoM(aLocationCurve, pullSettings);
+                    ICurve aCurve = aLocationCurve.ToBHoM();
                     if (aCurve != null)
                     {
                         oM.Geometry.Plane aPlane = null;
 
-                        double aMax = aBoundingBoxXYZ.Max.Z;
-                        if (pullSettings != null && pullSettings.ConvertUnits)
-                            aMax = aMax.ToSI(UnitType.UT_Length);
-
+                        double aMax = aBoundingBoxXYZ.Max.Z.ToSI(UnitType.UT_Length);
                         aPlane = BH.Engine.Geometry.Create.Plane(BH.Engine.Geometry.Create.Point(0, 0, aMax), BH.Engine.Geometry.Create.Vector(0, 0, 1));
                         ICurve aCurve_Max = BH.Engine.Geometry.Modify.IProject(aCurve, aPlane);
 
-                        double aMin = aBoundingBoxXYZ.Min.Z;
-                        if (pullSettings != null && pullSettings.ConvertUnits)
-                            aMin = aMin.ToSI(UnitType.UT_Length);
-
+                        double aMin = aBoundingBoxXYZ.Min.Z.ToSI(UnitType.UT_Length);
                         aPlane = BH.Engine.Geometry.Create.Plane(BH.Engine.Geometry.Create.Point(0, 0, aMin), BH.Engine.Geometry.Create.Vector(0, 0, 1));
                         ICurve aCurve_Min = BH.Engine.Geometry.Modify.IProject(aCurve, aPlane);
 
@@ -245,7 +218,7 @@ namespace BH.UI.Revit.Engine
             aPolyCurveList = new List<PolyCurve>();
             foreach (CurveLoop aCurveLoop in aCurveLoopList)
             {
-                PolyCurve aPolyCurve = Convert.ToBHoM(aCurveLoop, pullSettings);
+                PolyCurve aPolyCurve = aCurveLoop.ToBHoM();
                 if (aPolyCurve != null)
                     aPolyCurveList.Add(aPolyCurve);
             }

--- a/Revit_Engine/Create/Settings/PullSettings.cs
+++ b/Revit_Engine/Create/Settings/PullSettings.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -40,15 +40,13 @@ namespace BH.Engine.Adapters.Revit
         [Input("discipline", "Default disciplne for pull method")]
         [Input("refObjects", "Additional reference objects created during Pull process")]
         [Input("copyCustomData", "Saves Parameters of Revit Element into CustomData of BHoM Object")]
-        [Input("convertUnits", "Converts units of parameters to SI")]
         [Output("PullSettings")]
-        public static PullSettings PullSettings(Discipline discipline = Discipline.Physical, Dictionary<int, List<IBHoMObject>> refObjects = null, bool copyCustomData = true, bool convertUnits = true)
+        public static PullSettings PullSettings(Discipline discipline = Discipline.Physical, Dictionary<int, List<IBHoMObject>> refObjects = null, bool copyCustomData = true)
         {
             PullSettings aPullSettings = new PullSettings()
             {
                 Discipline = discipline,
                 CopyCustomData = copyCustomData,
-                ConvertUnits = convertUnits,
                 RefObjects = refObjects
             };
 
@@ -68,6 +66,30 @@ namespace BH.Engine.Adapters.Revit
                 Discipline = discipline,
                 MapSettings = mapSettings,
                 RefObjects = new Dictionary<int, List<IBHoMObject>>(),
+            };
+
+            return aPullSettings;
+        }
+
+
+        /***************************************************/
+        /****            Deprecated methods             ****/
+        /***************************************************/
+
+        [Description("Creates Pull Settings class which contols pull behaviour of Adapter")]
+        [Input("discipline", "Default disciplne for pull method")]
+        [Input("refObjects", "Additional reference objects created during Pull process")]
+        [Input("copyCustomData", "Saves Parameters of Revit Element into CustomData of BHoM Object")]
+        [Input("convertUnits", "Converts units of parameters to SI")]
+        [Output("PullSettings")]
+        [Deprecated("3.0", "The method has been replaced with a similar one without argument convertUnits.")]
+        public static PullSettings PullSettings(Discipline discipline = Discipline.Physical, Dictionary<int, List<IBHoMObject>> refObjects = null, bool copyCustomData = true, bool convertUnits = true)
+        {
+            PullSettings aPullSettings = new PullSettings()
+            {
+                Discipline = discipline,
+                CopyCustomData = copyCustomData,
+                RefObjects = refObjects
             };
 
             return aPullSettings;

--- a/Revit_oM/Settings/PullSettings.cs
+++ b/Revit_oM/Settings/PullSettings.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -34,7 +34,6 @@ namespace BH.oM.Adapters.Revit.Settings
 
         public Enums.Discipline Discipline { get; set; } = Enums.Discipline.Physical;
         public bool CopyCustomData { get; set; } = true;
-        public bool ConvertUnits { get; set; } = true;
         public MapSettings MapSettings { get; set; } = null;
         public Dictionary<int, List<IBHoMObject>> RefObjects = null;
 

--- a/Revit_oM/Settings/PushSettings.cs
+++ b/Revit_oM/Settings/PushSettings.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -35,7 +35,6 @@ namespace BH.oM.Adapters.Revit.Settings
         /***************************************************/
 
         public bool CopyCustomData { get; set; } = true;
-        public bool ConvertUnits { get; set; } = true;
         public AdapterMode AdapterMode { get; set; } = AdapterMode.Replace;
         public FamilyLoadSettings FamilyLoadSettings { get; set; } = null;
         public MapSettings MapSettings { get; set; } = null;

--- a/Revit_oM/Settings/UpdatePropertySettings.cs
+++ b/Revit_oM/Settings/UpdatePropertySettings.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -32,7 +32,6 @@ namespace BH.oM.Adapters.Revit.Settings
 
         public string ParameterName { get; set; } = null;
         public object Value { get; set; } = null;
-        public bool ConvertUnits { get; set; } = true;
 
         /***************************************************/
 


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #450 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Existing macro test files on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2F%5FMacro).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- The decision on unit conversion has been removed from Revit_Toolkit - the units are converted automatically now.


### Additional comments
There are three types of items:
- classes in `BH.oM.Adapters.Revit` - I have not deprecated these, just removed a property - happy to log it in Versioning_Toolkit, but probably will need help from @adecler 
- methods in `BH.Engine.Adapters.Revit` - only one, it has been deprecated
- methods in `BH.UI.Revit.Engine` - since they are not exposed in any UI, I have just changed it without deprecating - I hope that is fine @adecler @al-fisher @rwemay 

**Please** check the code carefully - chances that I made some stupid mistake are relatively high.