### PR TITLE
Push and pull of multi segment grids enabled

### DIFF
--- a/Adapter_Revit_UI/CRUD/Read.cs
+++ b/Adapter_Revit_UI/CRUD/Read.cs
@@ -187,8 +187,7 @@ namespace BH.UI.Revit.Adapter
                         options.ComputeReferences = false;
                         options.DetailLevel = ViewDetailLevel.Fine;
                         options.IncludeNonVisibleObjects = BH.Engine.Adapters.Revit.Query.IncludeNonVisibleObjects(filterRequests);
-
-                        //TODO: this should be taken out only once for element, not for each iBHoMObject?
+                        
                         foreach(IBHoMObject iBHoMObject in iBHoMObjects)
                         {
                             ElementId elementId = iBHoMObject.ElementId();
@@ -206,6 +205,7 @@ namespace BH.UI.Revit.Adapter
                     result.AddRange(iBHoMObjects);
                     elementIDList.Add(element.Id.IntegerValue);
 
+                    //TODO: atm it has been glued to the existing code, should be done in a more structured way
                     if (element is MultiSegmentGrid)
                     {
                         foreach (ElementId elementId in (element as MultiSegmentGrid).GetGridIds())

--- a/Engine_Revit_UI/Convert/Geometry/ToBHoM/Grid.cs
+++ b/Engine_Revit_UI/Convert/Geometry/ToBHoM/Grid.cs
@@ -25,6 +25,7 @@ using Autodesk.Revit.DB;
 using BH.oM.Base;
 using BH.oM.Adapters.Revit.Settings;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -73,7 +74,14 @@ namespace BH.UI.Revit.Engine
                 return gridSegments[0].ToBHoMGrid(pullSettings);
             else
             {
-                grid = BH.Engine.Geometry.SettingOut.Create.Grid(new BH.oM.Geometry.PolyCurve { Curves = gridSegments.Select(x => x.Curve.IToBHoM()).ToList() });
+                List<BH.oM.Geometry.PolyCurve> joinedGridCurves = BH.Engine.Geometry.Compute.IJoin(gridSegments.Select(x => x.Curve.IToBHoM()).ToList());
+                if (joinedGridCurves.Count != 1)
+                {
+                    BH.Engine.Reflection.Compute.RecordError(String.Format("Revit grid consists of disjoint segments. Element id: {0}", revitGrid.Id));
+                    return null;
+                }
+
+                grid = BH.Engine.Geometry.SettingOut.Create.Grid(joinedGridCurves[0]);
                 grid.Name = revitGrid.Name;
             }
             

--- a/Engine_Revit_UI/Convert/ToBHoM.cs
+++ b/Engine_Revit_UI/Convert/ToBHoM.cs
@@ -413,6 +413,27 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
+        public static IBHoMObject ToBHoM(this MultiSegmentGrid grid, PullSettings pullSettings = null)
+        {
+            grid.CheckIfNullPull();
+
+            pullSettings = pullSettings.DefaultIfNull();
+
+            switch (pullSettings.Discipline)
+            {
+                case Discipline.Architecture:
+                case Discipline.Environmental:
+                case Discipline.Structural:
+                case Discipline.Physical:
+                    return grid.ToBHoMGrid(pullSettings);
+            }
+
+            grid.NotConvertedWarning();
+            return null;
+        }
+
+        /***************************************************/
+
         public static IBHoMObject ToBHoM(this ElementType elementType, PullSettings pullSettings = null)
         {
             elementType.CheckIfNullPull();

--- a/Engine_Revit_UI/Query/BHoMTypes.cs
+++ b/Engine_Revit_UI/Query/BHoMTypes.cs
@@ -213,7 +213,13 @@ namespace BH.UI.Revit.Engine
                 return result;
             }
 
-            if(element is ViewSheet)
+            if (element is MultiSegmentGrid)
+            {
+                result.Add(typeof(oM.Geometry.SettingOut.Grid));
+                return result;
+            }
+
+            if (element is ViewSheet)
             {
                 result.Add(typeof(Sheet));
                 return result;

--- a/Engine_Revit_UI/Query/BuiltInCategories.cs
+++ b/Engine_Revit_UI/Query/BuiltInCategories.cs
@@ -186,6 +186,11 @@ namespace BH.UI.Revit.Engine
                 builtInCategories.Add(Autodesk.Revit.DB.BuiltInCategory.OST_StructuralStiffener);
                 builtInCategories.Add(Autodesk.Revit.DB.BuiltInCategory.OST_StructuralFramingOther);
             }
+            if (type == typeof(oM.Geometry.SettingOut.Grid))
+            {
+                builtInCategories.Add(Autodesk.Revit.DB.BuiltInCategory.OST_Grids);
+                builtInCategories.Add(Autodesk.Revit.DB.BuiltInCategory.OST_GridChains);
+            }
 
             return builtInCategories;
         }

--- a/Engine_Revit_UI/Query/RevitTypes.cs
+++ b/Engine_Revit_UI/Query/RevitTypes.cs
@@ -149,6 +149,7 @@ namespace BH.UI.Revit.Engine
             if (type == typeof(oM.Geometry.SettingOut.Grid))
             {
                 result.Add(typeof(Grid));
+                result.Add(typeof(MultiSegmentGrid));
                 return result;
             }
 
@@ -210,7 +211,7 @@ namespace BH.UI.Revit.Engine
                 result.Add(typeof(FamilySymbol));
                 return result;
             }
-
+            
             return null;
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #23

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue23%2DMultiSegmentGrids).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- push and pull of multi segment grids has been enabled


### Additional comments
<!-- As required -->
Due to structure of Revit's object model (see [this](https://www.revitapidocs.com/2020/706e504e-20dd-e017-6bdf-e5265848d150.htm) and [this](https://www.revitapidocs.com/2020/47888507-2d69-664a-ead4-e481c7c5f42d.htm)), I needed to implement a workaround in `Read` file. Would be good to civilize it when working on simplifying the Toolkit.

https://github.com/BHoM/Revit_Toolkit/blob/5a6ab0b465e391fa8dd78073dce947e322f69bc4/Adapter_Revit_UI/CRUD/Read.cs#L208-L218