### PR TITLE
Boilerplate ToBHoMConstruction removed

### DIFF
--- a/Engine_Revit_UI/Convert/Physical/ToBHoM/Construction.cs
+++ b/Engine_Revit_UI/Convert/Physical/ToBHoM/Construction.cs
@@ -35,42 +35,6 @@ namespace BH.UI.Revit.Engine
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static oM.Physical.Constructions.Construction ToBHoMConstruction(this WallType wallType, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
-        {
-            settings = settings.DefaultIfNull();
-
-            return ((HostObjAttributes)wallType).ToBHoMConstruction(settings, refObjects);
-        }
-
-        /***************************************************/
-
-        public static oM.Physical.Constructions.Construction ToBHoMConstruction(this FloorType floorType, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
-        {
-            settings = settings.DefaultIfNull();
-
-            return ((HostObjAttributes)floorType).ToBHoMConstruction(settings, refObjects);
-        }
-
-        /***************************************************/
-
-        public static oM.Physical.Constructions.Construction ToBHoMConstruction(this CeilingType ceilingType, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
-        {
-            settings = settings.DefaultIfNull();
-
-            return ((HostObjAttributes)ceilingType).ToBHoMConstruction(settings, refObjects);
-        }
-
-        /***************************************************/
-
-        public static oM.Physical.Constructions.Construction ToBHoMConstruction(this RoofType roofType, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
-        {
-            settings = settings.DefaultIfNull();
-
-            return ((HostObjAttributes)roofType).ToBHoMConstruction(settings, refObjects);
-        }
-
-        /***************************************************/
-
         public static oM.Physical.Constructions.Construction ToBHoMConstruction(this HostObjAttributes hostObjAttributes, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();

--- a/Engine_Revit_UI/Convert/ToBHoM.cs
+++ b/Engine_Revit_UI/Convert/ToBHoM.cs
@@ -198,67 +198,16 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static IBHoMObject ToBHoM(this WallType wallType, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject ToBHoM(this HostObjAttributes hostObjAttributes, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
                 case Discipline.Structural:
-                    return wallType.ToBHoMSurfaceProperty(null, settings, refObjects) as IBHoMObject;
+                    return hostObjAttributes.ToBHoMSurfaceProperty(null, settings, refObjects) as IBHoMObject;
                 case Discipline.Architecture:
                 case Discipline.Physical:
                 case Discipline.Environmental:
-                    return wallType.ToBHoMConstruction(settings, refObjects);
-                default:
-                    return null;
-            }
-        }
-
-        /***************************************************/
-
-        public static IBHoMObject ToBHoM(this FloorType floorType, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
-        {
-            switch (discipline)
-            {
-                case Discipline.Structural:
-                    return floorType.ToBHoMSurfaceProperty(null, settings, refObjects);
-                case Discipline.Architecture:
-                case Discipline.Physical:
-                case Discipline.Environmental:
-                    return floorType.ToBHoMConstruction(settings, refObjects);
-                default:
-                    return null;
-            }
-        }
-
-        /***************************************************/
-
-        public static IBHoMObject ToBHoM(this CeilingType ceilingType, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
-        {
-            switch (discipline)
-            {
-                case Discipline.Structural:
-                    return ceilingType.ToBHoMSurfaceProperty(null, settings, refObjects);
-                case Discipline.Architecture:
-                case Discipline.Physical:
-                case Discipline.Environmental:
-                    return ceilingType.ToBHoMConstruction(settings, refObjects);
-                default:
-                    return null;
-            }
-        }
-
-        /***************************************************/
-
-        public static IBHoMObject ToBHoM(this RoofType roofType, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
-        {
-            switch (discipline)
-            {
-                case Discipline.Structural:
-                    return roofType.ToBHoMSurfaceProperty(null, settings, refObjects);
-                case Discipline.Architecture:
-                case Discipline.Physical:
-                case Discipline.Environmental:
-                    return roofType.ToBHoMConstruction(settings, refObjects);
+                    return hostObjAttributes.ToBHoMConstruction(settings, refObjects);
                 default:
                     return null;
             }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #542

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue542%2DUnnecessaryToBHoMConstruction) - this will work with any (even empty) Revit file.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `ToBHoMConstruction` method has been unified and made work on any types that inherit from `Autodesk.Revit.DB.HostObjAttributes` when converted to BHoM

