### PR TITLE
FilterByType method deprecated

### DIFF
--- a/Revit_Engine/Query/FilterByType.cs
+++ b/Revit_Engine/Query/FilterByType.cs
@@ -38,6 +38,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This is a duplicate of BH.Engine.Base.Query.FilterByType method.", typeof(BH.Engine.Base.Query), "FilterByType")]
         [Description("Filters objects by type.")]
         [Input("objects", "Objects to be filtered by Type")]
         [Input("type", "Type")]

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -51,6 +51,10 @@
       <HintPath>..\..\BHoM_Adapter\Build\BHoM_Adapter.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="BHoM_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\BHoM_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Common_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Common_oM.dll</HintPath>


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #543 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.Engine.Adapters.Revit.Query.FilterByType(IEnumerable<object>, Type)` has been deprecated as it is a duplicate of same method in `BH.Engine.Base.Query`
