### PR TITLE
Read and Delete stopped from crashing on empty ElementId collection

### DIFF
--- a/Adapter_Revit_UI/CRUD/Delete.cs
+++ b/Adapter_Revit_UI/CRUD/Delete.cs
@@ -56,7 +56,7 @@ namespace BH.UI.Revit.Adapter
             if (!removeConfig.IncludeClosedWorksets)
                 worksetPrefilter = document.ElementIdsByWorksets(document.OpenWorksetIds().Union(document.SystemWorksetIds()).ToList());
 
-            List<ElementId> elementIds = request.IElementIds(uiDocument, worksetPrefilter).RemoveGridSegmentIds(document).ToList();
+            IEnumerable<ElementId> elementIds = request.IElementIds(uiDocument, worksetPrefilter).RemoveGridSegmentIds(document);
 
             List<ElementId> deletedIds = Delete(elementIds, document, removeConfig.RemovePinned);
             if (deletedIds == null)
@@ -92,7 +92,7 @@ namespace BH.UI.Revit.Adapter
 
         /***************************************************/
 
-        private static List<ElementId> Delete(ICollection<ElementId> elementIds, Document document, bool removePinned)
+        private static List<ElementId> Delete(IEnumerable<ElementId> elementIds, Document document, bool removePinned)
         {
             if (elementIds == null)
             {
@@ -138,27 +138,6 @@ namespace BH.UI.Revit.Adapter
             }
         }
 
-        //FOR REFERENCE DELETING REVITFILEPREVIEW
-        //TODO: this is deleting a family based on a .rfa file - is it ever useful? Would rather pull the families and choose which to delete.
-        //if(revitSettings.GeneralSettings.AdapterMode == oM.Adapters.Revit.Enums.AdapterMode.Delete)
-        //{
-        //    IEnumerable<FamilySymbol> familySymbols = Query.FamilySymbols(revitFilePreview, document);
-        //    if (familySymbols != null)
-        //    {
-        //        if (familySymbols.Count() > 0)
-        //            family = familySymbols.First().Family;
-
-        //        foreach (FamilySymbol familySymbol in familySymbols)
-        //            document.Delete(familySymbol.Id);
-        //    }
-
-        //    SetIdentifiers(bhomObject, family);
-
-        //    IEnumerable<ElementId> elementIDs = family.GetFamilySymbolIds();
-        //    if (elementIDs == null || elementIDs.Count() == 0)
-        //        document.Delete(family.Id);
-        //}
-        //else
-        //{
+        /***************************************************/
     }
 }

--- a/Adapter_Revit_UI/CRUD/Read.cs
+++ b/Adapter_Revit_UI/CRUD/Read.cs
@@ -31,7 +31,6 @@ using BH.oM.Data.Requests;
 using BH.oM.Geometry;
 using BH.UI.Revit.Engine;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -67,7 +66,7 @@ namespace BH.UI.Revit.Adapter
             if (!pullConfig.IncludeClosedWorksets)
                 worksetPrefilter = document.ElementIdsByWorksets(document.OpenWorksetIds().Union(document.SystemWorksetIds()).ToList());
 
-            List<ElementId> elementIds = request.IElementIds(uiDocument, worksetPrefilter).RemoveGridSegmentIds(document).ToList();
+            IEnumerable<ElementId> elementIds = request.IElementIds(uiDocument, worksetPrefilter).RemoveGridSegmentIds(document);
             if (elementIds == null)
                 return new List<IBHoMObject>();
 

--- a/Engine_Revit_UI/Modify/RemoveGridSegmentIds.cs
+++ b/Engine_Revit_UI/Modify/RemoveGridSegmentIds.cs
@@ -37,6 +37,9 @@ namespace BH.UI.Revit.Engine
             if (ids == null || document == null)
                 return null;
 
+            if (ids.Count() == 0)
+                return ids;
+
             HashSet<ElementId> segmentIds = new HashSet<ElementId>();
             foreach (MultiSegmentGrid grid in new FilteredElementCollector(document, ids.ToList()).OfClass(typeof(MultiSegmentGrid)).Cast<MultiSegmentGrid>())
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #583

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue583%2DEmptyIdCollection) - just open an empty Revit model, select nothing and try to pull, after fix the error below should disappear:

![image](https://user-images.githubusercontent.com/26874773/76085693-d9232d00-5fb2-11ea-9433-b0fc4dc3cf8d.png)

Please note that the error may be covered by an empty config note due to [Grasshopper_Toolkit #480](https://github.com/BHoM/Grasshopper_Toolkit/issues/480).

### Additional comments
There might be a conflict with #577 - I will be happy to let it go first as it is much more serious than this one.