### PR TITLE
RecordNote calls uncommented and empty IRequest check added

### DIFF
--- a/Adapter_Revit_UI/AdapterActions/Pull.cs
+++ b/Adapter_Revit_UI/AdapterActions/Pull.cs
@@ -50,7 +50,7 @@ namespace BH.UI.Revit.Adapter
             RevitPullConfig pullConfig = actionConfig as RevitPullConfig;
             if (pullConfig == null)
             {
-                //BH.Engine.Reflection.Compute.RecordNote("Revit Pull Config has not been specified. Default Revit Pull Config is used.");
+                BH.Engine.Reflection.Compute.RecordNote("Revit Pull Config has not been specified. Default Revit Pull Config is used.");
                 pullConfig = new RevitPullConfig();
             }
 

--- a/Adapter_Revit_UI/AdapterActions/Push.cs
+++ b/Adapter_Revit_UI/AdapterActions/Push.cs
@@ -73,7 +73,7 @@ namespace BH.UI.Revit.Adapter
             RevitPushConfig pushConfig = actionConfig as RevitPushConfig;
             if (pushConfig == null)
             {
-                //BH.Engine.Reflection.Compute.RecordNote("Revit Push Config has not been specified. Default Revit Push Config is used.");
+                BH.Engine.Reflection.Compute.RecordNote("Revit Push Config has not been specified. Default Revit Push Config is used.");
                 pushConfig = new RevitPushConfig();
             }
 

--- a/Adapter_Revit_UI/AdapterActions/Remove.cs
+++ b/Adapter_Revit_UI/AdapterActions/Remove.cs
@@ -61,7 +61,7 @@ namespace BH.UI.Revit.Adapter
             RevitRemoveConfig removeConfig = actionConfig as RevitRemoveConfig;
             if (removeConfig == null)
             {
-                //BH.Engine.Reflection.Compute.RecordNote("Revit Remove Config has not been specified. Default Revit Remove Config is used.");
+                BH.Engine.Reflection.Compute.RecordNote("Revit Remove Config has not been specified. Default Revit Remove Config is used.");
                 removeConfig = new RevitRemoveConfig();
             }
 

--- a/Engine_Revit_UI/Compute/Notes.cs
+++ b/Engine_Revit_UI/Compute/Notes.cs
@@ -35,12 +35,12 @@ namespace BH.UI.Revit.Engine
 
         internal static void MaterialNotInLibraryNote(this Material material)
         {
-            //string message = "Material could not be found in BHoM Libary.";
+            string message = "Material could not be found in BHoM Libary.";
 
-            //if (material != null)
-            //    message = string.Format("{0} Material Id: {1}", message, material.Id.IntegerValue);
+            if (material != null)
+                message = string.Format("{0} Material Id: {1}", message, material.Id.IntegerValue);
 
-            //BH.Engine.Reflection.Compute.RecordNote(message);
+            BH.Engine.Reflection.Compute.RecordNote(message);
         }
 
         /***************************************************/

--- a/Revit_Adapter/AdapterActions/Pull.cs
+++ b/Revit_Adapter/AdapterActions/Pull.cs
@@ -36,6 +36,22 @@ namespace BH.Adapter.Revit
 
         public override IEnumerable<object> Pull(IRequest request, PullType pullType = PullType.AdapterDefault, ActionConfig actionConfig = null)
         {
+            //Check if request is not null or empty
+            if (request == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("BHoM objects could not be read because provided IRequest is null or empty.");
+                return new List<object>();
+            }
+            else if (request is FilterRequest)
+            {
+                FilterRequest filterRequest = (FilterRequest)request;
+                if (filterRequest.Type == null && String.IsNullOrWhiteSpace(filterRequest.Tag) && (filterRequest.Equalities == null || filterRequest.Equalities.Count == 0))
+                {
+                    BH.Engine.Reflection.Compute.RecordError("BHoM objects could not be read because provided IRequest is null or empty.");
+                    return new List<object>();
+                }
+            }
+
             //Initialize Revit config
             RevitPullConfig pullConfig = actionConfig as RevitPullConfig;
 

--- a/Revit_Adapter/AdapterActions/Remove.cs
+++ b/Revit_Adapter/AdapterActions/Remove.cs
@@ -21,19 +21,10 @@
  */
 
 using BH.oM.Adapter;
-using BH.Adapter.Socket;
-using BH.oM.Base;
-using BH.oM.Data.Requests;
-using BH.oM.Reflection.Debugging;
-using BH.oM.Adapters.Revit.Settings;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using BH.oM.Reflection.Attributes;
-using System.ComponentModel;
 using BH.oM.Adapters.Revit;
+using BH.oM.Data.Requests;
+using System;
+using System.Collections.Generic;
 
 namespace BH.Adapter.Revit
 {
@@ -45,6 +36,22 @@ namespace BH.Adapter.Revit
 
         public override int Remove(IRequest request, ActionConfig actionConfig = null)
         {
+            //Check if request is not null or empty
+            if (request == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("BHoM objects could not be read because provided IRequest is null or empty.");
+                return 0;
+            }
+            else if (request is FilterRequest)
+            {
+                FilterRequest filterRequest = (FilterRequest)request;
+                if (filterRequest.Type == null && String.IsNullOrWhiteSpace(filterRequest.Tag) && (filterRequest.Equalities == null || filterRequest.Equalities.Count == 0))
+                {
+                    BH.Engine.Reflection.Compute.RecordError("BHoM objects could not be read because provided IRequest is null or empty.");
+                    return 0;
+                }
+            }
+
             //Initialize Revit config
             RevitRemoveConfig removeConfig = actionConfig as RevitRemoveConfig;
 

--- a/Revit_Engine/Modify/DefaultIfNull.cs
+++ b/Revit_Engine/Modify/DefaultIfNull.cs
@@ -19,12 +19,8 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-using System.IO;
-using System.ComponentModel;
-using System.Collections.Generic;
 
 using BH.oM.Adapters.Revit.Settings;
-using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -39,7 +35,7 @@ namespace BH.Engine.Adapters.Revit
             if (settings == null)
             {
                 BH.Engine.Reflection.Compute.RecordNote("Revit settings are not set. Default settings are used.");
-                return RevitSettings.Default;
+                return new RevitSettings();
             }
 
             return settings;

--- a/Revit_Engine/Modify/DefaultIfNull.cs
+++ b/Revit_Engine/Modify/DefaultIfNull.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Adapters.Revit
         {
             if (settings == null)
             {
-                //BH.Engine.Reflection.Compute.RecordNote("Revit settings are not set. Default settings are used.");
+                BH.Engine.Reflection.Compute.RecordNote("Revit settings are not set. Default settings are used.");
                 return RevitSettings.Default;
             }
 


### PR DESCRIPTION
### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
Depends on [Grasshopper_Toolkit #490](https://github.com/BHoM/Grasshopper_Toolkit/pull/490), but will compile without it (so CI should not complain).

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #597
Closes #611

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
- [#597](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue597%2DRecordNote) to be used with Revit file from [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2F%5FMacro%2FPull%2FRevit%2FRequests)
- [#611](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue611%2DNullRequest)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `RecordNote` calls have been uncommented
- Empty FilterRequest check has been added to `Pull` and `Remove` adapter actions to prevent it from being processed


### Additional comments
<!-- As required -->
This PR should not conflict with #609, but it will be safe to let the latter take priority on merge.