### PR TITLE
Pull of Energy Analysis model refactored

### DIFF
--- a/Engine_Revit_UI/Convert/Environment/ToBHoM/Building.cs
+++ b/Engine_Revit_UI/Convert/Environment/ToBHoM/Building.cs
@@ -38,84 +38,82 @@ namespace BH.UI.Revit.Engine
         /***************************************************/
         /****               Public Methods              ****/
         /***************************************************/
-        
-        public static List<IBHoMObject> ToBHoMObjects(this ProjectInfo projectInfo, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+
+        public static Building ToBHoMBuilding(this ProjectInfo projectInfo, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
             Document document = projectInfo.Document;
 
             Building building = refObjects.GetValue<Building>(projectInfo.Id);
-            if (building == null)
+            if (building != null)
+                return building;
+
+            double elevation = 0;
+            double longitude = 0;
+            double latitude = 0;
+            double timeZone = 0;
+            string placeName = string.Empty;
+            string weatherStationName = string.Empty;
+
+            if (document.SiteLocation != null)
             {
-                double elevation = 0;
-                double longitude = 0;
-                double latitude = 0;
-                double timeZone = 0;
-                string placeName = string.Empty;
-                string weatherStationName = string.Empty;
-
-                if (document.SiteLocation != null)
-                {
-                    elevation = document.SiteLocation.Elevation.ToSI(UnitType.UT_Length);
-                    longitude = document.SiteLocation.Longitude.ToSI(UnitType.UT_Length);
-                    latitude = document.SiteLocation.Latitude.ToSI(UnitType.UT_Length);
-                    timeZone = document.SiteLocation.TimeZone;
-                    placeName = document.SiteLocation.PlaceName;
-                    weatherStationName = document.SiteLocation.WeatherStationName;
-                }
-
-                double projectAngle = 0;
-                double projectEastWestOffset = 0;
-                double projectElevation = 0;
-                double projectNorthSouthOffset = 0;
-
-                if (document.ActiveProjectLocation != null)
-                {
-                    ProjectLocation projectLocation = document.ActiveProjectLocation;
-                    XYZ xyz = new XYZ(0, 0, 0);
-                    ProjectPosition projectPosition = projectLocation.GetProjectPosition(xyz);
-                    if (projectPosition != null)
-                    {
-                        projectAngle = projectPosition.Angle;
-                        projectEastWestOffset = projectPosition.EastWest;
-                        projectElevation = projectPosition.Elevation;
-                        projectNorthSouthOffset = projectPosition.NorthSouth;
-                    }
-                }
-
-                building = BH.Engine.Environment.Create.Building(elevation: elevation, latitude: latitude, longitude: longitude);
-
-                //Set ExtendedProperties
-                OriginContextFragment originContext = new OriginContextFragment();
-                originContext.ElementID = projectInfo.Id.IntegerValue.ToString();
-                originContext.Description = projectInfo.OrganizationDescription;
-                originContext.TypeName = projectInfo.Name;
-                building.AddFragment(originContext);
-
-                BuildingAnalyticalFragment buildingAnalytical = new BuildingAnalyticalFragment();
-                buildingAnalytical.GMTOffset = timeZone;
-                buildingAnalytical.NorthAngle = projectAngle;
-                building.AddFragment(buildingAnalytical);
-
-                BuildingContextFragment buildingContext = new BuildingContextFragment();
-                buildingContext.PlaceName = placeName;
-                buildingContext.WeatherStation = weatherStationName;
-                building.AddFragment(buildingContext);
-
-                //Set identifiers & custom data
-                building.SetIdentifiers(document.ProjectInformation);
-
-                building.CustomData["Project East/West Offset"] = projectEastWestOffset;
-                building.CustomData["Project North/South Offset"] = projectNorthSouthOffset;
-                building.CustomData["Project Elevation"] = projectElevation;
-
-                building.SetCustomData(document.ProjectInformation);
-
-                refObjects.AddOrReplace(projectInfo.Id, building);
+                elevation = document.SiteLocation.Elevation.ToSI(UnitType.UT_Length);
+                longitude = document.SiteLocation.Longitude.ToSI(UnitType.UT_Length);
+                latitude = document.SiteLocation.Latitude.ToSI(UnitType.UT_Length);
+                timeZone = document.SiteLocation.TimeZone;
+                placeName = document.SiteLocation.PlaceName;
+                weatherStationName = document.SiteLocation.WeatherStationName;
             }
 
-            List<IBHoMObject> bhomObjectList = document.GetEnergyAnalysisModel(settings, refObjects);
-            return bhomObjectList;
+            double projectAngle = 0;
+            double projectEastWestOffset = 0;
+            double projectElevation = 0;
+            double projectNorthSouthOffset = 0;
+
+            if (document.ActiveProjectLocation != null)
+            {
+                ProjectLocation projectLocation = document.ActiveProjectLocation;
+                XYZ xyz = new XYZ(0, 0, 0);
+                ProjectPosition projectPosition = projectLocation.GetProjectPosition(xyz);
+                if (projectPosition != null)
+                {
+                    projectAngle = projectPosition.Angle;
+                    projectEastWestOffset = projectPosition.EastWest;
+                    projectElevation = projectPosition.Elevation;
+                    projectNorthSouthOffset = projectPosition.NorthSouth;
+                }
+            }
+
+            building = BH.Engine.Environment.Create.Building(elevation: elevation, latitude: latitude, longitude: longitude);
+
+            //Set ExtendedProperties
+            OriginContextFragment originContext = new OriginContextFragment();
+            originContext.ElementID = projectInfo.Id.IntegerValue.ToString();
+            originContext.Description = projectInfo.OrganizationDescription;
+            originContext.TypeName = projectInfo.Name;
+            building.AddFragment(originContext);
+
+            BuildingAnalyticalFragment buildingAnalytical = new BuildingAnalyticalFragment();
+            buildingAnalytical.GMTOffset = timeZone;
+            buildingAnalytical.NorthAngle = projectAngle;
+            building.AddFragment(buildingAnalytical);
+
+            BuildingContextFragment buildingContext = new BuildingContextFragment();
+            buildingContext.PlaceName = placeName;
+            buildingContext.WeatherStation = weatherStationName;
+            building.AddFragment(buildingContext);
+
+            //Set identifiers & custom data
+            building.SetIdentifiers(document.ProjectInformation);
+
+            building.CustomData["Project East/West Offset"] = projectEastWestOffset;
+            building.CustomData["Project North/South Offset"] = projectNorthSouthOffset;
+            building.CustomData["Project Elevation"] = projectElevation;
+
+            building.SetCustomData(document.ProjectInformation);
+
+            refObjects.AddOrReplace(projectInfo.Id, building);
+            return building;
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/ToBHoM.cs
+++ b/Engine_Revit_UI/Convert/ToBHoM.cs
@@ -52,12 +52,25 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static IEnumerable<IBHoMObject> ToBHoM(this ProjectInfo projectInfo, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject ToBHoM(this ProjectInfo projectInfo, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
                 case Discipline.Environmental:
-                    return projectInfo.ToBHoMObjects(settings, refObjects);
+                    return projectInfo.ToBHoMBuilding(settings, refObjects);
+                default:
+                    return null;
+            }
+        }
+
+        /***************************************************/
+
+        public static IEnumerable<IBHoMObject> ToBHoM(this EnergyAnalysisDetailModel energyAnalysisModel, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            switch (discipline)
+            {
+                case Discipline.Environmental:
+                    return energyAnalysisModel.ToBHoMEnergyAnalysisModel(settings, refObjects);
                 default:
                     return null;
             }

--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -246,6 +246,7 @@
   <ItemGroup>
     <Compile Include="Compute\Errors.cs" />
     <Compile Include="Convert\Architecture\ToBHoM\Room.cs" />
+    <Compile Include="Convert\Environment\ToBHoM\EnergyAnalysisModel.cs" />
     <Compile Include="Convert\Environment\ToRevit\Space.cs" />
     <Compile Include="Convert\Geometry\ToBHoM\Curve.cs" />
     <Compile Include="Convert\Geometry\ToBHoM\Grid.cs" />
@@ -334,6 +335,7 @@
     <Compile Include="Query\ElementIds\ElementIdsByUniqueIds.cs" />
     <Compile Include="Query\ElementIds\ElementIdsByViewType.cs" />
     <Compile Include="Query\ElementIds\ElementIdsByWorksets.cs" />
+    <Compile Include="Query\ElementIds\ElementIdsEnergyAnalysisModel.cs" />
     <Compile Include="Query\ElementIds\ElementIdsViewTemplate.cs" />
     <Compile Include="Query\EmptyMaterialFragment.cs" />
     <Compile Include="Query\GetValues.cs" />
@@ -389,7 +391,6 @@
     <Compile Include="Query\Element.cs" />
     <Compile Include="Query\ElementId.cs" />
     <Compile Include="Query\ElementIds\ElementIds.cs" />
-    <Compile Include="Query\GetEnergyAnalysisModel.cs" />
     <Compile Include="Query\IntegerValue.cs" />
     <Compile Include="Query\MaterialGrade.cs" />
     <Compile Include="Query\Outlines.cs" />

--- a/Engine_Revit_UI/Query/ElementIds/ElementIds.cs
+++ b/Engine_Revit_UI/Query/ElementIds/ElementIds.cs
@@ -205,6 +205,13 @@ namespace BH.UI.Revit.Engine
             return uIDocument.Document.ElementIdsByParameter(request.ParameterName, request.TextComparisonType, request.Value, ids);
         }
 
+        /***************************************************/
+
+        public static IEnumerable<ElementId> ElementIds(this EnergyAnalysisModelRequest request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        {
+            return uIDocument.Document.ElementIdsEnergyAnalysisModel(ids);
+        }
+
 
         /***************************************************/
         /****        Interface methods - Requests       ****/

--- a/Engine_Revit_UI/Query/ElementIds/ElementIdsEnergyAnalysisModel.cs
+++ b/Engine_Revit_UI/Query/ElementIds/ElementIdsEnergyAnalysisModel.cs
@@ -1,0 +1,69 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Collections.Generic;
+
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+using BH.oM.Base;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit;
+using BH.oM.Adapters.Revit.Enums;
+using BH.oM.Adapters.Revit.Interface;
+using BH.oM.Data.Requests;
+using Autodesk.Revit.DB.Analysis;
+using Autodesk.Revit.DB.Mechanical;
+
+namespace BH.UI.Revit.Engine
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static IEnumerable<ElementId> ElementIdsEnergyAnalysisModel(this Document document, IEnumerable<ElementId> ids = null)
+        {
+            if (document == null)
+                return null;
+
+            if (ids != null && ids.Count() == 0)
+                return new List<ElementId>();
+
+            HashSet<ElementId> result = new HashSet<ElementId>();
+            EnergyAnalysisDetailModel energyAnalysisDetailModel = EnergyAnalysisDetailModel.GetMainEnergyAnalysisDetailModel(document);
+            if (energyAnalysisDetailModel != null && energyAnalysisDetailModel.IsValidObject)
+                result.Add(energyAnalysisDetailModel.Id);
+
+            if (ids != null)
+                result.IntersectWith(ids);
+
+            return result;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Engine/Query/Discipline.cs
+++ b/Revit_Engine/Query/Discipline.cs
@@ -20,15 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-
+using BH.oM.Adapters.Revit;
 using BH.oM.Adapters.Revit.Enums;
 using BH.oM.Data.Requests;
-using System.Collections.Generic;
-using System.Linq;
-using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
-using BH.oM.Adapters.Revit.Settings;
+using System;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -82,6 +79,13 @@ namespace BH.Engine.Adapters.Revit
                 if (discipline == oM.Adapters.Revit.Enums.Discipline.Undefined)
                     discipline = requestDiscipline;
                 else if (discipline != requestDiscipline)
+                    return null;
+            }
+            else if (request is EnergyAnalysisModelRequest)
+            {
+                if (discipline == oM.Adapters.Revit.Enums.Discipline.Undefined)
+                    discipline = oM.Adapters.Revit.Enums.Discipline.Environmental;
+                else if (discipline != oM.Adapters.Revit.Enums.Discipline.Environmental)
                     return null;
             }
 

--- a/Revit_oM/Requests/EnergyAnalysisModelRequest.cs
+++ b/Revit_oM/Requests/EnergyAnalysisModelRequest.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Data.Requests;
+using System.ComponentModel;
+
+namespace BH.oM.Adapters.Revit
+{
+    [Description("IRequest that filters all elements that are contained in an energy analysis model.")]
+    public class EnergyAnalysisModelRequest : IRequest
+    {
+        /***************************************************/
+        /****                Properties                 ****/
+        /***************************************************/
+
+
+
+        /***************************************************/
+    }
+}

--- a/Revit_oM/Revit_oM.csproj
+++ b/Revit_oM/Revit_oM.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Interface\IInstance.cs" />
     <Compile Include="Properties\InstanceProperties.cs" />
     <Compile Include="Requests\CategoryRequest.cs" />
+    <Compile Include="Requests\EnergyAnalysisModelRequest.cs" />
     <Compile Include="Requests\FamilyRequest.cs" />
     <Compile Include="Requests\ActiveWorksetRequest.cs" />
     <Compile Include="Requests\ParameterBoolRequest.cs" />


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #566 



### Test files
<!-- Link to test files to validate the proposed changes -->
[This script](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue566%2DToBHoMBuilding) with [this model](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2F%5FMacro%2FPull%2FEnvironment%2FFrom%20MajaLindroth).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `EnergyAnalysisModelRequest` allowing pull of the energy analysis model has been implemented
- `ProjectInfo.ToBHoMBuilding` allowing conversion of `Autodesk.Revit.DB.ProjectInfo` to `BH.oM.Environment.Elements.Building` has been implemented
- `EnergyAnalysisDetailModel.ToBHoMEnergyAnalysisModel` method has been implemented in order to replace `ProjectInfo.ToBHoMObjects`


### Additional comments
This PR should not change the results of energy analysis model pull - the only difference is that now the user is meant to use `EnergyAnalysisModelRequest` instead of a `FilterRequest` with `Building` type argument.

The change is implemented in order to align the conversion methods so that they all could be treated in the same manner (e.g. after this change it will be possible to centralize `SetCustomData` and `SetIdentifiers`).