### PR TITLE
DeleteThenCreate Push bug fix & cleanup of MultiSegmentGrids Pull

### DIFF
--- a/Adapter_Revit_UI/CRUD/Delete.cs
+++ b/Adapter_Revit_UI/CRUD/Delete.cs
@@ -58,6 +58,8 @@ namespace BH.UI.Revit.Adapter
 
             if (elementIDList == null)
                 return false;
+            else if (elementIDList.Count == 0)
+                return true;
 
             bool result = false;
             using (Transaction transaction = new Transaction(document, "Delete"))

--- a/Adapter_Revit_UI/CRUD/Read.cs
+++ b/Adapter_Revit_UI/CRUD/Read.cs
@@ -118,7 +118,7 @@ namespace BH.UI.Revit.Adapter
             if (!pullConfig.IncludeClosedWorksets)
                 worksetPrefilter = document.ElementIdsByWorksets(document.OpenWorksetIds().Union(document.SystemWorksetIds()).ToList());
 
-            List<ElementId> elementIds = request.IElementIds(uiDocument, worksetPrefilter).ToList();
+            List<ElementId> elementIds = request.IElementIds(uiDocument, worksetPrefilter).RemoveGridSegmentIds(document).ToList();
             if (elementIds == null)
                 return null;
             
@@ -144,8 +144,6 @@ namespace BH.UI.Revit.Adapter
                 mapSettings = BH.Engine.Adapters.Revit.Query.DefaultMapSettings();
             
             List<IBHoMObject> result = new List<IBHoMObject>();
-            List <int> elementIDList = new List<int>();
-
             Dictionary<string, List<IBHoMObject>> refObjects = new Dictionary<string, List<IBHoMObject>>();
 
             foreach (ElementId id in elementIds)
@@ -175,19 +173,6 @@ namespace BH.UI.Revit.Adapter
                     }
 
                     result.AddRange(iBHoMObjects);
-                    elementIDList.Add(element.Id.IntegerValue);
-
-                    //TODO: atm it has been glued to the existing code, should be done in a more structured way
-                    if (element is MultiSegmentGrid)
-                    {
-                        foreach (ElementId elementId in (element as MultiSegmentGrid).GetGridIds())
-                        {
-                            if (elementIDList.Contains(elementId.IntegerValue))
-                                result.RemoveAll(x => x.CustomData.ContainsKey(BH.Engine.Adapters.Revit.Convert.ElementId) && (int)x.CustomData[BH.Engine.Adapters.Revit.Convert.ElementId] != elementId.IntegerValue);
-                            else
-                                elementIDList.Add(elementId.IntegerValue);
-                        }
-                    }
                 }
             }
 

--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -311,6 +311,7 @@
     <Compile Include="Convert\ToSI.cs" />
     <Compile Include="Convert\FromSI.cs" />
     <Compile Include="Modify\AddSpaceId.cs" />
+    <Compile Include="Modify\RemoveGridSegmentIds.cs" />
     <Compile Include="Modify\SetTags.cs" />
     <Compile Include="Modify\UpdateMaterialProperties.cs" />
     <Compile Include="Modify\UpdateValues.cs" />

--- a/Engine_Revit_UI/Modify/RemoveGridSegmentIds.cs
+++ b/Engine_Revit_UI/Modify/RemoveGridSegmentIds.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.UI.Revit.Engine
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static IEnumerable<ElementId> RemoveGridSegmentIds(this IEnumerable<ElementId> ids, Document document)
+        {
+            if (ids == null || document == null)
+                return null;
+
+            HashSet<ElementId> segmentIds = new HashSet<ElementId>();
+            foreach (MultiSegmentGrid grid in new FilteredElementCollector(document, ids.ToList()).OfClass(typeof(MultiSegmentGrid)).Cast<MultiSegmentGrid>())
+            {
+                segmentIds.UnionWith(grid.GetGridIds());
+            }
+
+            return ids.Except(segmentIds);
+        }
+
+        /***************************************************/
+    }
+}


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #515
Closes #557 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[#515](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue23%2DMultiSegmentGrids)
[#557](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue557%2DDeleteThenCreatePushIssue)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Bug causing pushing an object with `PushType == PushType.DeleteThenCreate` return no output when nothing gets deleted prior to creation has been fixed
- Removal of unnecessary ids from elementId list in case of `MultiSegmentGrids` has been migrated from core `Read` to a separate method

