### PR TITLE
Revit_Engine: Compute and Create descriptions added and Create.BHoMObject deprecated

### DIFF
--- a/Revit_Engine/Compute/SortByPerformance.cs
+++ b/Revit_Engine/Compute/SortByPerformance.cs
@@ -21,11 +21,10 @@
  */
 
 using BH.oM.Adapters.Revit.Interface;
-using BH.oM.Adapters.Revit;
-using BH.oM.Base;
-using BH.oM.Reflection.Attributes;
 using BH.oM.Data.Requests;
+using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -35,6 +34,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public Methods               ****/
         /***************************************************/
 
+        [Description("Groups and sorts IRequests by their estimated execution time in order to execute fastest first. Order from slowest to fastest: IParameterRequest, IlogicalRequests, others. ")]
+        [Input("requests", "A collection of IRequests to be sorted.")]
+        [Output("sortedRequests")]
         public static List<IRequest> SortByPerformance(this List<IRequest> requests)
         {
             List<IRequest> allRequests = new List<IRequest>();

--- a/Revit_Engine/Create/Config/RevitPullConfig.cs
+++ b/Revit_Engine/Create/Config/RevitPullConfig.cs
@@ -34,11 +34,11 @@ namespace BH.Engine.Adapters.Revit
         /***************************************************/
 
         [Description("Creates a pull action-specific configuration used for adapter interaction with Revit.")]
-        [Input("discipline", "Discipline used on push/pull action. Default is Physical.")]
-        [Input("includeClosedWorksets", "Elements from closed worksets will be processed if true.")]
-        [Input("pullEdges", "If true, edges of elements will be pulled and stored under Revit_edges in CustomData.")]
-        [Input("includeNonVisible", "Invisible element edges will be pulled and passed to CustomData if true. PullEdges switched to true needed for this to activate.")]
-        [Output("RevitPullConfig")]
+        [InputFromProperty("discipline")]
+        [InputFromProperty("includeClosedWorksets")]
+        [InputFromProperty("pullEdges")]
+        [InputFromProperty("includeNonVisible")]
+        [Output("revitPullConfig")]
         public static RevitPullConfig RevitPullConfig(Discipline discipline = Discipline.Undefined, bool includeClosedWorksets = false, bool pullEdges = false, bool includeNonVisible = false)
         {
             return new RevitPullConfig { Discipline = discipline, IncludeClosedWorksets = includeClosedWorksets, PullEdges = pullEdges, IncludeNonVisible = includeNonVisible };

--- a/Revit_Engine/Create/Config/RevitPushConfig.cs
+++ b/Revit_Engine/Create/Config/RevitPushConfig.cs
@@ -33,9 +33,9 @@ namespace BH.Engine.Adapters.Revit
         /***************************************************/
 
         [Description("Creates a push action-specific configuration used for adapter interaction with Revit.")]
-        [Input("suppressFailureMessages", "If true, Revit warnings and failure messages will be suppressed (not shown to the user). Whilst this option may speed the pushing process up in case of multiple warnings, it may lead to important issues.")]
-        [Input("includeClosedWorksets", "Elements from closed worksets will be processed if true.")]
-        [Output("RevitPushConfig")]
+        [InputFromProperty("suppressFailureMessages")]
+        [InputFromProperty("includeClosedWorksets")]
+        [Output("revitPushConfig")]
         public static RevitPushConfig RevitPushConfig(bool suppressFailureMessages = false, bool includeClosedWorksets = false)
         {
             return new RevitPushConfig { SuppressFailureMessages = suppressFailureMessages, IncludeClosedWorksets = includeClosedWorksets };

--- a/Revit_Engine/Create/Config/RevitRemoveConfig.cs
+++ b/Revit_Engine/Create/Config/RevitRemoveConfig.cs
@@ -32,11 +32,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates a pull action-specific configuration used for adapter interaction with Revit.")]
-        [Input("suppressFailureMessages", "If true, Revit warnings and failure messages will be suppressed (not shown to the user). Whilst this option may speed the pushing process up in case of multiple warnings, it may lead to important issues.")]
-        [Input("includeClosedWorksets", "Elements from closed worksets will be processed if true.")]
-        [Input("removePinned", "Pinned elements will be processed if true.")]
-        [Output("RevitRemoveConfig")]
+        [Description("Creates a remove action-specific configuration used for adapter interaction with Revit.")]
+        [InputFromProperty("suppressFailureMessages")]
+        [InputFromProperty("includeClosedWorksets")]
+        [InputFromProperty("removePinned")]
+        [Output("revitRemoveConfig")]
         public static RevitRemoveConfig RevitRemoveConfig(bool suppressFailureMessages = false, bool includeClosedWorksets = false, bool removePinned = false)
         {
             return new RevitRemoveConfig { SuppressFailureMessages = suppressFailureMessages, IncludeClosedWorksets = includeClosedWorksets, RemovePinned = removePinned };

--- a/Revit_Engine/Create/Elements/BHoMObject.cs
+++ b/Revit_Engine/Create/Elements/BHoMObject.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "BH.Engine.Adapters.Revit.Create.BHoMObject is not used any more.")]
         [Description("Creates BHoMObject by given Revit ElementId (Element.Id). Allows to pull parameters from any element from Revit")]
         [Input("elementId", "Integer value for Revit ElementId")]
         [Output("BHoMObject")]
@@ -47,6 +47,7 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Deprecated("3.1", "BH.Engine.Adapters.Revit.Create.BHoMObject is not used any more.")]
         [Description("Creates BHoMObject by given Revit UniqueId (Element.UniqueId). Allows to pull parameters from any element from Revit")]
         [Input("uniqueId", "String value for Revit UniqueId")]
         [Output("BHoMObject")]

--- a/Revit_Engine/Create/Elements/DraftingInstance.cs
+++ b/Revit_Engine/Create/Elements/DraftingInstance.cs
@@ -20,15 +20,14 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-using System;
-
+using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
-using BH.oM.Adapters.Revit.Properties;
-using BH.Engine.Geometry;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace BH.Engine.Adapters.Revit
@@ -39,12 +38,12 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates DraftingInstance by given Family Name, Type Name, Location and View Name. Drafting Instance defines all view specific 2D elements")]
-        [Input("familyName", "Revit Family Name")]
-        [Input("familyTypeName", "Revit Family Type Name")]
-        [Input("location", "Location of DraftingObject on View")]
-        [Input("viewName", "View assigned to DraftingInstance")]
-        [Output("DraftingInstance")]
+        [Description("Creates DraftingInstance object based on point location, Revit family name and family type name. Such DraftingInstance can be pushed to Revit as a point-driven drafting element.")]
+        [Input("familyName", "Name of Revit family to be used when creating the element.")]
+        [Input("familyTypeName", "Name of Revit family type to be used when creating the element.")]
+        [InputFromProperty("viewName")]
+        [InputFromProperty("location")]
+        [Output("draftingInstance")]
         public static DraftingInstance DraftingInstance(string familyName, string familyTypeName, string viewName, Point location)
         {
             if (string.IsNullOrWhiteSpace(familyName) || string.IsNullOrWhiteSpace(familyTypeName) || string.IsNullOrWhiteSpace(viewName) || location == null)
@@ -55,11 +54,11 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates DraftingInstance on specific view by properties and location. Drafting Instance defines all view specific 2D elements")]
-        [Input("properties", "InstanceProperties of Instance")]
-        [Input("location", "Location of DraftingObject on View")]
-        [Input("viewName", "View assigned to DraftingInstance")]
-        [Output("DraftingInstance")]
+        [Description("Creates DraftingInstance object based on point location and BHoM InstanceProperties. Such DraftingInstance can be pushed to Revit as a point-driven drafting element.")]
+        [InputFromProperty("properties")]
+        [InputFromProperty("viewName")]
+        [InputFromProperty("location")]
+        [Output("draftingInstance")]
         public static DraftingInstance DraftingInstance(InstanceProperties properties, string viewName, Point location)
         {
             if (properties == null || string.IsNullOrWhiteSpace(viewName) || location == null)
@@ -78,11 +77,11 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates DraftingInstance on specific view by properties and location. Drafting Instance defines all view specific 2D elements")]
-        [Input("properties", "InstanceProperties of Instance")]
-        [Input("location", "Location of DraftingObject on View")]
-        [Input("viewName", "View assigned to DraftingInstance")]
-        [Output("DraftingInstance")]
+        [Description("Creates DraftingInstance object based on curve location and BHoM InstanceProperties. Such DraftingInstance can be pushed to Revit as a detail line.")]
+        [InputFromProperty("properties")]
+        [InputFromProperty("viewName")]
+        [InputFromProperty("location")]
+        [Output("draftingInstance")]
         public static DraftingInstance DraftingInstance(InstanceProperties properties, string viewName, ICurve location)
         {
             if (properties == null || string.IsNullOrWhiteSpace(viewName) || location == null)
@@ -101,10 +100,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates DraftingInstance. Drafting Instance defines all view specific 2D elements")]
-        [Input("location", "Location of DraftingObject on View")]
-        [Input("viewName", "View assigned to DraftingInstance")]
-        [Output("DraftingInstance")]
+        [Description("Creates DraftingInstance object based on curve location. Such DraftingInstance can be pushed to Revit as a detail line with default graphic style.")]
+        [InputFromProperty("viewName")]
+        [InputFromProperty("location")]
+        [Output("draftingInstance")]
         public static DraftingInstance DraftingInstance(string viewName, ICurve location)
         {
             if (string.IsNullOrWhiteSpace(viewName) || location == null)
@@ -127,11 +126,11 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates DraftingInstance. Drafting Instance defines all view specific 2D elements")]
-        [Input("name", "InstanceProperties name")]
-        [Input("location", "Location of DraftingObject on View")]
-        [Input("viewName", "View assigned to DraftingInstance")]
-        [Output("DraftingInstance")]
+        [Description("Creates DraftingInstance object based on curve location and graphic style name. Such DraftingInstance can be pushed to Revit as a detail line.")]
+        [Input("name", "Name of Revit graphic style to be used to create the element on Push.")]
+        [InputFromProperty("viewName")]
+        [InputFromProperty("location")]
+        [Output("draftingInstance")]
         public static DraftingInstance DraftingInstance(string name, string viewName, ICurve location)
         {
             if (string.IsNullOrWhiteSpace(viewName) || location == null)
@@ -155,6 +154,12 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Description("Creates DraftingInstance object based on curve location, Revit family name and family type name. Such DraftingInstance can be pushed to Revit as a view specific, curve-driven element, e.g. load line.")]
+        [Input("familyName", "Name of Revit family to be used when creating the element.")]
+        [Input("familyTypeName", "Name of Revit family type to be used when creating the element.")]
+        [InputFromProperty("viewName")]
+        [InputFromProperty("location")]
+        [Output("draftingInstance")]
         public static DraftingInstance DraftingInstance(string familyName, string familyTypeName, string viewName, ICurve location)
         {
             if (string.IsNullOrWhiteSpace(familyName) || string.IsNullOrWhiteSpace(familyTypeName) || string.IsNullOrWhiteSpace(viewName) || location == null)
@@ -165,6 +170,11 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Description("Creates DraftingInstance object based on surface location and Revit filled region type name. Such DraftingInstance can be pushed to Revit as a filled region.")]
+        [Input("name", "Name of Revit filled region type to be used when creating the element.")]
+        [InputFromProperty("viewName")]
+        [InputFromProperty("location")]
+        [Output("draftingInstance")]
         public static DraftingInstance DraftingInstance(string name, string viewName, ISurface location)
         {
             InstanceProperties instanceProperties = new InstanceProperties();
@@ -175,6 +185,11 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Description("Creates DraftingInstance object based on surface location and BHoM InstanceProperties. Such DraftingInstance can be pushed to Revit as a filled region.")]
+        [InputFromProperty("properties")]
+        [InputFromProperty("viewName")]
+        [InputFromProperty("location")]
+        [Output("draftingInstance")]
         public static DraftingInstance DraftingInstance(InstanceProperties properties, string viewName, ISurface location)
         {
             if (properties == null || string.IsNullOrWhiteSpace(viewName))
@@ -220,6 +235,7 @@ namespace BH.Engine.Adapters.Revit
 
             return draftingInstance;
         }
+
 
         /***************************************************/
         /****            Deprecated methods             ****/

--- a/Revit_Engine/Create/Elements/ModelInstance.cs
+++ b/Revit_Engine/Create/Elements/ModelInstance.cs
@@ -20,12 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
-using BH.oM.Adapters.Revit.Properties;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -35,11 +34,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates ModelInstance by given Point, Family Name and Family Type Name. ModelInstance represents generic 3D elements which have not been defined in BHoM structure")]
-        [Input("location", "Location Point of Object in 3D space")]
-        [Input("familyName", "Revit Family Name")]
-        [Input("familyTypeName", "Revit Family Type Name")]
-        [Output("ModelInstance")]
+        [Description("Creates ModelInstance object based on point location, Revit family name and family type name. Such ModelInstance can be pushed to Revit as a point-driven element, e.g. chair.")]
+        [Input("familyName", "Name of Revit family to be used when creating the element.")]
+        [Input("familyTypeName", "Name of Revit family type to be used when creating the element.")]
+        [InputFromProperty("location")]
+        [Output("modelInstance")]
         public static ModelInstance ModelInstance(string familyName, string familyTypeName, Point location)
         {
             if (location == null || string.IsNullOrWhiteSpace(familyTypeName) || string.IsNullOrWhiteSpace(familyName))
@@ -50,11 +49,11 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates ModelInstance by given Point, Family Name and Family Type Name. ModelInstance represents generic 3D elements which have not been defined in BHoM structure")]
-        [Input("location", "Location Curve of Object in 3D space")]
-        [Input("familyName", "Revit Family Name")]
-        [Input("familyTypeName", "Revit Family Type Name")]
-        [Output("ModelInstance")]
+        [Description("Creates ModelInstance object based on curve location, Revit family name and family type name. Such ModelInstance can be pushed to Revit as a curve-driven element, e.g. duct.")]
+        [Input("familyName", "Name of Revit family to be used when creating the element.")]
+        [Input("familyTypeName", "Name of Revit family type to be used when creating the element.")]
+        [InputFromProperty("location")]
+        [Output("modelInstance")]
         public static ModelInstance ModelInstance(string familyName, string familyTypeName, ICurve location)
         {
             if (location == null || string.IsNullOrWhiteSpace(familyTypeName) || string.IsNullOrWhiteSpace(familyName))
@@ -65,10 +64,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates ModelInstance by given Point, Family Name and Family Type Name. ModelInstance represents generic 3D elements which have not been defined in BHoM structure")]
-        [Input("location", "Location Point of Object in 3D space")]
-        [Input("properties", "InstanceProperties of Instance")]
-        [Output("ModelInstance")]
+        [Description("Creates ModelInstance object based on point location and BHoM InstanceProperties. Such ModelInstance can be pushed to Revit as a point-driven element, e.g. chair.")]
+        [InputFromProperty("properties")]
+        [InputFromProperty("location")]
+        [Output("modelInstance")]
         public static ModelInstance ModelInstance(InstanceProperties properties, Point location)
         {
             if (properties == null || location == null)
@@ -86,10 +85,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates ModelInstance by given Point, Family Name and Family Type Name. ModelInstance represents generic 3D elements which have not been defined in BHoM structure")]
-        [Input("location", "Location Curve of Object in 3D space")]
-        [Input("properties", "InstanceProperties of Instance")]
-        [Output("ModelInstance")]
+        [Description("Creates ModelInstance object based on curve location and BHoM InstanceProperties. Such ModelInstance can be pushed to Revit as a point-driven element, e.g. chair.")]
+        [InputFromProperty("properties")]
+        [InputFromProperty("location")]
+        [Output("modelInstance")]
         public static ModelInstance ModelInstance(InstanceProperties properties, ICurve location)
         {
             if (properties == null || location == null)
@@ -107,9 +106,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates ModelInstance by given Point, Family Name and Family Type Name. ModelInstance represents generic 3D elements which have not been defined in BHoM structure")]
-        [Input("location", "Location Curve of Object in 3D space")]
-        [Output("ModelInstance")]
+        [Description("Creates ModelInstance object based on curve location. Such ModelInstance can be pushed to Revit as model line.")]
+        [InputFromProperty("location")]
+        [Output("modelInstance")]
         public static ModelInstance ModelInstance(ICurve location)
         {
             if (location == null)
@@ -131,10 +130,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates ModelInstance by given Point, Family Name and Family Type Name. ModelInstance represents generic 3D elements which have not been defined in BHoM structure")]
-        [Input("name", "InstanceProperties name")]
-        [Input("location", "Location Curve of Object in 3D space")]
-        [Output("ModelInstance")]
+        [Description("Creates ModelInstance object based on curve location. Such ModelInstance can be pushed to Revit as model line.")]
+        [Input("name", "Name of Revit line type to be applied to the model line.")]
+        [InputFromProperty("location")]
+        [Output("modelInstance")]
         public static ModelInstance ModelInstance(string name, ICurve location)
         {
             if (location == null)
@@ -157,32 +156,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates ModelInstance from given IBHoMObject. ModelInstance represents generic 3D elements which have not been defined in BHoM structure")]
-        [Input("bHoMObject", "IBHoMObject")]
-        [Output("ModelInstance")]
-        public static ModelInstance ModelInstance(oM.Base.IBHoMObject bHoMObject)
-        {
-            if (bHoMObject == null)
-                return null;
-
-            InstanceProperties instanceProperties = new InstanceProperties()
-            {
-                Name = bHoMObject.Name,
-                CustomData = new System.Collections.Generic.Dictionary<string, object>(bHoMObject.CustomData)
-            };
-
-            ModelInstance modelInstance = new ModelInstance()
-            {
-                Name = bHoMObject.Name,
-                Properties = instanceProperties,
-                CustomData = new System.Collections.Generic.Dictionary<string, object>(bHoMObject.CustomData)
-            };
-
-            return modelInstance;
-        }
-
-        /***************************************************/
-
+        [Description("Creates ModelInstance object based on surface location. Such ModelInstance can be pushed to Revit as DirectShape.")]
+        [Input("categoryName", "Name of Revit category, to which the pushed DirectShape element will be assigned.")]
+        [InputFromProperty("location")]
+        [Output("modelInstance")]
         public static ModelInstance ModelInstance(string categoryName, ISurface location)
         {
             if (string.IsNullOrWhiteSpace(categoryName) || location == null)
@@ -204,6 +181,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Description("Creates ModelInstance object based on solid location. Such ModelInstance can be pushed to Revit as DirectShape.")]
+        [Input("categoryName", "Name of Revit category, to which the pushed DirectShape element will be assigned.")]
+        [InputFromProperty("location")]
+        [Output("modelInstance")]
         public static ModelInstance ModelInstance(string categoryName, ISolid location)
         {
             if (string.IsNullOrWhiteSpace(categoryName) || location == null)
@@ -219,6 +200,32 @@ namespace BH.Engine.Adapters.Revit
                 Location = location
             };
             modelInstance.CustomData.Add(Convert.CategoryName, categoryName);
+
+            return modelInstance;
+        }
+
+        /***************************************************/
+
+        [Description("Creates ModelInstance object based on other BHoMObject's properties. After assigning location to it, such ModelInstance can be pushed to Revit as any model element.")]
+        [Input("bHoMObject", "BHoM object to inherit properties from.")]
+        [Output("modelInstance")]
+        public static ModelInstance ModelInstance(oM.Base.IBHoMObject bHoMObject)
+        {
+            if (bHoMObject == null)
+                return null;
+
+            InstanceProperties instanceProperties = new InstanceProperties()
+            {
+                Name = bHoMObject.Name,
+                CustomData = new System.Collections.Generic.Dictionary<string, object>(bHoMObject.CustomData)
+            };
+
+            ModelInstance modelInstance = new ModelInstance()
+            {
+                Name = bHoMObject.Name,
+                Properties = instanceProperties,
+                CustomData = new System.Collections.Generic.Dictionary<string, object>(bHoMObject.CustomData)
+            };
 
             return modelInstance;
         }

--- a/Revit_Engine/Create/Elements/Sheet.cs
+++ b/Revit_Engine/Create/Elements/Sheet.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,10 +32,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates Sheet object by given name and number.")]
-        [Input("name", "Sheet Name")]
-        [Input("number", "Sheet Number")]
-        [Output("Sheet")]
+        [Description("Creates BHoM Sheet object.")]
+        [Input("name", "Name of the created Sheet correspondent with Revit sheet name.")]
+        [Input("number", "Number of the created Sheet correspondent with Revit sheet number.")]
+        [Output("sheet")]
         public static Sheet Sheet(string name, string number)
         {
             Sheet sheet = new Sheet()

--- a/Revit_Engine/Create/Elements/ViewPlan.cs
+++ b/Revit_Engine/Create/Elements/ViewPlan.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,10 +32,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates ViewPlan object by given name and Level Name.")]
-        [Input("name", "View plan Name")]
-        [Input("levelName", "Level Name")]
-        [Output("ViewPlan")]
+        [Description("Creates BHoM ViewPlan object linked to a specific Revit level.")]
+        [Input("name", "Name of the created ViewPlan correspondent with Revit view name.")]
+        [InputFromProperty("levelName")]
+        [Output("viewPlan")]
         public static ViewPlan ViewPlan(string name, string levelName)
         {
             ViewPlan viewPlan = new ViewPlan()
@@ -56,9 +55,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates ViewPlan object by given name.")]
-        [Input("name", "View plan Name")]
-        [Output("ViewPlan")]
+        [Description("Creates BHoM ViewPlan object not linked to any specific Revit level.")]
+        [Input("name", "Name of the created ViewPlan correspondent with Revit view name.")]
+        [Output("viewPlan")]
         public static ViewPlan ViewPlan(string name)
         {
             ViewPlan viewPlan = new ViewPlan()
@@ -78,11 +77,11 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates ViewPlan object by given name and Level Name.")]
-        [Input("name", "View plan Name")]
-        [Input("levelName", "Level Name")]
-        [Input("viewTemplateName", "View Template Name")]
-        [Output("ViewPlan")]
+        [Description("Creates BHoM ViewPlan object linked to a specific level, based on specific Revit view template.")]
+        [Input("name", "Name of the created ViewPlan correspondent with Revit view name.")]
+        [InputFromProperty("levelName")]
+        [Input("viewTemplateName", "Name of Revit view template to be assigned to the created ViewPlan.")]
+        [Output("viewPlan")]
         public static ViewPlan ViewPlan(string name, string levelName, string viewTemplateName)
         {
             ViewPlan viewPlan = new ViewPlan()

--- a/Revit_Engine/Create/Elements/Viewport.cs
+++ b/Revit_Engine/Create/Elements/Viewport.cs
@@ -20,11 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,11 +33,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates Viewport on specific location point and which is assigned to the view by given name and to the sheet by given sheet Number.")]
-        [Input("sheetNumber", "Sheet Number linked with this Viewport")]
-        [Input("viewName", "View Name linked with this Viewport")]
-        [Input("location", "Location of the view port on sheet")]
-        [Output("Viewport")]
+        [Description("Creates BHoM Viewport object in specific point location, linked to the view by given name and to the sheet by given sheet Number.")]
+        [Input("sheetNumber", "Revit sheet number linked with created Viewport")]
+        [Input("viewName", "Revit view name linked with created Viewport")]
+        [InputFromProperty("location")]
+        [Output("viewport")]
         public static Viewport Viewport(string sheetNumber, string viewName, Point location)
         {
             Viewport viewport = new Viewport()

--- a/Revit_Engine/Create/Generic/FamilyLibrary.cs
+++ b/Revit_Engine/Create/Generic/FamilyLibrary.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,10 +32,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates Family Library Class which holds information about families can be loaded to model.")]
-        [Input("directory", "Directory from where famlies will be loaded if not exists in model")]
-        [Input("topDirectoryOnly", "Search through top dilectory folder and skip subfolders")]
-        [Output("FamilyLibrary")]
+        [Description("Creates an object that stores information about families that can be loaded to model.")]
+        [Input("directory", "Directory from which Revit families will be loaded if they do not exist in the model.")]
+        [Input("topDirectoryOnly", "Search through top directory folder only and skip subfolders.")]
+        [Output("familyLibrary")]
         public static FamilyLibrary FamilyLibrary(string directory, bool topDirectoryOnly = false)
         {
             return new FamilyLibrary().Append(directory, topDirectoryOnly);

--- a/Revit_Engine/Create/Generic/RevitFilePreview.cs
+++ b/Revit_Engine/Create/Generic/RevitFilePreview.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates Revit File Preview Class which stores basic information about Revit File such as Family Category, Familiy Type Names etc.")]
-        [Input("path", "Path to the Revit file")]
-        [Output("RevitFilePreview")]
+        [Description("Creates an object that stores basic information about Revit family file (.rfa) such as family category, familiy type names etc.")]
+        [InputFromProperty("path")]
+        [Output("revitFilePreview")]
         public static RevitFilePreview RevitFilePreview(string path)
         {
             RevitFilePreview revitFilePreview = new RevitFilePreview()

--- a/Revit_Engine/Create/Generic/TypeMap.cs
+++ b/Revit_Engine/Create/Generic/TypeMap.cs
@@ -20,11 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
+using System;
+using System.ComponentModel;
 
 
 namespace BH.Engine.Adapters.Revit
@@ -35,9 +34,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates a TypeMap that contains the information about the relationship between BHoM property names and Revit parameter names.")]
-        [Input("type", "BHoM type, which properties are meant to be matched with Revit parameters")]
-        [Output("TypeMap")]
+        [Description("Creates an object that contains the information about the relationship between BHoM property names and Revit parameter names.")]
+        [InputFromProperty("type")]
+        [Output("typeMap")]
         public static TypeMap TypeMap(Type type)
         {
             if (type == null)

--- a/Revit_Engine/Create/Properties/InstanceProperties.cs
+++ b/Revit_Engine/Create/Properties/InstanceProperties.cs
@@ -33,10 +33,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates InstanceProperties")]
-        [Input("familyName", "Revit Family Name")]
-        [Input("familyTypeName", "Revit Family Type Name")]
-        [Output("InstanceProperties")]
+        [Description("Creates an object that carries information about correspondent Revit family type.")]
+        [Input("familyName", "Name of the correspondent Revit family.")]
+        [Input("familyTypeName", "Name of the correspondent Revit family type.")]
+        [Output("instanceProperties")]
         public static InstanceProperties InstanceProperties(string familyName, string familyTypeName)
         {
             InstanceProperties instanceProperties = new InstanceProperties()
@@ -52,9 +52,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Creates InstanceProperties")]
-        [Input("name", "name")]
-        [Output("InstanceProperties")]
+        [Description("Creates an object that carries information about correspondent Revit family type.")]
+        [Input("name", "Name of the correspondent Revit family type in format FamilyName: FamilyTypeName.")]
+        [Output("instanceProperties")]
         public static InstanceProperties InstanceProperties(string name)
         {
             InstanceProperties instanceProperties = new InstanceProperties()

--- a/Revit_Engine/Create/Settings/ConnectionSettings.cs
+++ b/Revit_Engine/Create/Settings/ConnectionSettings.cs
@@ -20,11 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Reflection.Attributes;
-
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,11 +32,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates Connection Settings Class which stores basic information about Adapter Connection settings such as Push Port, Pull Port and Maximum Time to Wait")]
-        [Input("pushPort", "Push Port for Revit Adapter")]
-        [Input("pullPort", "Pull Port for Revit Adapter")]
-        [Input("maxMinutesToWait", "Max Time to wait for response [min]")]
-        [Output("ConnectionSettings")]
+        [Description("Creates an object that carries socket connection settings for Revit Adapter.")]
+        [InputFromProperty("pushPort")]
+        [InputFromProperty("pullPort")]
+        [InputFromProperty("maxMinutesToWait")]
+        [Output("connectionSettings")]
         public static ConnectionSettings ConnectionSettings(int pushPort = 14128, int pullPort = 14129, int maxMinutesToWait = 10)
         {
             return new ConnectionSettings()

--- a/Revit_Engine/Create/Settings/FamilyLoadSettings.cs
+++ b/Revit_Engine/Create/Settings/FamilyLoadSettings.cs
@@ -20,11 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,11 +33,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates Family Load Settings class which contols Family loading behaviour when family not available in project")]
-        [Input("familyLibrary", "FamilyLibrary which defines directory to be searched")]
-        [Input("overwriteFamily", "Overwrite Family if exists in model")]
-        [Input("overwriteParameterValues", "Overwrite parameter values for existing types")]
-        [Output("FamilyLoadSettings")]
+        [Description("Creates an object that contols family loading behaviour when family is not loaded in project.")]
+        [InputFromProperty("familyLibrary")]
+        [InputFromProperty("overwriteFamily")]
+        [InputFromProperty("overwriteParameterValues")]
+        [Output("familyLoadSettings")]
         public static FamilyLoadSettings FamilyLoadSettings(FamilyLibrary familyLibrary = null, bool overwriteFamily = true, bool overwriteParameterValues = true)
         {
             FamilyLoadSettings familyLoadSettings = new FamilyLoadSettings()

--- a/Revit_Engine/Create/Settings/MapSettings.cs
+++ b/Revit_Engine/Create/Settings/MapSettings.cs
@@ -20,12 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Collections.Generic;
-using System.ComponentModel;
-
-using BH.oM.Reflection.Attributes;
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -35,9 +34,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates MapSettings")]
-        [Input("typeMaps", "List of typeMaps for MapSettings")]
-        [Output("MapSettings")]
+        [Description("Creates a collection of relationships between property names of BHoM types and parameter names of correspondent Revit elements")]
+        [InputFromProperty("typeMaps")]
+        [Output("mapSettings")]
         public static MapSettings MapSettings(IEnumerable<TypeMap> typeMaps)
         {
             MapSettings mapSettings = new MapSettings();

--- a/Revit_Engine/Create/Settings/RevitSettings.cs
+++ b/Revit_Engine/Create/Settings/RevitSettings.cs
@@ -33,14 +33,14 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Creates Revit Settings class which contols behaviour of Revit Adapter")]
-        [Input("connectionSettings", "Connection Settings for Revit Adapter")]
-        [Input("familyLoadSettings", "FamilyLoad Settings for Revit Adapter")]
-        [Input("mapSettings", "Map Settings for Revit Adapter")]
-        [Input("tagsParameterName", "Name of the parameter to which the tags will be assigned")]
-        [Input("distanceTolerance", "Distance tolerance to be used by the adapter")]
-        [Input("angleTolerance", "Angle tolerance to be used by the adapter")]
-        [Output("RevitSettings")]
+        [Description("Creates an object that carries general settings that are applicable to all actions performed by the instance of Revit adapter.")]
+        [InputFromProperty("connectionSettings")]
+        [InputFromProperty("familyLoadSettings")]
+        [InputFromProperty("mapSettings")]
+        [InputFromProperty("tagsParameterName")]
+        [InputFromProperty("distanceTolerance")]
+        [InputFromProperty("angleTolerance")]
+        [Output("revitSettings")]
         public static RevitSettings RevitSettings(ConnectionSettings connectionSettings = null, FamilyLoadSettings familyLoadSettings = null, MapSettings mapSettings = null, string tagsParameterName = null, double distanceTolerance = BH.oM.Geometry.Tolerance.Distance, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
         {
             RevitSettings settings = new RevitSettings();

--- a/Revit_Engine/Modify/AddMap.cs
+++ b/Revit_Engine/Modify/AddMap.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Adapters.Revit
         [Input("typeMap", "TypeMap")]
         [Input("sourceName", "BHoM parameter name of type")]
         [Input("destinationName", "Revit parameter name to be mapped")]
-        [Output("TypeMap")]
+        [Output("typeMap")]
         public static TypeMap AddMap(this TypeMap typeMap, string sourceName, string destinationName)
         {
             if (string.IsNullOrWhiteSpace(destinationName))
@@ -58,7 +58,7 @@ namespace BH.Engine.Adapters.Revit
         [Input("typeMap", "TypeMap")]
         [Input("sourceName", "BHoM parameter name of type")]
         [Input("destinationNames", "Revit parameter names to be mapped")]
-        [Output("TypeMap")]
+        [Output("typeMap")]
         public static TypeMap AddMap(this TypeMap typeMap, string sourceName, IEnumerable<string> destinationNames)
         {
             if (typeMap == null)

--- a/Revit_Engine/Modify/AddMap.cs
+++ b/Revit_Engine/Modify/AddMap.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Adapters.Revit
         [Input("typeMap", "TypeMap")]
         [Input("sourceName", "BHoM parameter name of type")]
         [Input("destinationName", "Revit parameter name to be mapped")]
-        [Output("typeMap")]
+        [Output("TypeMap")]
         public static TypeMap AddMap(this TypeMap typeMap, string sourceName, string destinationName)
         {
             if (string.IsNullOrWhiteSpace(destinationName))
@@ -58,7 +58,7 @@ namespace BH.Engine.Adapters.Revit
         [Input("typeMap", "TypeMap")]
         [Input("sourceName", "BHoM parameter name of type")]
         [Input("destinationNames", "Revit parameter names to be mapped")]
-        [Output("typeMap")]
+        [Output("TypeMap")]
         public static TypeMap AddMap(this TypeMap typeMap, string sourceName, IEnumerable<string> destinationNames)
         {
             if (typeMap == null)

--- a/Revit_oM/Elements/DraftingInstance.cs
+++ b/Revit_oM/Elements/DraftingInstance.cs
@@ -35,10 +35,10 @@ namespace BH.oM.Adapters.Revit.Elements
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("Information about family type of the instance.")]
+        [Description("Information about Revit family type or graphic type of the instance.")]
         public InstanceProperties Properties { get; set; } = new InstanceProperties();
 
-        [Description("Location of the instance in space.")]
+        [Description("Location of the instance in three dimensional space.")]
         public IGeometry Location { get; set; } = new Point();
 
         [Description("Name of Revit view to which the instance belongs.")]

--- a/Revit_oM/Elements/ModelInstance.cs
+++ b/Revit_oM/Elements/ModelInstance.cs
@@ -35,10 +35,10 @@ namespace BH.oM.Adapters.Revit.Elements
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("Information about family type of the instance.")]
+        [Description("Information about Revit family type of the instance.")]
         public InstanceProperties Properties { get; set; } = new InstanceProperties();
 
-        [Description("Location of the instance in space.")]
+        [Description("Location of the instance in in three dimensional space.")]
         public IGeometry Location { get; set; } = new Point();
 
         /***************************************************/

--- a/Revit_oM/Generic/RevitFilePreview.cs
+++ b/Revit_oM/Generic/RevitFilePreview.cs
@@ -25,7 +25,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Generic
 {
-    [Description("Wrapper for Revit family file that allows processing it with BHoM. Prototype, currently with limited functionality.")]
+    [Description("Wrapper for Revit family file (.rfa) that stores basic information about it such as family category, familiy type names etc. Prototype, currently with limited functionality.")]
     public class RevitFilePreview : BHoMObject
     {
         /***************************************************/

--- a/Revit_oM/Settings/MapSettings.cs
+++ b/Revit_oM/Settings/MapSettings.cs
@@ -34,7 +34,7 @@ namespace BH.oM.Adapters.Revit.Settings
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("A list of entities defining relationships between property names of BHoM types and parameter names of correspondent Revit elements.")]
+        [Description("A collection of entities defining relationships between property names of each BHoM type and parameter names of correspondent Revit elements.")]
         public List<TypeMap> TypeMaps { get; set; } = new List<TypeMap>();
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #615
Second part o #595, `Modify` and `Query` still need a refresh.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.Engine.Adapters.Revit.Compute` and `BH.Engine.Adapters.Revit.Create` descriptions added and/or refreshed
`BH.Engine.Adapters.Revit.Create.BHoMObject` deprecated 
