### PR TITLE
FullCRUD renamed to FullPush and error handling fixes

### DIFF
--- a/Adapter_Revit_UI/AdapterActions/Push.cs
+++ b/Adapter_Revit_UI/AdapterActions/Push.cs
@@ -63,9 +63,9 @@ namespace BH.UI.Revit.Adapter
             // If unset, set the pushType to AdapterSettings' value (base AdapterSettings default is FullCRUD). Disallow the unsupported PushTypes.
             if (pushType == PushType.AdapterDefault)
                 pushType = PushType.DeleteThenCreate;
-            else if (pushType == PushType.FullCRUD)
+            else if (pushType == PushType.FullPush)
             {
-                BH.Engine.Reflection.Compute.RecordError("Full CRUD is currently not supported by Revit_Toolkit, please use Create, UpdateOnly or DeleteThenCreate instead.");
+                BH.Engine.Reflection.Compute.RecordError("Full Push is currently not supported by Revit_Toolkit, please use Create, UpdateOnly or DeleteThenCreate instead.");
                 return new List<object>();
             }
             

--- a/Adapter_Revit_UI/CRUD/Create.cs
+++ b/Adapter_Revit_UI/CRUD/Create.cs
@@ -34,10 +34,10 @@ namespace BH.UI.Revit.Adapter
     public partial class RevitUIAdapter
     {
         /***************************************************/
-        /****              Private Methods              ****/
+        /****               Public Methods              ****/
         /***************************************************/
 
-        private List<IBHoMObject> Create(IEnumerable<IBHoMObject> bHoMObjects, RevitPushConfig pushConfig)
+        public List<IBHoMObject> Create(IEnumerable<IBHoMObject> bHoMObjects, RevitPushConfig pushConfig)
         {
             Document document = this.Document;
             RevitSettings settings = this.RevitSettings.DefaultIfNull();
@@ -55,7 +55,7 @@ namespace BH.UI.Revit.Adapter
 
         /***************************************************/
 
-        private static Element Create(IBHoMObject bHoMObject, Document document, RevitSettings settings, Dictionary<Guid, List<int>> refObjects)
+        public static Element Create(IBHoMObject bHoMObject, Document document, RevitSettings settings, Dictionary<Guid, List<int>> refObjects)
         {
             if (bHoMObject == null)
             {

--- a/Adapter_Revit_UI/CRUD/Delete.cs
+++ b/Adapter_Revit_UI/CRUD/Delete.cs
@@ -67,10 +67,10 @@ namespace BH.UI.Revit.Adapter
 
 
         /***************************************************/
-        /****              Private Methods              ****/
+        /****               Public Methods              ****/
         /***************************************************/
 
-        private static bool Delete(IBHoMObject bHoMObject, Document document)
+        public static bool Delete(IBHoMObject bHoMObject, Document document)
         {
             ElementId elementId = Engine.Query.ElementId(bHoMObject);
             if (elementId == null)
@@ -92,7 +92,7 @@ namespace BH.UI.Revit.Adapter
 
         /***************************************************/
 
-        private static List<ElementId> Delete(IEnumerable<ElementId> elementIds, Document document, bool removePinned)
+        public static List<ElementId> Delete(IEnumerable<ElementId> elementIds, Document document, bool removePinned)
         {
             if (elementIds == null)
             {
@@ -111,7 +111,7 @@ namespace BH.UI.Revit.Adapter
 
         /***************************************************/
 
-        private static IEnumerable<ElementId> Delete(ElementId elementId, Document document, bool deletePinned)
+        public static IEnumerable<ElementId> Delete(ElementId elementId, Document document, bool deletePinned)
         {
             Element element = document.GetElement(elementId);
             if (element == null)

--- a/Adapter_Revit_UI/CRUD/Read.cs
+++ b/Adapter_Revit_UI/CRUD/Read.cs
@@ -115,10 +115,10 @@ namespace BH.UI.Revit.Adapter
 
 
         /***************************************************/
-        /****              Private Methods              ****/
+        /****               Public Methods              ****/
         /***************************************************/
 
-        private static IEnumerable<IBHoMObject> Read(Element element, Discipline discipline, RevitSettings settings, Dictionary<string, List<IBHoMObject>> refObjects)
+        public static IEnumerable<IBHoMObject> Read(Element element, Discipline discipline, RevitSettings settings, Dictionary<string, List<IBHoMObject>> refObjects)
         {
             if (element == null || !element.IsValidObject)
                 return new List<IBHoMObject>();

--- a/Adapter_Revit_UI/CRUD/Update.cs
+++ b/Adapter_Revit_UI/CRUD/Update.cs
@@ -31,10 +31,10 @@ namespace BH.UI.Revit.Adapter
     public partial class RevitUIAdapter
     {
         /***************************************************/
-        /****              Private Methods              ****/
+        /****               Public Methods              ****/
         /***************************************************/
 
-        private static bool Update(Element element, IBHoMObject bHoMObject, RevitSettings settings)
+        public static bool Update(Element element, IBHoMObject bHoMObject, RevitSettings settings)
         {
             string tagsParameterName = settings.TagsParameterName;
             

--- a/Revit_Adapter/AdapterActions/Pull.cs
+++ b/Revit_Adapter/AdapterActions/Pull.cs
@@ -46,6 +46,12 @@ namespace BH.Adapter.Revit
                 return InternalAdapter.Pull(request, pullType, pullConfig);
             }
 
+            if (!this.IsValid())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Revit Adapter is not valid. Please check if it has been set up correctly and activated.");
+                return new List<object>();
+            }
+
             //Reset the wait event
             m_WaitEvent.Reset();
 

--- a/Revit_Adapter/AdapterActions/Push.cs
+++ b/Revit_Adapter/AdapterActions/Push.cs
@@ -46,6 +46,12 @@ namespace BH.Adapter.Revit
                 return InternalAdapter.Push(objects, tag, pushType, pushConfig);
             }
 
+            if (!this.IsValid())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Revit Adapter is not valid. Please check if it has been set up correctly and activated.");
+                return new List<object>();
+            }
+
             //Reset the wait event
             m_WaitEvent.Reset();
 

--- a/Revit_Adapter/AdapterActions/Remove.cs
+++ b/Revit_Adapter/AdapterActions/Remove.cs
@@ -55,6 +55,12 @@ namespace BH.Adapter.Revit
                 return InternalAdapter.Remove(request, removeConfig);
             }
 
+            if (!this.IsValid())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Revit Adapter is not valid. Please check if it has been set up correctly and activated.");
+                return 0;
+            }
+
             //Reset the wait event
             m_WaitEvent.Reset();
 

--- a/Revit_Adapter/RevitAdapter.cs
+++ b/Revit_Adapter/RevitAdapter.cs
@@ -130,7 +130,7 @@ namespace BH.Adapter.Revit
             m_WaitEvent.Reset();
 
             if (!returned)
-                Engine.Reflection.Compute.RecordError("Failed to connect to Revit");
+                Engine.Reflection.Compute.RecordError("Failed to connect to Revit. Check if one and only one instance of Revit is open and RevitListener is activated in Add-Ins tab.");
 
             return returned;
         }

--- a/Revit_UI/EventHandlers/Pull.cs
+++ b/Revit_UI/EventHandlers/Pull.cs
@@ -45,11 +45,22 @@ namespace BH.UI.Revit
                     //Get instance of listener
                     RevitListener listener = RevitListener.Listener;
 
-                    //Get the revit adapter
-                    RevitUIAdapter adapter = listener.GetAdapter(app.ActiveUIDocument.Document);
+                    IEnumerable<object> objs;
 
-                    //Pull the data
-                    IEnumerable<object> objs = adapter.Pull(listener.LatestRequest, listener.LatestPullType, listener.LatestConfig);
+                    // Do not attempt to pull if no document is open.
+                    if (app.ActiveUIDocument == null || app.ActiveUIDocument.Document == null)
+                    {
+                        BH.Engine.Reflection.Compute.RecordError("The adaper has successfully connected to Revit, but open document could not be found. Pull aborted.");
+                        objs = new List<object>();
+                    }
+                    else
+                    {
+                        //Get the revit adapter
+                        RevitUIAdapter adapter = listener.GetAdapter(app.ActiveUIDocument.Document);
+
+                        //Pull the data
+                        objs = adapter.Pull(listener.LatestRequest, listener.LatestPullType, listener.LatestConfig);
+                    }
 
                     //Clear the previous data
                     listener.LatestPullType = oM.Adapter.PullType.AdapterDefault;

--- a/Revit_UI/EventHandlers/Push.cs
+++ b/Revit_UI/EventHandlers/Push.cs
@@ -46,12 +46,23 @@ namespace BH.UI.Revit
                     //Get instance of listener
                     RevitListener listener = RevitListener.Listener;
 
-                    //Get the revit adapter
-                    RevitUIAdapter adapter = listener.GetAdapter(app.ActiveUIDocument.Document);
+                    IEnumerable<object> objs;
 
-                    //Push the data
-                    List<object> objs = adapter.Push(listener.LatestPackage, listener.LatestTag, listener.LatestPushType, listener.LatestConfig);
+                    // Do not attempt to push if no document is open.
+                    if (app.ActiveUIDocument == null || app.ActiveUIDocument.Document == null)
+                    {
+                        BH.Engine.Reflection.Compute.RecordError("The adaper has successfully connected to Revit, but open document could not be found. Push aborted.");
+                        objs = new List<object>();
+                    }
+                    else
+                    {
+                        //Get the revit adapter
+                        RevitUIAdapter adapter = listener.GetAdapter(app.ActiveUIDocument.Document);
 
+                        //Push the data
+                        objs = adapter.Push(listener.LatestPackage, listener.LatestTag, listener.LatestPushType, listener.LatestConfig);
+                    }
+                    
                     //Clear the lastest package list
                     listener.LatestPackage.Clear();
                     listener.LatestPushType = oM.Adapter.PushType.AdapterDefault;

--- a/Revit_UI/EventHandlers/Remove.cs
+++ b/Revit_UI/EventHandlers/Remove.cs
@@ -45,12 +45,20 @@ namespace BH.UI.Revit
                     //Get instance of listener
                     RevitListener listener = RevitListener.Listener;
 
-                    //Get the revit adapter
-                    RevitUIAdapter adapter = listener.GetAdapter(app.ActiveUIDocument.Document);
+                    int count = 0;
 
-                    //Remove the elements
-                    int count = adapter.Remove(listener.LatestRequest, listener.LatestConfig);
+                    // Do not attempt to remove if no document is open.
+                    if (app.ActiveUIDocument == null || app.ActiveUIDocument.Document == null)
+                        BH.Engine.Reflection.Compute.RecordError("The adaper has successfully connected to Revit, but open document could not be found. Remove aborted.");
+                    else
+                    {
+                        //Get the revit adapter
+                        RevitUIAdapter adapter = listener.GetAdapter(app.ActiveUIDocument.Document);
 
+                        //Remove the elements
+                        count = adapter.Remove(listener.LatestRequest, listener.LatestConfig);
+                    }
+                    
                     //Clear the previous data
                     listener.LatestConfig = null;
 


### PR DESCRIPTION
### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
[BHoM Adapter #214](https://github.com/BHoM/BHoM_Adapter/pull/214)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #604
Closes #605 
Closes #606 
Closes #607 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[#604](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue604%2DFullPush)
#605 does not require a test file
[#606 and #607](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue606%2C607%2DNullReferenceHandlers)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- the code has been aligned to the change from `PushType.FullCRUD` to `PushType.FullPush`
- all `private` CRUD methods were made `public`
- `NullReferenceExceptions` occurring on inactive adapter and no open document in Revit were prevented and replaced with Errors recorded by Reflection
- Connection error message has been extended to make it more informative


### Additional comments
Although covering 4 issues, this PR is rather minimalistic. Happy to support in case of any issues with reviewing it.