### PR TITLE
Descriptions added to Adapter and oM, AdapterMode deprecated

### DIFF
--- a/Revit_Adapter/RevitAdapter.cs
+++ b/Revit_Adapter/RevitAdapter.cs
@@ -21,18 +21,13 @@
  */
 
 using BH.Adapter.Socket;
-using BH.oM.Base;
-using BH.oM.Data.Requests;
-using BH.oM.Reflection.Debugging;
 using BH.oM.Adapters.Revit.Settings;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using BH.oM.Reflection.Attributes;
+using BH.oM.Reflection.Debugging;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
-using BH.oM.Adapter;
+using System.Threading;
 
 namespace BH.Adapter.Revit
 {
@@ -51,7 +46,7 @@ namespace BH.Adapter.Revit
         /***************************************************/
 
         [Description("Adapter to connect to an open Revit file. Connection will be made to the active document (based on active view). Make sure to only have ONE Revit Window open, or connection will not work as intended.")]
-        [Input("revitSettings", "Connect RevitSettings to control what is being connected")]
+        [Input("revitSettings", "General settings that are applicable to all actions performed by this adapter, e.g. connection settings, tolerances, parameter mapping settings etc.")]
         [Input("active", "Establish connection with Revit by setting to 'True'")]
         [Output("adapter", "Adapter to Revit")]
         public RevitAdapter(RevitSettings revitSettings = null, bool active = false)

--- a/Revit_Engine/Modify/DefaultIfNull.cs
+++ b/Revit_Engine/Modify/DefaultIfNull.cs
@@ -19,12 +19,8 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-using System.IO;
-using System.ComponentModel;
-using System.Collections.Generic;
 
 using BH.oM.Adapters.Revit.Settings;
-using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -38,8 +34,8 @@ namespace BH.Engine.Adapters.Revit
         {
             if (settings == null)
             {
-                //BH.Engine.Reflection.Compute.RecordNote("Revit settings are not set. Default settings are used.");
-                return RevitSettings.Default;
+                BH.Engine.Reflection.Compute.RecordNote("Revit settings are not set. Default settings are used.");
+                return new RevitSettings();
             }
 
             return settings;

--- a/Revit_oM/Elements/DraftingInstance.cs
+++ b/Revit_oM/Elements/DraftingInstance.cs
@@ -35,7 +35,7 @@ namespace BH.oM.Adapters.Revit.Elements
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("Information about family type of the instance, see description of InstanceProperties for more details.")]
+        [Description("Information about family type of the instance.")]
         public InstanceProperties Properties { get; set; } = new InstanceProperties();
 
         [Description("Location of the instance in space.")]

--- a/Revit_oM/Elements/DraftingInstance.cs
+++ b/Revit_oM/Elements/DraftingInstance.cs
@@ -24,19 +24,24 @@ using BH.oM.Adapters.Revit.Interface;
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Base;
 using BH.oM.Geometry;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
+    [Description("A generic wrapper BHoM type corresponding to any view-specific Revit element (drafting elements e.g. lines and hatches, tags, text notes etc.).")]
     public class DraftingInstance : BHoMObject, IInstance 
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("Information about family type of the instance, see description of InstanceProperties for more details.")]
         public InstanceProperties Properties { get; set; } = new InstanceProperties();
 
+        [Description("Location of the instance in space.")]
         public IGeometry Location { get; set; } = new Point();
 
+        [Description("Name of Revit view to which the instance belongs.")]
         public string ViewName { get; set; } = string.Empty;
 
         /***************************************************/

--- a/Revit_oM/Elements/Family.cs
+++ b/Revit_oM/Elements/Family.cs
@@ -27,14 +27,14 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
-    [Description("A wrapper BHoM type for Revit family.")]
+    [Description("A wrapper BHoM type for Revit family used on Pull and Update of Revit families.")]
     public class Family : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("A list of BHoM wrapper objects representing Revit family types.")]
+        [Description("Wrapped Revit family types that belong to the family.")]
         public List<InstanceProperties> PropertiesList { get; set; } = new List<InstanceProperties>();
 
         /***************************************************/

--- a/Revit_oM/Elements/Family.cs
+++ b/Revit_oM/Elements/Family.cs
@@ -23,15 +23,18 @@
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Base;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
+    [Description("A wrapper BHoM type for Revit family.")]
     public class Family : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("A list of BHoM wrapper objects representing Revit family types.")]
         public List<InstanceProperties> PropertiesList { get; set; } = new List<InstanceProperties>();
 
         /***************************************************/

--- a/Revit_oM/Elements/ModelInstance.cs
+++ b/Revit_oM/Elements/ModelInstance.cs
@@ -24,17 +24,21 @@ using BH.oM.Adapters.Revit.Interface;
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Base;
 using BH.oM.Geometry;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
+    [Description("A generic wrapper BHoM type corresponding to any view-independent Revit element (model elements, e.g. duct or beam).")]
     public class ModelInstance : BHoMObject, IInstance
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("Information about family type of the instance, see description of InstanceProperties for more details.")]
         public InstanceProperties Properties { get; set; } = new InstanceProperties();
 
+        [Description("Location of the instance in space.")]
         public IGeometry Location { get; set; } = new Point();
 
         /***************************************************/

--- a/Revit_oM/Elements/ModelInstance.cs
+++ b/Revit_oM/Elements/ModelInstance.cs
@@ -28,14 +28,14 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
-    [Description("A generic wrapper BHoM type corresponding to any view-independent Revit element (model elements, e.g. duct or beam).")]
+    [Description("A generic wrapper BHoM type corresponding to any view-independent Revit element (model elements, e.g. duct or beam). On Push it can be used to generate or update Revit model elements that do not have a correspondent BHoM type, on Pull all Revit model elements that do not have explicit Convert method for given discipline will be converted to ModelInstance.")]
     public class ModelInstance : BHoMObject, IInstance
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("Information about family type of the instance, see description of InstanceProperties for more details.")]
+        [Description("Information about family type of the instance.")]
         public InstanceProperties Properties { get; set; } = new InstanceProperties();
 
         [Description("Location of the instance in space.")]

--- a/Revit_oM/Elements/Sheet.cs
+++ b/Revit_oM/Elements/Sheet.cs
@@ -22,15 +22,18 @@
 
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
+    [Description("A wrapper BHoM type for Revit sheet.")]
     public class Sheet : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("An entity storing the information about Revit sheet type, see description of InstanceProperties for more details.")]
         public InstanceProperties InstanceProperties { get; set; } = new InstanceProperties();
 
         /***************************************************/

--- a/Revit_oM/Elements/Sheet.cs
+++ b/Revit_oM/Elements/Sheet.cs
@@ -26,14 +26,14 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
-    [Description("A wrapper BHoM type for Revit sheet.")]
+    [Description("A wrapper BHoM type for Revit sheet, used to create or update Revit sheets (on Push) and represent them as BHoMObjects (on Pull).")]
     public class Sheet : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("An entity storing the information about Revit sheet type, see description of InstanceProperties for more details.")]
+        [Description("An entity storing the information about Revit sheet type.")]
         public InstanceProperties InstanceProperties { get; set; } = new InstanceProperties();
 
         /***************************************************/

--- a/Revit_oM/Elements/ViewPlan.cs
+++ b/Revit_oM/Elements/ViewPlan.cs
@@ -27,14 +27,14 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
-    [Description("A wrapper BHoM type for Revit plan view.")]
+    [Description("A wrapper BHoM type for Revit plan view, used to create or update Revit plans (on Push) and represent them as BHoMObjects (on Pull).")]
     public class ViewPlan : BHoMObject, IView
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("An entity storing the information about Revit view type, see description of InstanceProperties for more details.")]
+        [Description("An entity storing the information about Revit view type.")]
         public InstanceProperties InstanceProperties { get; set; } = new InstanceProperties();
 
         [Description("Name of Revit level to which the view belongs (Associated Level).")]

--- a/Revit_oM/Elements/ViewPlan.cs
+++ b/Revit_oM/Elements/ViewPlan.cs
@@ -23,19 +23,24 @@
 using BH.oM.Base;
 using BH.oM.Adapters.Revit.Interface;
 using BH.oM.Adapters.Revit.Properties;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
+    [Description("A wrapper BHoM type for Revit plan view.")]
     public class ViewPlan : BHoMObject, IView
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("An entity storing the information about Revit view type, see description of InstanceProperties for more details.")]
         public InstanceProperties InstanceProperties { get; set; } = new InstanceProperties();
 
+        [Description("Name of Revit level to which the view belongs (Associated Level).")]
         public string LevelName { get; set; } = string.Empty;
 
+        [Description("If true, the object represents a Revit view template, if false, the object represents an actual Revit view.")]
         public bool IsTemplate { get; set; } = false;
 
         /***************************************************/

--- a/Revit_oM/Elements/Viewport.cs
+++ b/Revit_oM/Elements/Viewport.cs
@@ -27,14 +27,14 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
-    [Description("A wrapper BHoM type for Revit viewport.")]
+    [Description("A wrapper BHoM type for Revit viewport, used to create or update Revit viewports (on Push) and represent them as BHoMObjects (on Pull).")]
     public class Viewport : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("An entity storing the information about Revit viewport type, see description of InstanceProperties for more details.")]
+        [Description("An entity storing the information about Revit viewport type.")]
         public InstanceProperties InstanceProperties { get; set; } = new InstanceProperties();
 
         [Description("Location of the viewport in Revit sheet space.")]

--- a/Revit_oM/Elements/Viewport.cs
+++ b/Revit_oM/Elements/Viewport.cs
@@ -23,18 +23,22 @@
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Base;
 using BH.oM.Geometry;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Elements
 {
+    [Description("A wrapper BHoM type for Revit viewport.")]
     public class Viewport : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("An entity storing the information about Revit viewport type, see description of InstanceProperties for more details.")]
         public InstanceProperties InstanceProperties { get; set; } = new InstanceProperties();
 
-        public Point Location { get; set; } = new Point() { X =0, Y = 0, Z = 0 };
+        [Description("Location of the viewport in Revit sheet space.")]
+        public Point Location { get; set; } = new Point() { X = 0, Y = 0, Z = 0 };
 
         /***************************************************/
     }

--- a/Revit_oM/Enums/AdapterMode.cs
+++ b/Revit_oM/Enums/AdapterMode.cs
@@ -20,12 +20,24 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+
 namespace BH.oM.Adapters.Revit.Enums
 {
+    /***************************************************/
+
+    [Deprecated("3.1", "BH.oM.Adapters.Revit.Enums.AdapterMode enum is not used any more.")]
+    [Description("Enumerator defining the adapter Push mode.")]
     public enum AdapterMode
     {
+        [Description("Delete elements from Revit document.")]
         Delete,
+        [Description("Delete and recreate elements in Revit document.")]
         Replace,
+        [Description("Update elements in Revit document.")]
         Update,
     }
+
+    /***************************************************/
 }

--- a/Revit_oM/Enums/Discipline.cs
+++ b/Revit_oM/Enums/Discipline.cs
@@ -20,14 +20,26 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System.ComponentModel;
+
 namespace BH.oM.Adapters.Revit.Enums
 {
+    /***************************************************/
+
+    [Description("Enumerator allowing choosing to which discipline (and corresponding namespace) should Revit elements be converted on pull.")]
     public enum Discipline
     {
+        [Description("Default discipline to be used.")]
         Undefined,
+        [Description("Elements to be converted to types from BH.oM.Environment. If no suitable conversion exists, default discipline to be used.")]
         Environmental,
+        [Description("Elements to be converted to types from BH.oM.Structure. If no suitable conversion exists, default discipline to be used.")]
         Structural,
+        [Description("Elements to be converted to types from BH.oM.Architecture. If no suitable conversion exists, default discipline to be used.")]
         Architecture,
+        [Description("Elements to be converted to types from BH.oM.Physical. If no suitable conversion exists, default discipline to be used.")]
         Physical,
     }
+
+    /***************************************************/
 }

--- a/Revit_oM/Enums/NumberComparisonType.cs
+++ b/Revit_oM/Enums/NumberComparisonType.cs
@@ -20,17 +20,29 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System.ComponentModel;
+
 namespace BH.oM.Adapters.Revit.Enums
 {
+    /***************************************************/
 
+    [Description("Enumerator defining the way in which two numbers are compared.")]
     public enum NumberComparisonType
     {
+        [Description("Check if input number and reference number are equal.")]
         Equal,
+        [Description("Check if input number and reference number are not equal.")]
         NotEqual,
+        [Description("Check if input number is greater than reference number.")]
         Greater,
+        [Description("Check if input number is smaller than reference number.")]
         Less,
+        [Description("Check if input number is smaller than or equal to reference number.")]
         LessOrEqual,
+        [Description("Check if input number is greater than or equal to reference number.")]
         GreaterOrEqual,
     }
+
+    /***************************************************/
 }
 

--- a/Revit_oM/Enums/RevitViewType.cs
+++ b/Revit_oM/Enums/RevitViewType.cs
@@ -20,113 +20,66 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System.ComponentModel;
+
 namespace BH.oM.Adapters.Revit.Enums
 {
+    /***************************************************/
 
+    [Description("Enumerator defining view type of Revit view. A clone of Autodesk.Revit.DB.ViewType enum.")]
     public enum RevitViewType
     {
-        //
-        // Summary:
-        //     Undefined/unspecified type of view.
+        [Description("Undefined/unspecified type of view.")]
         Undefined = 0,
-        //
-        // Summary:
-        //     Floor plan type of view.
+        [Description("Floor plan type of view.")]
         FloorPlan = 1,
-        //
-        // Summary:
-        //     Reflected ceiling plan type of view.
+        [Description("Reflected ceiling plan type of view.")]
         CeilingPlan = 2,
-        //
-        // Summary:
-        //     Elevation type of view.
+        [Description("Elevation type of view.")]
         Elevation = 3,
-        //
-        // Summary:
-        //     3-D type of view.
+        [Description("3-D type of view.")]
         ThreeD = 4,
-        //
-        // Summary:
-        //     Schedule type of view.
+        [Description("Schedule type of view.")]
         Schedule = 5,
-        //
-        // Summary:
-        //     Drawing sheet type of view.
+        [Description("Drawing sheet type of view.")]
         DrawingSheet = 6,
-        //
-        // Summary:
-        //     The project browser view.
+        [Description("The project browser view.")]
         ProjectBrowser = 7,
-        //
-        // Summary:
-        //     Report type of view.
+        [Description("Report type of view.")]
         Report = 8,
-        //
-        // Summary:
-        //     Drafting type of view.
+        [Description("Drafting type of view.")]
         DraftingView = 10,
-        //
-        // Summary:
-        //     Legend type of view.
+        [Description("Legend type of view.")]
         Legend = 11,
-        //
-        // Summary:
-        //     The MEP system browser view.
+        [Description("The MEP system browser view.")]
         SystemBrowser = 12,
-        //
-        // Summary:
-        //     Structural plan or Engineering plan type of view.
+        [Description("Structural plan or Engineering plan type of view.")]
         EngineeringPlan = 115,
-        //
-        // Summary:
-        //     Area plan type of view.
+        [Description("Area plan type of view.")]
         AreaPlan = 116,
-        //
-        // Summary:
-        //     Cross section type of view.
+        [Description("Cross section type of view.")]
         Section = 117,
-        //
-        // Summary:
-        //     Detail type of view.
+        [Description("Detail type of view.")]
         Detail = 118,
-        //
-        // Summary:
-        //     Cost Report view.
+        [Description("Cost Report view.")]
         CostReport = 119,
-        //
-        // Summary:
-        //     Loads Report view.
+        [Description("Loads Report view.")]
         LoadsReport = 120,
-        //
-        // Summary:
-        //     Pressure Loss Report view.
+        [Description("Pressure Loss Report view.")]
         PresureLossReport = 121,
-        //
-        // Summary:
-        //     Column Schedule type of view.
+        [Description("Column Schedule type of view.")]
         ColumnSchedule = 122,
-        //
-        // Summary:
-        //     Panel Schedule Report view.
+        [Description("Panel Schedule Report view.")]
         PanelSchedule = 123,
-        //
-        // Summary:
-        //     Walk-Through type of 3D view.
+        [Description("Walk-Through type of 3D view.")]
         Walkthrough = 124,
-        //
-        // Summary:
-        //     Rendering type of view.
+        [Description("Rendering type of view.")]
         Rendering = 125,
-        //
-        // Summary:
-        //     Systems analysis report view.
+        [Description("Systems analysis report view.")]
         SystemsAnalysisReport = 126,
-        //
-        // Summary:
-        //     Revit's internal type of view
-        //
-        // Remarks:
-        //     Internal views are not available to API users
+        [Description("Revit's internal type of view.")]
         Internal = 214
     }
+
+    /***************************************************/
 }

--- a/Revit_oM/Enums/TextComparisonType.cs
+++ b/Revit_oM/Enums/TextComparisonType.cs
@@ -20,15 +20,28 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System.ComponentModel;
+
 namespace BH.oM.Adapters.Revit.Enums
 {
+    /***************************************************/
+
+    [Description("Enumerator defining the way in which two strings are compared.")]
     public enum TextComparisonType
     {
+        [Description("Check if input string and reference string are the same.")]
         Equal,
+        [Description("Check if input string and reference string are different.")]
         NotEqual,
+        [Description("Check if the input input string contains reference string.")]
         Contains,
+        [Description("Check if the input input string does not contain reference string.")]
         ContainsNot,
+        [Description("Check if the input input string starts with reference string.")]
         StartsWith,
+        [Description("Check if the input input string ends with reference string.")]
         EndsWith,
     }
+
+    /***************************************************/
 }

--- a/Revit_oM/Generic/FamilyLibrary.cs
+++ b/Revit_oM/Generic/FamilyLibrary.cs
@@ -26,14 +26,13 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Generic
 {
-    [Description("Library of Revit families that can be loaded to the model. Limited functionality at the moment.")]
+    [Description("Library of Revit families that can be loaded to the model. Prototype, currently with limited functionality.")]
     public class FamilyLibrary : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
-
-        [Description("Dictionary.")]
+        
         public Dictionary<string, Dictionary<string, Dictionary<string, string>>> Dictionary { get; set; } = null;
 
         /***************************************************/

--- a/Revit_oM/Generic/FamilyLibrary.cs
+++ b/Revit_oM/Generic/FamilyLibrary.cs
@@ -22,15 +22,18 @@
 
 using System.Collections.Generic;
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Generic
 {
+    [Description("Library of Revit families that can be loaded to the model. Limited functionality at the moment.")]
     public class FamilyLibrary : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("Dictionary.")]
         public Dictionary<string, Dictionary<string, Dictionary<string, string>>> Dictionary { get; set; } = null;
 
         /***************************************************/

--- a/Revit_oM/Generic/RevitFilePreview.cs
+++ b/Revit_oM/Generic/RevitFilePreview.cs
@@ -21,15 +21,18 @@
  */
 
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Generic
 {
+    [Description("Wrapper for Revit family file that allows processing it with BHoM. Limited functionality at the moment.")]
     public class RevitFilePreview : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("Path to the Revit family file wrapped by this object.")]
         public string Path { get; set; } = null;
 
         /***************************************************/

--- a/Revit_oM/Generic/RevitFilePreview.cs
+++ b/Revit_oM/Generic/RevitFilePreview.cs
@@ -25,7 +25,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Generic
 {
-    [Description("Wrapper for Revit family file that allows processing it with BHoM. Limited functionality at the moment.")]
+    [Description("Wrapper for Revit family file that allows processing it with BHoM. Prototype, currently with limited functionality.")]
     public class RevitFilePreview : BHoMObject
     {
         /***************************************************/

--- a/Revit_oM/Generic/TypeMap.cs
+++ b/Revit_oM/Generic/TypeMap.cs
@@ -34,7 +34,7 @@ namespace BH.oM.Adapters.Revit.Generic
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("BHoM type being, which property names are being mapped with Revit element parameters.")]
+        [Description("BHoM type, which property names are being mapped with Revit element parameters.")]
         public Type Type { get; set; } = null;
 
         [Description("A collection of BHoM type property names and sets of their correspondent Revit parameter names.")]

--- a/Revit_oM/Generic/TypeMap.cs
+++ b/Revit_oM/Generic/TypeMap.cs
@@ -20,20 +20,24 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
-
-using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Generic
 {
+    [Description("An entity defining the relationship between property names of BHoM type and parameter names of correspondent Revit elements.")]
     public class TypeMap : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("BHoM type being, which property names are being mapped with Revit element parameters.")]
         public Type Type { get; set; } = null;
+
+        [Description("A collection of BHoM type property names and sets of their correspondent Revit parameter names.")]
         public Dictionary<string, HashSet<string>> Map = new Dictionary<string, HashSet<string>>();
 
         /***************************************************/

--- a/Revit_oM/Interface/IInstance.cs
+++ b/Revit_oM/Interface/IInstance.cs
@@ -27,14 +27,14 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Interface
 {
-    [Description("A generic wrapper BHoM interface corresponding to any Revit element.")]
+    [Description("A base interface for BHoM wrapper classes that can wrap Revit elements.")]
     public interface IInstance : IBHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("Information about family type of the instance, see description of InstanceProperties for more details.")]
+        [Description("Information about family type of the instance.")]
         InstanceProperties Properties { get; set; }
 
         [Description("Location of the instance in space.")]

--- a/Revit_oM/Interface/IInstance.cs
+++ b/Revit_oM/Interface/IInstance.cs
@@ -23,17 +23,21 @@
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Base;
 using BH.oM.Geometry;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Interface
 {
+    [Description("A generic wrapper BHoM interface corresponding to any Revit element.")]
     public interface IInstance : IBHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("Information about family type of the instance, see description of InstanceProperties for more details.")]
         InstanceProperties Properties { get; set; }
 
+        [Description("Location of the instance in space.")]
         IGeometry Location { get; set; }
 
         /***************************************************/

--- a/Revit_oM/Interface/IParameterRequest.cs
+++ b/Revit_oM/Interface/IParameterRequest.cs
@@ -20,12 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Adapters.Revit.Properties;
-using BH.oM.Base;
 using BH.oM.Data.Requests;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Interface
 {
+    [Description("Interface for types that filter elements based on parameter value criterion.")]
     public interface IParameterRequest : IRequest
     {
         /***************************************************/

--- a/Revit_oM/Interface/IParameterRequest.cs
+++ b/Revit_oM/Interface/IParameterRequest.cs
@@ -25,7 +25,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Interface
 {
-    [Description("Interface for types that filter elements based on parameter value criterion.")]
+    [Description("Interface for Requests that filter elements based on parameter value criterion.")]
     public interface IParameterRequest : IRequest
     {
         /***************************************************/

--- a/Revit_oM/Interface/IView.cs
+++ b/Revit_oM/Interface/IView.cs
@@ -22,17 +22,21 @@
 
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Interface
 {
+    [Description("A wrapper BHoM interface for any Revit view.")]
     public interface IView : IBHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("An entity storing the information about Revit view type, see description of InstanceProperties for more details.")]
         InstanceProperties InstanceProperties { get; set; }
 
+        [Description("If true, the object represents a Revit view template, if false, the object represents an actual Revit view.")]
         bool IsTemplate { get; set; }
 
         /***************************************************/

--- a/Revit_oM/Interface/IView.cs
+++ b/Revit_oM/Interface/IView.cs
@@ -26,14 +26,14 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Interface
 {
-    [Description("A wrapper BHoM interface for any Revit view.")]
+    [Description("A base interface for BHoM wrapper classes that can wrap Revit views.")]
     public interface IView : IBHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("An entity storing the information about Revit view type, see description of InstanceProperties for more details.")]
+        [Description("An entity storing the information about Revit view type.")]
         InstanceProperties InstanceProperties { get; set; }
 
         [Description("If true, the object represents a Revit view template, if false, the object represents an actual Revit view.")]

--- a/Revit_oM/Properties/InstanceProperties.cs
+++ b/Revit_oM/Properties/InstanceProperties.cs
@@ -21,14 +21,18 @@
  */
 
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Properties
 {
+    [Description("A generic wrapper BHoM type corresponding to any Revit family type. Name of InstanceProperties corresponds to family type name, type parameter values are stored in CustomData under corresponding keys.")]
     public class InstanceProperties : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
+
+
 
         /***************************************************/
     }

--- a/Revit_oM/Revit_oM.csproj
+++ b/Revit_oM/Revit_oM.csproj
@@ -53,6 +53,10 @@
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Quantities_oM">
+      <HintPath>..\..\BHoM\Build\Quantities_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Reflection_oM">
       <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
       <Private>False</Private>

--- a/Revit_oM/Revit_oM.csproj
+++ b/Revit_oM/Revit_oM.csproj
@@ -53,6 +53,10 @@
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Reflection_oM">
+      <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Revit_oM/Settings/ConnectionSettings.cs
+++ b/Revit_oM/Settings/ConnectionSettings.cs
@@ -22,17 +22,24 @@
 
 
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Settings
 {
+    [Description("Socket connection settings for Revit Adapter.")]
     public class ConnectionSettings : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("Socket push port - this value needs to be equal to push port set in Revit Listener located in Add-Ins tab of Revit ribbon.")]
         public int PushPort { get; set; } = 14128;
+
+        [Description("Socket pull port - this value needs to be equal to pull port set in Revit Listener located in Add-Ins tab of Revit ribbon.")]
         public int PullPort { get; set; } = 14129;
+
+        [Description("Maximum number of minutes per adapter action, after which the adapter will automatically stop exchanging data with Revit. Increase this number if push/pull action is expected to take longer.")]
         public int MaxMinutesToWait { get; set; } = 10;
 
         /***************************************************/

--- a/Revit_oM/Settings/FamilyLoadSettings.cs
+++ b/Revit_oM/Settings/FamilyLoadSettings.cs
@@ -22,17 +22,24 @@
 
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Settings
 {
+    [Description("Revit family load settings for Revit Adapter. Limited functionality at the moment.")]
     public class FamilyLoadSettings : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("Library of Revit families that can be loaded to the model.")]
         public FamilyLibrary FamilyLibrary { get; set; } = new FamilyLibrary();
+
+        [Description("If true, Revit family will be overwritten on load, if false it will not be changed.")]
         public bool OverwriteFamily { get; set; } = true;
+
+        [Description("If true, Revit family parameters will be overwritten on load, if false they will not be changed.")]
         public bool OverwriteParameterValues { get; set; } = true;
 
         /***************************************************/

--- a/Revit_oM/Settings/FamilyLoadSettings.cs
+++ b/Revit_oM/Settings/FamilyLoadSettings.cs
@@ -26,7 +26,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Settings
 {
-    [Description("Revit family load settings for Revit Adapter. Limited functionality at the moment.")]
+    [Description("Revit family load settings for Revit Adapter. Prototype, currently with limited functionality.")]
     public class FamilyLoadSettings : BHoMObject
     {
         /***************************************************/

--- a/Revit_oM/Settings/MapSettings.cs
+++ b/Revit_oM/Settings/MapSettings.cs
@@ -20,19 +20,21 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Collections.Generic;
-
-using BH.oM.Base;
 using BH.oM.Adapters.Revit.Generic;
+using BH.oM.Base;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Settings
 {
+    [Description("A collection of relationships between property names of BHoM types and parameter names of correspondent Revit elements.")]
     public class MapSettings : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("A list of entities defining relationships between property names of BHoM types and parameter names of correspondent Revit elements.")]
         public List<TypeMap> TypeMaps { get; set; } = new List<TypeMap>();
 
         /***************************************************/

--- a/Revit_oM/Settings/RevitSettings.cs
+++ b/Revit_oM/Settings/RevitSettings.cs
@@ -26,31 +26,31 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Settings
 {
+    [Description("General settings that are applicable to all actions performed by the instance of Revit adapter.")]
     public class RevitSettings : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
 
+        [Description("Socket connection settings.")]
         public ConnectionSettings ConnectionSettings { get; set; } = new ConnectionSettings();
-        public FamilyLoadSettings FamilyLoadSettings { get; set; } = new FamilyLoadSettings();
-        public MapSettings MapSettings { get; set; } = new MapSettings();
 
-        //TODO: move this to MapSettings
+        [Description("Revit family load settings. Limited functionality at the moment.")]
+        public FamilyLoadSettings FamilyLoadSettings { get; set; } = new FamilyLoadSettings();
+
+        [Description("A collection of relationships between property names of BHoM types and parameter names of correspondent Revit elements.")]
+        public MapSettings MapSettings { get; set; } = new MapSettings();
+        
+        [Description("Name of Revit parameter to be used to store BHoM tags.")]
         public string TagsParameterName { get; set; } = "BHE_Tags";
 
+        [Description("Distance tolerance to be used in geometry processing.")]
         public double DistanceTolerance { get; set; } = BH.oM.Geometry.Tolerance.Distance;
 
+        [Description("Angle tolerance to be used in geometry processing.")]
         public double AngleTolerance { get; set; } = BH.oM.Geometry.Tolerance.Angle;
-
-
-        /***************************************************/
-        /****                  Default                  ****/
-        /***************************************************/
-
-        [Description("Default settings, used if not set by the user.")]
-        public static readonly RevitSettings Default = new RevitSettings();
-
+        
         /***************************************************/
     }
 }

--- a/Revit_oM/Settings/RevitSettings.cs
+++ b/Revit_oM/Settings/RevitSettings.cs
@@ -22,6 +22,7 @@
 
 
 using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
 using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Settings
@@ -32,22 +33,21 @@ namespace BH.oM.Adapters.Revit.Settings
         /***************************************************/
         /****             Public Properties             ****/
         /***************************************************/
-
-        [Description("Socket connection settings.")]
+        
         public ConnectionSettings ConnectionSettings { get; set; } = new ConnectionSettings();
-
-        [Description("Revit family load settings. Limited functionality at the moment.")]
+        
         public FamilyLoadSettings FamilyLoadSettings { get; set; } = new FamilyLoadSettings();
-
-        [Description("A collection of relationships between property names of BHoM types and parameter names of correspondent Revit elements.")]
+        
         public MapSettings MapSettings { get; set; } = new MapSettings();
         
         [Description("Name of Revit parameter to be used to store BHoM tags.")]
         public string TagsParameterName { get; set; } = "BHE_Tags";
 
+        [Length]
         [Description("Distance tolerance to be used in geometry processing.")]
         public double DistanceTolerance { get; set; } = BH.oM.Geometry.Tolerance.Distance;
 
+        [Angle]
         [Description("Angle tolerance to be used in geometry processing.")]
         public double AngleTolerance { get; set; } = BH.oM.Geometry.Tolerance.Angle;
         


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #613
First part o #595, the rest will follow on Monday.

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- missing descriptions have been added to Revit_oM and Revit_Adapter
- legacy `BH.oM.Adapters.Revit.Enums.AdapterMode` has been deprecated


### Additional comments
<!-- As required -->
There is one conflict with #612, but same changes have been made to the file on both branches, so I believe it will be fine.