### PR TITLE
Tags revisited and Notes changed to Warnings

### DIFF
--- a/Adapter_Revit_UI/AdapterActions/Pull.cs
+++ b/Adapter_Revit_UI/AdapterActions/Pull.cs
@@ -50,7 +50,7 @@ namespace BH.UI.Revit.Adapter
             RevitPullConfig pullConfig = actionConfig as RevitPullConfig;
             if (pullConfig == null)
             {
-                BH.Engine.Reflection.Compute.RecordNote("Revit Pull Config has not been specified. Default Revit Pull Config is used.");
+                BH.Engine.Reflection.Compute.RecordWarning("Revit Pull Config has not been specified. Default Revit Pull Config is used.");
                 pullConfig = new RevitPullConfig();
             }
 

--- a/Adapter_Revit_UI/AdapterActions/Pull.cs
+++ b/Adapter_Revit_UI/AdapterActions/Pull.cs
@@ -50,7 +50,7 @@ namespace BH.UI.Revit.Adapter
             RevitPullConfig pullConfig = actionConfig as RevitPullConfig;
             if (pullConfig == null)
             {
-                BH.Engine.Reflection.Compute.RecordWarning("Revit Pull Config has not been specified. Default Revit Pull Config is used.");
+                //BH.Engine.Reflection.Compute.RecordNote("Revit Pull Config has not been specified. Default Revit Pull Config is used.");
                 pullConfig = new RevitPullConfig();
             }
 

--- a/Adapter_Revit_UI/AdapterActions/Push.cs
+++ b/Adapter_Revit_UI/AdapterActions/Push.cs
@@ -73,7 +73,7 @@ namespace BH.UI.Revit.Adapter
             RevitPushConfig pushConfig = actionConfig as RevitPushConfig;
             if (pushConfig == null)
             {
-                BH.Engine.Reflection.Compute.RecordWarning("Revit Push Config has not been specified. Default Revit Push Config is used.");
+                //BH.Engine.Reflection.Compute.RecordNote("Revit Push Config has not been specified. Default Revit Push Config is used.");
                 pushConfig = new RevitPushConfig();
             }
 

--- a/Adapter_Revit_UI/AdapterActions/Push.cs
+++ b/Adapter_Revit_UI/AdapterActions/Push.cs
@@ -73,7 +73,7 @@ namespace BH.UI.Revit.Adapter
             RevitPushConfig pushConfig = actionConfig as RevitPushConfig;
             if (pushConfig == null)
             {
-                BH.Engine.Reflection.Compute.RecordNote("Revit Push Config has not been specified. Default Revit Push Config is used.");
+                BH.Engine.Reflection.Compute.RecordWarning("Revit Push Config has not been specified. Default Revit Push Config is used.");
                 pushConfig = new RevitPushConfig();
             }
 
@@ -88,6 +88,18 @@ namespace BH.UI.Revit.Adapter
             {
                 BH.Engine.Reflection.Compute.RecordError("Input objects were invalid.");
                 return new List<object>();
+            }
+
+            // Add tag to each object
+            if (!string.IsNullOrWhiteSpace(tag))
+            {
+                foreach (IBHoMObject obj in objectsToPush)
+                {
+                    if (obj.Tags == null)
+                        obj.Tags = new HashSet<string> { tag };
+                    else
+                        obj.Tags.Add(tag);
+                }
             }
 
             // Push the objects

--- a/Adapter_Revit_UI/AdapterActions/Remove.cs
+++ b/Adapter_Revit_UI/AdapterActions/Remove.cs
@@ -61,7 +61,7 @@ namespace BH.UI.Revit.Adapter
             RevitRemoveConfig removeConfig = actionConfig as RevitRemoveConfig;
             if (removeConfig == null)
             {
-                BH.Engine.Reflection.Compute.RecordWarning("Revit Remove Config has not been specified. Default Revit Remove Config is used.");
+                //BH.Engine.Reflection.Compute.RecordNote("Revit Remove Config has not been specified. Default Revit Remove Config is used.");
                 removeConfig = new RevitRemoveConfig();
             }
 

--- a/Adapter_Revit_UI/AdapterActions/Remove.cs
+++ b/Adapter_Revit_UI/AdapterActions/Remove.cs
@@ -61,7 +61,7 @@ namespace BH.UI.Revit.Adapter
             RevitRemoveConfig removeConfig = actionConfig as RevitRemoveConfig;
             if (removeConfig == null)
             {
-                BH.Engine.Reflection.Compute.RecordNote("Revit Remove Config has not been specified. Default Revit Remove Config is used.");
+                BH.Engine.Reflection.Compute.RecordWarning("Revit Remove Config has not been specified. Default Revit Remove Config is used.");
                 removeConfig = new RevitRemoveConfig();
             }
 

--- a/Adapter_Revit_UI/Modify/SetTags.cs
+++ b/Adapter_Revit_UI/Modify/SetTags.cs
@@ -23,6 +23,7 @@
 using Autodesk.Revit.DB;
 
 using BH.oM.Base;
+using System;
 
 namespace BH.UI.Revit.Adapter
 {
@@ -42,8 +43,8 @@ namespace BH.UI.Revit.Adapter
                 return;
 
             string newValue = null;
-            if(bHoMObject.Tags != null)
-                newValue = string.Join("\n", bHoMObject.Tags);
+            if (bHoMObject.Tags != null && bHoMObject.Tags.Count != 0)
+                newValue = string.Join("; ", bHoMObject.Tags);
 
             string oldValue = parameter.AsString();
 
@@ -63,19 +64,16 @@ namespace BH.UI.Revit.Adapter
                 return;
 
             string tags = parameter.AsString();
-
-            IBHoMObject iBHoMObject = bHoMObject.GetShallowClone();
-
-            if (string.IsNullOrEmpty(tags) && (bHoMObject.Tags == null || bHoMObject.Tags.Count == 0))
+            if (string.IsNullOrEmpty(tags))
                 return;
 
-            if (iBHoMObject.Tags == null)
-                iBHoMObject.Tags = new System.Collections.Generic.HashSet<string>();
+            if (bHoMObject.Tags == null)
+                bHoMObject.Tags = new System.Collections.Generic.HashSet<string>();
 
-            string[] values = tags.Split('\n');
+            string[] values = tags.Split(new string[] { "; " }, StringSplitOptions.None);
 
             foreach (string value in values)
-                iBHoMObject.Tags.Add(value);
+                bHoMObject.Tags.Add(value);
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Compute/Notes.cs
+++ b/Engine_Revit_UI/Compute/Notes.cs
@@ -40,7 +40,7 @@ namespace BH.UI.Revit.Engine
             if (material != null)
                 message = string.Format("{0} BHoM Guid: {1}", message, material.BHoM_Guid);
 
-            BH.Engine.Reflection.Compute.RecordNote(message);
+            BH.Engine.Reflection.Compute.RecordWarning(message);
         }
 
         /***************************************************/
@@ -52,7 +52,7 @@ namespace BH.UI.Revit.Engine
             if (material != null)
                 message = string.Format("{0} Material Id: {1}", message, material.Id.IntegerValue);
 
-            BH.Engine.Reflection.Compute.RecordNote(message);
+            BH.Engine.Reflection.Compute.RecordWarning(message);
         }
 
         /***************************************************/
@@ -64,7 +64,7 @@ namespace BH.UI.Revit.Engine
             if (element != null)
                 message = string.Format("{0} Element Id: {1}", message, element.Id.IntegerValue);
 
-            BH.Engine.Reflection.Compute.RecordNote(message);
+            BH.Engine.Reflection.Compute.RecordWarning(message);
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Compute/Notes.cs
+++ b/Engine_Revit_UI/Compute/Notes.cs
@@ -33,42 +33,16 @@ namespace BH.UI.Revit.Engine
         /****             Internal methods              ****/
         /***************************************************/
 
-        internal static void NonIsotopicStructuralAssetNote(this oM.Physical.Materials.Material material)
-        {
-            string message = "Revit Structural Asset is Non-Isotopic.";
-
-            if (material != null)
-                message = string.Format("{0} BHoM Guid: {1}", message, material.BHoM_Guid);
-
-            BH.Engine.Reflection.Compute.RecordWarning(message);
-        }
-
-        /***************************************************/
-
         internal static void MaterialNotInLibraryNote(this Material material)
         {
-            string message = "Material could not be found in BHoM Libary.";
+            //string message = "Material could not be found in BHoM Libary.";
 
-            if (material != null)
-                message = string.Format("{0} Material Id: {1}", message, material.Id.IntegerValue);
+            //if (material != null)
+            //    message = string.Format("{0} Material Id: {1}", message, material.Id.IntegerValue);
 
-            BH.Engine.Reflection.Compute.RecordWarning(message);
+            //BH.Engine.Reflection.Compute.RecordNote(message);
         }
 
         /***************************************************/
-
-        internal static void MaterialNotInLibraryNote(this Element element)
-        {
-            string message = "Material could not be found in BHoM Libary.";
-
-            if (element != null)
-                message = string.Format("{0} Element Id: {1}", message, element.Id.IntegerValue);
-
-            BH.Engine.Reflection.Compute.RecordWarning(message);
-        }
-
-        /***************************************************/
-
-
     }
 }

--- a/Engine_Revit_UI/Query/ElementIds/ElementIds.cs
+++ b/Engine_Revit_UI/Query/ElementIds/ElementIds.cs
@@ -39,15 +39,23 @@ namespace BH.UI.Revit.Engine
 
         public static IEnumerable<ElementId> ElementIds(this FilterRequest request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
         {
+            IEnumerable<ElementId> elementIds = ids;
+
             object idObject;
             if (request.Equalities.TryGetValue("ObjectIds", out idObject) && idObject is IList)
             {
                 IList list = idObject as IList;
                 if (list != null)
-                    ids = uIDocument.Document.ElementIdsByIdObjects(list, ids);
+                    elementIds = uIDocument.Document.ElementIdsByIdObjects(list, elementIds);
             }
 
-            return uIDocument.Document.ElementIdsByBHoMType(request.Type, ids);
+            if (request.Type != null)
+                elementIds = uIDocument.Document.ElementIdsByBHoMType(request.Type, elementIds);
+
+            if (!string.IsNullOrWhiteSpace(request.Tag))
+                BH.Engine.Reflection.Compute.RecordError("Filtering based on tag declared in FilterRequest is currently not supported. The tag-related filter has not been applied.");
+
+            return elementIds;
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Query/ElementIds/ElementIdsByParameter.cs
+++ b/Engine_Revit_UI/Query/ElementIds/ElementIdsByParameter.cs
@@ -101,6 +101,8 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             HashSet<ElementId> result = new HashSet<ElementId>();
+            if (ids != null && ids.Count() == 0)
+                return result;
 
             FilteredElementCollector collector = ids == null ? new FilteredElementCollector(document) : new FilteredElementCollector(document, ids.ToList());
             foreach (Element element in collector.WherePasses(new LogicalOrFilter(new ElementIsElementTypeFilter(), new ElementIsElementTypeFilter(true))))
@@ -148,6 +150,8 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             HashSet<ElementId> result = new HashSet<ElementId>();
+            if (ids != null && ids.Count() == 0)
+                return result;
 
             FilteredElementCollector collector = ids == null ? new FilteredElementCollector(document) : new FilteredElementCollector(document, ids.ToList());
             foreach (Element element in collector.WherePasses(new LogicalOrFilter(new ElementIsElementTypeFilter(), new ElementIsElementTypeFilter(true))))
@@ -172,6 +176,8 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             HashSet<ElementId> result = new HashSet<ElementId>();
+            if (ids != null && ids.Count() == 0)
+                return result;
 
             FilteredElementCollector collector = ids == null ? new FilteredElementCollector(document) : new FilteredElementCollector(document, ids.ToList());
             foreach (Element element in collector.WherePasses(new LogicalOrFilter(new ElementIsElementTypeFilter(), new ElementIsElementTypeFilter(true))))
@@ -195,6 +201,8 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             HashSet<ElementId> result = new HashSet<ElementId>();
+            if (ids != null && ids.Count() == 0)
+                return result;
 
             FilteredElementCollector collector = ids == null ? new FilteredElementCollector(document) : new FilteredElementCollector(document, ids.ToList());
             foreach (Element element in collector.WherePasses(new LogicalOrFilter(new ElementIsElementTypeFilter(), new ElementIsElementTypeFilter(true))))

--- a/Revit_Engine/Modify/DefaultIfNull.cs
+++ b/Revit_Engine/Modify/DefaultIfNull.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Adapters.Revit
         {
             if (settings == null)
             {
-                BH.Engine.Reflection.Compute.RecordNote("Revit settings are not set. Default settings are used.");
+                BH.Engine.Reflection.Compute.RecordWarning("Revit settings are not set. Default settings are used.");
                 return RevitSettings.Default;
             }
 

--- a/Revit_Engine/Modify/DefaultIfNull.cs
+++ b/Revit_Engine/Modify/DefaultIfNull.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Adapters.Revit
         {
             if (settings == null)
             {
-                BH.Engine.Reflection.Compute.RecordWarning("Revit settings are not set. Default settings are used.");
+                //BH.Engine.Reflection.Compute.RecordNote("Revit settings are not set. Default settings are used.");
                 return RevitSettings.Default;
             }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #544
Closes #586

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Test file on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue544%2DTags) - it can be run with an empty Revit model based on structural template.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Tags were refactored in order to follow the adapter changes: now they get added/updated correctly, also appear on pull. Separator between multiple tags in Revit changed from breaking line (_\n_) to semicolon plus space (_; _) for preview purposes.
- Any Notes generated by Revit_Toolkit were elevated to Warnings following [Grasshopper_Toolkit #480](https://github.com/BHoM/Grasshopper_Toolkit/issues/480)


### Additional comments
<!-- As required -->
This PR is meant to enable using tags on push and pass them to returned objects on pull. Tag-based filtering on pull does not work atm since it would require deeper intervention into the current framework (#593 raised).