### PR TITLE
BH.Engine.Adapters.Revit.Query.IsZero(double) deprecated

### DIFF
--- a/Revit_Engine/Query/IsZero.cs
+++ b/Revit_Engine/Query/IsZero.cs
@@ -33,7 +33,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
         
-        [DeprecatedAttribute("3.1", "This method is questionably useful and potentially harmful as it introduces a hardcoded tolerance.")]
+        [DeprecatedAttribute("3.1", "This method should not be used as it introduces a hardcoded tolerance.")]
         [Description("Checks if given double value is almost equal 0 (MicroDistance Tolerance).")]
         [Input("value", "Double value")]
         [Output("IsZero")]

--- a/Revit_Engine/Query/IsZero.cs
+++ b/Revit_Engine/Query/IsZero.cs
@@ -32,7 +32,8 @@ namespace BH.Engine.Adapters.Revit
         /***************************************************/
         /****              Public methods               ****/
         /***************************************************/
-
+        
+        [DeprecatedAttribute("3.1", "This method is questionably useful and potentially harmful as it introduces a hardcoded tolerance.")]
         [Description("Checks if given double value is almost equal 0 (MicroDistance Tolerance).")]
         [Input("value", "Double value")]
         [Output("IsZero")]


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #532

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed

### Changelog
- `BH.Engine.Adapters.Revit.Query.IsZero(double)` method has been deprecated

