### PR TITLE
Unit conversion fixed on pull

### DIFF
--- a/Engine_Revit_UI/Modify/SetCustomData.cs
+++ b/Engine_Revit_UI/Modify/SetCustomData.cs
@@ -71,7 +71,7 @@ namespace BH.UI.Revit.Engine
             switch (parameter.StorageType)
             {
                 case StorageType.Double:
-                    value = parameter.AsDouble();
+                    value = parameter.AsDouble().ToSI(parameter.Definition.UnitType);
                     break;
                 case StorageType.ElementId:
                     ElementId elementID = parameter.AsElementId();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #490

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
One can e.g. pull wall panels from [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2F%5FMacro%2FPull%2FStructure) and look up _Unconnected Height_ parameter - it is ~10ft instead of 3m prior to this fix.


### Additional comments
<!-- As required -->
Sorry for the late catch and thanks @rboulton-BH @FraserGreenroyd for flagging it up 👍 