### PR TITLE
Revit_Engine: Modify and Query descriptions added and GetProperty/SetProperty duplicates deprecated

### DIFF
--- a/Engine_Revit_UI/Convert/Revit/ToRevit/Viewport.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/Viewport.cs
@@ -46,11 +46,11 @@ namespace BH.UI.Revit.Engine
 
             settings = settings.DefaultIfNull();
 
-            string viewName = viewport.ViewName();
+            string viewName = viewport.CustomDataValue("View Name") as string;
             if (string.IsNullOrEmpty(viewName))
                 return null;
 
-            string sheetNumber = viewport.SheetNumber();
+            string sheetNumber = viewport.CustomDataValue("Sheet Number") as string;
             if (string.IsNullOrEmpty(sheetNumber))
                 return null;
 

--- a/Revit_Engine/Modify/AddMap.cs
+++ b/Revit_Engine/Modify/AddMap.cs
@@ -20,15 +20,14 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.Revit.Generic;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Reflection.Attributes;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
-using System.ComponentModel;
-using System.Collections.Generic;
-
-using BH.oM.Adapters.Revit.Generic;
-using BH.oM.Reflection.Attributes;
-using BH.oM.Adapters.Revit.Settings;
 
 
 namespace BH.Engine.Adapters.Revit
@@ -38,12 +37,12 @@ namespace BH.Engine.Adapters.Revit
         /***************************************************/
         /****              Public methods               ****/
         /***************************************************/
-
-        [Description("Links Revit parameter with BHoM parameter for given TypeMap.")]
-        [Input("typeMap", "TypeMap")]
-        [Input("sourceName", "BHoM parameter name of type")]
-        [Input("destinationName", "Revit parameter name to be mapped")]
-        [Output("TypeMap")]
+        
+        [Description("Links Revit parameter with BHoM type property or CustomData inside existing TypeMap.")]
+        [Input("typeMap", "TypeMap to be extended.")]
+        [Input("sourceName", "BHoM type property or CustomData name.")]
+        [Input("destinationName", "Revit parameter name to be mapped.")]
+        [Output("typeMap")]
         public static TypeMap AddMap(this TypeMap typeMap, string sourceName, string destinationName)
         {
             if (string.IsNullOrWhiteSpace(destinationName))
@@ -53,12 +52,12 @@ namespace BH.Engine.Adapters.Revit
         }
 
         /***************************************************/
-
-        [Description("Links Revit parameter with BHoM parameter for given TypeMap.")]
-        [Input("typeMap", "TypeMap")]
-        [Input("sourceName", "BHoM parameter name of type")]
-        [Input("destinationNames", "Revit parameter names to be mapped")]
-        [Output("TypeMap")]
+        
+        [Description("Links Revit parameters with BHoM type property or CustomData inside existing TypeMap.")]
+        [Input("typeMap", "TypeMap to be extended.")]
+        [Input("sourceName", "BHoM type property or CustomData name.")]
+        [Input("destinationName", "Revit parameter name to be mapped.")]
+        [Output("typeMap")]
         public static TypeMap AddMap(this TypeMap typeMap, string sourceName, IEnumerable<string> destinationNames)
         {
             if (typeMap == null)
@@ -102,12 +101,12 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Links Revit parameter with BHoM parameter for given type and MapSettings.")]
-        [Input("mapSettings", "MapSettings")]
-        [Input("type", "BHoM type to be mapped")]
-        [Input("sourceName", "BHoM parameter name of type")]
-        [Input("destinationName", "Revit parameter name to be mapped")]
-        [Output("MapSettings")]
+        [Description("Links Revit parameter with BHoM type property or CustomData inside existing MapSettings.")]
+        [Input("mapSettings", "MapSettings to be extended.")]
+        [Input("type", "BHoM type to be mapped.")]
+        [Input("sourceName", "BHoM type property or CustomData name.")]
+        [Input("destinationName", "Revit parameter name to be mapped.")]
+        [Output("mapSettings")]
         public static MapSettings AddMap(this MapSettings mapSettings, Type type, string sourceName, string destinationName)
         {
             if (mapSettings == null)

--- a/Revit_Engine/Modify/AddMap.cs
+++ b/Revit_Engine/Modify/AddMap.cs
@@ -53,10 +53,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
         
-        [Description("Links Revit parameters with BHoM type property or CustomData inside existing TypeMap.")]
+        [Description("Links Revit parameters with BHoM type property or CustomData inside existing TypeMap. In case of multiple destinationNames, first found will be considered correspondent with given type property.")]
         [Input("typeMap", "TypeMap to be extended.")]
         [Input("sourceName", "BHoM type property or CustomData name.")]
-        [Input("destinationName", "Revit parameter name to be mapped.")]
+        [Input("destinationNames", "Revit parameter names to be mapped.")]
         [Output("typeMap")]
         public static TypeMap AddMap(this TypeMap typeMap, string sourceName, IEnumerable<string> destinationNames)
         {

--- a/Revit_Engine/Modify/AddTypeMap.cs
+++ b/Revit_Engine/Modify/AddTypeMap.cs
@@ -20,12 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-using System.Collections.Generic;
-
 using BH.oM.Adapters.Revit.Generic;
-using BH.oM.Reflection.Attributes;
 using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -35,11 +34,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Add TypeMap to the given MapSettings")]
-        [Input("mapSettings", "MapSettings")]
-        [Input("typeMap", "TypeMap to be added")]
-        [Input("merge", "merge TypeMap if already exists in MapSettings")]
-        [Output("MapSettings")]
+        [Description("Adds TypeMap to existing MapSettings.")]
+        [Input("mapSettings", "MapSettings to be extended.")]
+        [Input("typeMap", "TypeMap to be added.")]
+        [Input("merge", "If there is an existing TypeMap in MapSettings that maps same BHoM type, if true: merge the one to be added with it, if false: leave both TypeMaps separate.")]
+        [Output("mapSettings")]
         public static MapSettings AddTypeMap(this MapSettings mapSettings, TypeMap typeMap, bool merge = true)
         {
             if (mapSettings == null)

--- a/Revit_Engine/Modify/Append.cs
+++ b/Revit_Engine/Modify/Append.cs
@@ -19,12 +19,11 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-using System.IO;
-using System.ComponentModel;
-using System.Collections.Generic;
-
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,10 +33,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Adds new directory to FamilyLibrary.")]
-        [Input("directory", "Directory from where famlies will be loaded if not exists in model")]
-        [Input("topDirectoryOnly", "Search through top dilectory folder and skip subfolders")]
-        [Output("FamilyLibrary")]
+        [Description("Adds new directory to existing FamilyLibrary.")]
+        [Input("familyLibrary", "FamilyLibrary to be extended.")]
+        [Input("directory", "Directory to be added.")]
+        [Input("topDirectoryOnly", "If true, add top directory folder and skip subfolders.")]
+        [Output("familyLibrary")]
         public static FamilyLibrary Append(this FamilyLibrary familyLibrary, string directory, bool topDirectoryOnly = false)
         {
             if (familyLibrary == null)
@@ -63,9 +63,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Adds new path to FamilyLibrary.")]
-        [Input("path", "path of Revit file")]
-        [Output("FamilyLibrary")]
+        [Description("Adds new path to existing FamilyLibrary.")]
+        [Input("familyLibrary", "FamilyLibrary to be extended.")]
+        [Input("path", "Path of Revit file to be added.")]
+        [Output("familyLibrary")]
         public static FamilyLibrary Append(this FamilyLibrary familyLibrary, string path)
         {
             if (familyLibrary == null)

--- a/Revit_Engine/Modify/DefaultIfNull.cs
+++ b/Revit_Engine/Modify/DefaultIfNull.cs
@@ -21,6 +21,8 @@
  */
 
 using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -30,6 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Description("Sets RevitSettings to default value if they are null.")]
+        [Input("settings", "RevitSettings to be set to default if null.")]
+        [Output("revitSettings")]
         public static RevitSettings DefaultIfNull(this RevitSettings settings)
         {
             if (settings == null)

--- a/Revit_Engine/Modify/Move.cs
+++ b/Revit_Engine/Modify/Move.cs
@@ -20,11 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
-using BH.oM.Geometry;
 using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,10 +33,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Moves ModelInstance by given vector.")]
-        [Input("modelInstance", "ModelInstance to be moved")]
-        [Input("vector", "Vector")]
-        [Output("ModelInstance")]
+        [Description("Translates ModelInstance by given vector.")]
+        [Input("modelInstance", "ModelInstance to be moved.")]
+        [Input("vector", "Translation vector.")]
+        [Output("modelInstance")]
         public static ModelInstance Move(this ModelInstance modelInstance, Vector vector)
         {
             if (modelInstance == null)

--- a/Revit_Engine/Modify/RemoveIdentifiers.cs
+++ b/Revit_Engine/Modify/RemoveIdentifiers.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Removes Revit Identifiers from BHoM object.")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Output("IBHoMObject")]
+        [Description("Removes Revit-related identifiers (CustomData keys such as Revit_id, Revit_elementId etc.) from BHoM object.")]
+        [Input("bHoMObject", "BHoMObject to be cleaned.")]
+        [Output("bHoMObject")]
         public static IBHoMObject RemoveIdentifiers(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Modify/SetFamilyLibrary.cs
+++ b/Revit_Engine/Modify/SetFamilyLibrary.cs
@@ -33,6 +33,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of SetProperty.")]
         [Description("Sets Pull FamilyLibrary for RevitSettings.")]
         [Input("revitSettings", "RevitSettings")]
         [Input("familyLibrary", "FamilyLibrary to be set")]
@@ -51,6 +52,7 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of SetProperty.")]
         [Description("Sets Pull FamilyLibrary for FamilyLoadSettings.")]
         [Input("familyLoadSettings", "FamilyLoadSettings")]
         [Input("familyLibrary", "FamilyLibrary to be set")]

--- a/Revit_Engine/Modify/SetFamilyName.cs
+++ b/Revit_Engine/Modify/SetFamilyName.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Environment.Fragments;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of SetProperty.")]
         [Description("Sets Family name for Environment Context Properties")]
         [Input("originContextFragment", "Origin Context Properties")]
         [Input("familyName", "Revit Family Name")]

--- a/Revit_Engine/Modify/SetFamilyTypeName.cs
+++ b/Revit_Engine/Modify/SetFamilyTypeName.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
-using BH.oM.Reflection.Attributes;
 using BH.oM.Environment.Fragments;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of SetProperty.")]
         [Description("Sets Family Type name for Environment Context Properties")]
         [Input("originContextFragment", "Origin Context Properties")]
         [Input("familyTypeName", "Revit Family Type Name")]

--- a/Revit_Engine/Modify/SetMapSettings.cs
+++ b/Revit_Engine/Modify/SetMapSettings.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of SetProperty.")]
         [Description("Sets MapSettings for RevitSettings.")]
         [Input("revitSettings", "RevitSettings")]
         [Input("mapSettings", "MapSettings")]

--- a/Revit_Engine/Modify/SetTag.cs
+++ b/Revit_Engine/Modify/SetTag.cs
@@ -20,11 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-using System.Collections.Generic;
-
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,10 +33,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Sets Tag for BHoMObject.")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Input("tag", "tag to be set")]
-        [Output("IBHoMObject")]
+        [Description("Sets tag to BHoMObject.")]
+        [Input("bHoMObject", "BHoMObject to be modified.")]
+        [Input("tag", "Tag to be set.")]
+        [Output("bHoMObject")]
         public static IBHoMObject SetTag(this IBHoMObject bHoMObject, string tag)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Modify/UpdateCustomDataValue.cs
+++ b/Revit_Engine/Modify/UpdateCustomDataValue.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of SetProperty.")]
         [Description("Updates CustomData Value for given name.")]
         [Input("bHoMObject", "BHoMObject")]
         [Input("name", "CustomData Name")]

--- a/Revit_Engine/Query/AdjacentSpaceId.cs
+++ b/Revit_Engine/Query/AdjacentSpaceId.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("gets integer representation of adjacent Space ElementId (stored in CustomData) for given BHoMObject.")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Output("ElementId")]
+        [Description("Gets integer representation of adjacent space Revit ElementId (stored in CustomData) for given BHoMObject.")]
+        [Input("bHoMObject", "BHoMObject to be queried.")]
+        [Output("elementId")]
         public static int AdjacentSpaceId(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Query/CategoryName.cs
+++ b/Revit_Engine/Query/CategoryName.cs
@@ -20,15 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.Revit.Generic;
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Xml.Linq;
-using System.ComponentModel;
-
-using BH.oM.Base;
-using BH.oM.Adapters.Revit.Generic;
-using BH.oM.Data.Requests;
-using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -38,9 +36,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets Revit Category name from RevitFilePreview.")]
-        [Input("revitFilePreview", "RevitFilePreview")]
-        [Output("CategoryName")]
+        [Description("Gets Revit category name from RevitFilePreview.")]
+        [Input("revitFilePreview", "RevitFilePreview to be queried.")]
+        [Output("categoryName")]
         public static string CategoryName(this RevitFilePreview revitFilePreview)
         {
             if (revitFilePreview == null)
@@ -51,9 +49,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Gets Revit Category name from XDocument.")]
-        [Input("xDocument", "XDocument from Header of Revit Family File (*.rfa)")]
-        [Output("CategoryName")]
+        [Description("Gets Revit category name from XDocument.")]
+        [Input("xDocument", "XDocument from header of Revit family file (*.rfa).")]
+        [Output("categoryName")]
         public static string CategoryName(this XDocument xDocument)
         {
             if (xDocument == null || xDocument.Root == null || xDocument.Root.Attributes() == null)
@@ -87,9 +85,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Gets Revit Category name from BHoMObject.")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Output("CategoryName")]
+        [Description("Gets Revit category name from BHoMObject.")]
+        [Input("bHoMObject", "BHoMObject to be queried.")]
+        [Output("categoryName")]
         public static string CategoryName(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Query/CategoryNames.cs
+++ b/Revit_Engine/Query/CategoryNames.cs
@@ -20,11 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-using System.Collections.Generic;
-
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,11 +33,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets all Revit Category Names from FamilyLibrary for given Family name and Family Type name.")]
-        [Input("familyLibrary", "FamilyLibrary")]
-        [Input("familyName", "Family name")]
-        [Input("familyTypeName", "Family Type name")]
-        [Output("CategoryNames")]
+        [Description("Gets all Revit category names from FamilyLibrary for given family name and family fype name.")]
+        [Input("familyLibrary", "FamilyLibrary to be queried.")]
+        [Input("familyName", "Family name to be sought for.")]
+        [Input("familyTypeName", "Family type name to be sought for.")]
+        [Output("categoryNames")]
         public static List<string> CategoryNames(this FamilyLibrary familyLibrary, string familyName, string familyTypeName = null)
         {
             if (familyLibrary == null || familyLibrary.Dictionary == null)

--- a/Revit_Engine/Query/CategoryNames.cs
+++ b/Revit_Engine/Query/CategoryNames.cs
@@ -33,7 +33,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets all Revit category names from FamilyLibrary for given family name and family fype name.")]
+        [Description("Gets all Revit category names from FamilyLibrary for given family name and family type name.")]
         [Input("familyLibrary", "FamilyLibrary to be queried.")]
         [Input("familyName", "Family name to be sought for.")]
         [Input("familyTypeName", "Family type name to be sought for.")]

--- a/Revit_Engine/Query/CurrentDomainAssembly.cs
+++ b/Revit_Engine/Query/CurrentDomainAssembly.cs
@@ -20,11 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Reflection;
-using System.ComponentModel;
-
 using BH.oM.Reflection.Attributes;
+using System;
+using System.ComponentModel;
+using System.Reflection;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,9 +33,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets current domain assembly for given Manifest Module name.")]
-        [Input("manifestModuleName", "Manifest Module Name")]
-        [Output("Assembly")]
+        [Description("Gets current domain assembly with given ManifestModule name.")]
+        [Input("manifestModuleName", "ManifestModule name to be sought for.")]
+        [Output("assembly")]
         public static Assembly CurrentDomainAssembly(this string manifestModuleName)
         {
             foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())

--- a/Revit_Engine/Query/CustomDataValue.cs
+++ b/Revit_Engine/Query/CustomDataValue.cs
@@ -34,15 +34,15 @@ namespace BH.Engine.Adapters.Revit
 
         [Description("Gets value of BHoM objects's CustomData under given key.")]
         [Input("bHoMObject", "BHoMObject to be queried.")]
-        [Input("name", "CustomData key to be sought for.")]
+        [Input("key", "CustomData key to be sought for.")]
         [Output("value")]
-        public static object CustomDataValue(this IBHoMObject bHoMObject, string name)
+        public static object CustomDataValue(this IBHoMObject bHoMObject, string key)
         {
             if (bHoMObject == null)
                 return null;
 
             object obj;
-            if (bHoMObject.CustomData.TryGetValue(name, out obj))
+            if (bHoMObject.CustomData.TryGetValue(key, out obj))
                 return obj;
 
             return null;

--- a/Revit_Engine/Query/CustomDataValue.cs
+++ b/Revit_Engine/Query/CustomDataValue.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,10 +32,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets value of CustomData for given name.")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Input("name", "CustomData Name")]
-        [Output("Value")]
+        [Description("Gets value of BHoM objects's CustomData under given key.")]
+        [Input("bHoMObject", "BHoMObject to be queried.")]
+        [Input("name", "CustomData key to be sought for.")]
+        [Output("value")]
         public static object CustomDataValue(this IBHoMObject bHoMObject, string name)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Query/DefaultMapSettings.cs
+++ b/Revit_Engine/Query/DefaultMapSettings.cs
@@ -20,12 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Collections.Generic;
-
-using BH.oM.Environment.Fragments;
-using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Adapters.Revit.Generic;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Environment.Fragments;
 using BH.oM.Geometry.ShapeProfiles;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,7 +35,9 @@ namespace BH.Engine.Adapters.Revit
         /***************************************************/
         /****              Public methods               ****/
         /***************************************************/
-  
+
+        [Description("Creates an instance of MapSettings with default values.")]
+        [Output("mapSettings")]
         public static MapSettings DefaultMapSettings()
         {
             //TODO: To be moved to DataSets??

--- a/Revit_Engine/Query/Discipline.cs
+++ b/Revit_Engine/Query/Discipline.cs
@@ -35,9 +35,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets Discipline for given BHoM Type.")]
-        [Input("type", "BHoM Type")]
-        [Output("Discipline")]
+        [Description("Gets discipline to which given BHoM type belongs. The result is based on the namespace in which the type is declared, e.g. BH.oM.Structure.Elements.Bar will return oM.Adapters.Revit.Enums.Discipline.Structural.")]
+        [Input("type", "BHoM type to be queried.")]
+        [Output("discipline")]
         public static Discipline Discipline(this Type type)
         {
             if (type == null)
@@ -60,6 +60,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Description("Gets discipline enforced by the Request. If the result is different than defaultDiscipline and neither of two is Undefined, null is returned (the result discipline is conflicting with defaultDiscipline).")]
+        [Input("request", "BHoM Request to be queried.")]
+        [Input("defaultDiscipline", "Default discipline set in adapter's ActionConfig (RevitPullConfig).")]
+        [Output("discipline")]
         public static Discipline? Discipline(this IRequest request, Discipline? defaultDiscipline)
         {
             Discipline? discipline = defaultDiscipline;

--- a/Revit_Engine/Query/Discipline.cs
+++ b/Revit_Engine/Query/Discipline.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets discipline to which given BHoM type belongs. The result is based on the namespace in which the type is declared, e.g. BH.oM.Structure.Elements.Bar will return oM.Adapters.Revit.Enums.Discipline.Structural.")]
+        [Description("Gets the discipline to which a given BHoM type belongs. The result is based on the namespace in which the type is declared, e.g. BH.oM.Structure.Elements.Bar will return oM.Adapters.Revit.Enums.Discipline.Structural.")]
         [Input("type", "BHoM type to be queried.")]
         [Output("discipline")]
         public static Discipline Discipline(this Type type)

--- a/Revit_Engine/Query/Duplicate.cs
+++ b/Revit_Engine/Query/Duplicate.cs
@@ -21,9 +21,7 @@
  */
 
 using BH.oM.Base;
-using BH.oM.Data.Requests;
 using BH.oM.Reflection.Attributes;
-using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
@@ -34,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of Modify.RemoveIdentifiers.", typeof(Modify), "RemoveIdentifiers")]
         [Description("Duplicates given BHoMObject and removes its identity data (ElementId, AdapterIdName).")]
         [Input("bHoMObject", "BHoMObject")]
         [Output("BHoMObject")]

--- a/Revit_Engine/Query/Edges.cs
+++ b/Revit_Engine/Query/Edges.cs
@@ -34,9 +34,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns edges of given BHoMObject (stored in CustomData)")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Output("Edges")]
+        [Description("Returns edges of given BHoMObject captured on Pull. This value is stored in CustomData under key Revit_edges.")]
+        [Input("bHoMObject", "BHoMObject to be queried.")]
+        [Output("edges")]
         public static List<oM.Geometry.ICurve> Edges(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Query/ElementId.cs
+++ b/Revit_Engine/Query/ElementId.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("gets integer representation of ElementId (stored in CustomData) for given BHoMObject.")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Output("ElementId")]
+        [Description("Returns integer representation of ElementId of Revit element correspondent to given BHoMObject. This value is stored in CustomData under key Revit_elementId.")]
+        [Input("bHoMObject", "BHoMObject to be queried.")]
+        [Output("elementId")]
         public static int ElementId(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Query/Family.cs
+++ b/Revit_Engine/Query/Family.cs
@@ -20,13 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Elements;
-using BH.oM.Reflection.Attributes;
 using BH.oM.Adapters.Revit.Generic;
-
+using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace BH.Engine.Adapters.Revit
@@ -37,10 +35,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns Family based on RevitFilePreview and sepcified Family Type Names")]
-        [Input("revitFilePreview", "RevitFilePreview")]
-        [Input("familyTypeNames", "Family Type Names.")]
-        [Output("Family")]
+        [Description("Returns BHoM family wrapper based on RevitFilePreview and given Revit family type names.")]
+        [Input("revitFilePreview", "RevitFilePreview to be queried.")]
+        [Input("familyTypeNames", "Revit family type names sought for.")]
+        [Output("family")]
         public static Family Family(this RevitFilePreview revitFilePreview, IEnumerable<string> familyTypeNames)
         {
             if (revitFilePreview == null)
@@ -63,7 +61,7 @@ namespace BH.Engine.Adapters.Revit
                         continue;
 
                     oM.Adapters.Revit.Properties.InstanceProperties instanceProps = Create.InstanceProperties(familyName, familyTypeName);
-                    instanceProps = instanceProps.UpdateCustomDataValue(Convert.CategoryName, categoryName) as oM.Adapters.Revit.Properties.InstanceProperties;
+                    instanceProps.CustomData[Convert.CategoryName] = categoryName;
                     instanceProperties.Add(instanceProps);
                 }
             }
@@ -73,19 +71,18 @@ namespace BH.Engine.Adapters.Revit
                 PropertiesList = instanceProperties
             };
 
-            family = family.UpdateCustomDataValue(Convert.FamilyName, familyName) as Family;
-            family = family.UpdateCustomDataValue(Convert.CategoryName, categoryName) as Family;
-
-            family = family.UpdateCustomDataValue(Convert.FamilyPlacementTypeName, revitFilePreview.CustomDataValue(Convert.FamilyPlacementTypeName)) as Family;
+            family.CustomData[Convert.FamilyName] = familyName;
+            family.CustomData[Convert.CategoryName] = categoryName;
+            family.CustomData[Convert.FamilyPlacementTypeName] = revitFilePreview.CustomDataValue(Convert.FamilyPlacementTypeName);
 
             return family;
         }
 
         /***************************************************/
 
-        [Description("Returns Family based on RevitFilePreview")]
-        [Input("revitFilePreview", "RevitFilePreview")]
-        [Output("Family")]
+        [Description("Returns BHoM family wrapper based on RevitFilePreview.")]
+        [Input("revitFilePreview", "RevitFilePreview to be queried.")]
+        [Output("family")]
         public static Family Family(this RevitFilePreview revitFilePreview)
         {
             if (revitFilePreview == null)

--- a/Revit_Engine/Query/FamilyName.cs
+++ b/Revit_Engine/Query/FamilyName.cs
@@ -20,11 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Base;
-using BH.oM.Data.Requests;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets Revit Family name (stored in CustomData) for given BHoMObject.")]
+        [Description("Gets the name of Revit family correspondent to given BHoMObject. This value is stored in CustomData under key Revit_familyName.")]
         [Input("bHoMObject", "BHoMObject")]
-        [Output("FamilyName")]
+        [Output("familyName")]
         public static string FamilyName(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)
@@ -55,10 +53,10 @@ namespace BH.Engine.Adapters.Revit
         }
 
         /***************************************************/
-
-        [Description("Gets Revit Family name from Family Type Full Name in format [Family Name] : [Family Type Name].")]
-        [Input("familyTypeFullName", "Family Type Full Name")]
-        [Output("FamilyName")]
+        
+        [Description("Gets Revit family name from family type full name in format FamilyName: FamilyTypeName.")]
+        [Input("familyTypeFullName", "Family type full name to be queried.")]
+        [Output("familyName")]
         public static string FamilyName(this string familyTypeFullName)
         {
             if (string.IsNullOrWhiteSpace(familyTypeFullName))
@@ -73,9 +71,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Gets Revit Family name from Family Type Full Name in format [Family Name] : [Family Type Name].")]
-        [Input("revitFilePreview", "RevitFilePreview")]
-        [Output("FamilyName")]
+        [Description("Gets the name of Revit family represented by RevitFilePreview.")]
+        [Input("revitFilePreview", "RevitFilePreview to be queried.")]
+        [Output("familyName")]
         public static string FamilyName(this oM.Adapters.Revit.Generic.RevitFilePreview revitFilePreview)
         {
             if (revitFilePreview == null || string.IsNullOrWhiteSpace(revitFilePreview.Path))

--- a/Revit_Engine/Query/FamilyPlacementTypeName.cs
+++ b/Revit_Engine/Query/FamilyPlacementTypeName.cs
@@ -20,12 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
 
-using BH.oM.Base;
-using BH.oM.Data.Requests;
-using BH.oM.Reflection.Attributes;
 using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -35,6 +33,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Description("Gets placement type name of Revit family represented by RevitFilePreview.")]
+        [Input("revitFilePreview", "RevitFilePreview to be queried.")]
+        [Output("familyPlacementTypeName")]
         public static string FamilyPlacementTypeName(this oM.Adapters.Revit.Generic.RevitFilePreview revitFilePreview)
         {
             if (revitFilePreview == null || revitFilePreview.CustomData == null)
@@ -49,6 +50,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Description("Gets placement type name of Revit family.")]
+        [Input("family", "BHoM wrapper of Revit family to be queried.")]
+        [Output("familyPlacementTypeName")]
         public static string FamilyPlacementTypeName(this Family family)
         {
             if (family == null || family.CustomData == null)

--- a/Revit_Engine/Query/FamilyTypeFullName.cs
+++ b/Revit_Engine/Query/FamilyTypeFullName.cs
@@ -20,8 +20,6 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Base;
-using BH.oM.Data.Requests;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 
@@ -33,10 +31,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets Full Revit Family Type name for given Family and Type Name. Example: [FamilyName] : [FamilyTypeName]")]
-        [Input("familyName", "Family Name")]
-        [Input("familyTypeName", "Family Type Name")]
-        [Output("FamilyTypeFullName")]
+        [Description("Gets full name of Revit family type (in format FamilyName: FamilyTypeName) based on given family name and family type name.")]
+        [Input("familyName", "Family name to be used to build the string.")]
+        [Input("familyTypeName", "Family type name to be used to build the string.")]
+        [Output("familyTypeFullName")]
         public static string FamilyTypeFullName(string familyName, string familyTypeName)
         {
             if (string.IsNullOrWhiteSpace(familyName) || string.IsNullOrWhiteSpace(familyTypeName))

--- a/Revit_Engine/Query/FamilyTypeName.cs
+++ b/Revit_Engine/Query/FamilyTypeName.cs
@@ -21,7 +21,6 @@
  */
 
 using BH.oM.Base;
-using BH.oM.Data.Requests;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 
@@ -33,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets Revit Family Type name (stored in CustomData) for given BHoMObject.")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Output("FamilyTypeName")]
+        [Description("Gets the name of Revit family type correspondent to given BHoMObject. This value is stored in CustomData under key Revit_familyTypeName.")]
+        [Input("bHoMObject", "BHoMObject to be queried.")]
+        [Output("familyTypeName")]
         public static string FamilyTypeName(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)
@@ -55,9 +54,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Gets Revit Family Type name from Family Type Full Name in format [Family Name] : [Family Type Name].")]
-        [Input("familyTypeFullName", "BHoMObject")]
-        [Output("FamilyTypeName")]
+        [Description("Gets Revit family type name from family type full name in format FamilyName: FamilyTypeName.")]
+        [Input("familyTypeFullName", "Family type full name to be queried.")]
+        [Output("familyTypeName")]
         public static string FamilyTypeName(this string familyTypeFullName)
         {
             if (string.IsNullOrWhiteSpace(familyTypeFullName))

--- a/Revit_Engine/Query/FamilyTypeNames.cs
+++ b/Revit_Engine/Query/FamilyTypeNames.cs
@@ -20,13 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-using System.Collections.Generic;
-using System.Linq;
-using System.Xml.Linq;
-
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Xml.Linq;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -36,11 +35,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Gets Revit Family Type names in FamilyLibrary for given Category and Family Name.")]
-        [Input("familyLibrary", "FamilyLibrary")]
-        [Input("categoryName", "Category Name")]
-        [Input("familyName", "Family Name")]
-        [Output("FamilyTypeNames")]
+        [Description("Gets Revit family type names available in FamilyLibrary for given names of Revit category and family.")]
+        [Input("familyLibrary", "FamilyLibrary to be queried.")]
+        [Input("categoryName", "Name of Revit category to be sought for.")]
+        [Input("familyName", "Name of Revit family to be sought for.")]
+        [Output("familyTypeNames")]
         public static List<string> FamilyTypeNames(this FamilyLibrary familyLibrary, string categoryName = null, string familyName = null)
         {
             if (familyLibrary == null)
@@ -79,10 +78,10 @@ namespace BH.Engine.Adapters.Revit
         }
 
         /***************************************************/
-
-        [Description("Gets all Revit Family Type names in RevitFilePreview")]
-        [Input("revitFilePreview", "RevitFilePreview")]
-        [Output("FamilyTypeNames")]
+        
+        [Description("Gets all Revit family type names owned by Revit family represented by RevitFilePreview.")]
+        [Input("revitFilePreview", "RevitFilePreview to be queried.")]
+        [Output("familyTypeNames")]
         public static List<string> FamilyTypeNames(this RevitFilePreview revitFilePreview)
         {
             if (revitFilePreview == null)
@@ -93,9 +92,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Gets all Revit Family Type names in XDocument")]
-        [Input("xDocument", "XDocument from Header of Revit Family File (*.rfa)")]
-        [Output("FamilyTypeNames")]
+        [Description("Gets all Revit family type names in XDocument.")]
+        [Input("xDocument", "XDocument from header of Revit family file (*.rfa).")]
+        [Output("familyTypeNames")]
         public static List<string> FamilyTypeNames(this XDocument xDocument)
         {
             if (xDocument == null || xDocument.Root == null || xDocument.Root.Attributes() == null)

--- a/Revit_Engine/Query/FilterByType.cs
+++ b/Revit_Engine/Query/FilterByType.cs
@@ -20,15 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-
-using BH.oM.Adapters.Revit.Enums;
-using BH.oM.Data.Requests;
-using System.Collections.Generic;
-using System.Linq;
-using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
-using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 
 namespace BH.Engine.Adapters.Revit
 {

--- a/Revit_Engine/Query/InnerPolyCurves.cs
+++ b/Revit_Engine/Query/InnerPolyCurves.cs
@@ -34,7 +34,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns the PolyCurves from list that lie inside given outer PolyCurve. QUICK CHECK (BOUNDING BOX).")]
+        [Description("Returns the PolyCurves from the list that lie inside the provided PolyCurve. QUICK CHECK (BOUNDING BOX).")]
         [Input("polyCurve", "PolyCurve to be used as outer bounds of space.")]
         [Input("polyCurves", "Collection of PolyCurves to be queried for containment.")]
         [Output("innerPolyCurves")]

--- a/Revit_Engine/Query/InnerPolyCurves.cs
+++ b/Revit_Engine/Query/InnerPolyCurves.cs
@@ -20,15 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Geometry;
-using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
-using BH.oM.Environment.Elements;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
-using System;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -38,10 +34,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns the inner PolyCurves from list. QUICK CHECK (BOUNDING BOX)")]
-        [Input("polyCurve", "PolyCurve")]
-        [Input("polyCurves", "PolyCurves")]
-        [Output("PolyCurves")]
+        [Description("Returns the PolyCurves from list that lie inside given outer PolyCurve. QUICK CHECK (BOUNDING BOX).")]
+        [Input("polyCurve", "PolyCurve to be used as outer bounds of space.")]
+        [Input("polyCurves", "Collection of PolyCurves to be queried for containment.")]
+        [Output("innerPolyCurves")]
         public static List<PolyCurve> InnerPolyCurves(this PolyCurve polyCurve, IEnumerable<PolyCurve> polyCurves)
         {
             if (polyCurves == null || polyCurves.Count() == 0 || polyCurve == null)

--- a/Revit_Engine/Query/IsExternal.cs
+++ b/Revit_Engine/Query/IsExternal.cs
@@ -20,11 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
-using BH.oM.Base;
-using BH.oM.Reflection.Attributes;
 using BH.oM.Environment.Elements;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Cheks whatever Environment Panel is external element. Works only for Environment Panels pulled from analytical model and adjacency have been assigned.")]
-        [Input("environmentPanel", "Environment Panel pulled from Revit analytical model")]
-        [Output("IsExternal")]
+        [Description("Cheks whether environment panel is external element. Works only for environment panels pulled from analytical model with adjacency assigned.")]
+        [Input("environmentPanel", "Environment panel pulled from Revit analytical model.")]
+        [Output("isExternal")]
         public static bool IsExternal(this Panel environmentPanel)
         {
             if (environmentPanel == null)

--- a/Revit_Engine/Query/IsInternal.cs
+++ b/Revit_Engine/Query/IsInternal.cs
@@ -20,11 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
-using BH.oM.Base;
-using BH.oM.Reflection.Attributes;
 using BH.oM.Environment.Elements;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Cheks whatever Environment Panel is internal element. Works only for Environment Panels pulled from analytical model and adjacency have been assigned.")]
-        [Input("environmentPanel", "Environment Panel pulled from Revit analytical model")]
-        [Output("IsInternal")]
+        [Description("Cheks whether environment panel is internal element. Works only for environment panels pulled from analytical model with adjacency assigned.")]
+        [Input("environmentPanel", "Environment panel pulled from Revit analytical model.")]
+        [Output("isInternal")]
         public static bool IsInternal(this Panel environmentPanel)
         {
             if (environmentPanel == null)

--- a/Revit_Engine/Query/IsShade.cs
+++ b/Revit_Engine/Query/IsShade.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
-using BH.oM.Reflection.Attributes;
 using BH.oM.Environment.Elements;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Cheks whatever environment panel is shade element. Works only for Environment Panels pulled from analytical model and adjacency have been assigned.")]
-        [Input("environmentPanel", "Environment Panel pulled from Revit analytical model")]
-        [Output("IsShade")]
+        [Description("Cheks whether environment panel is shade element. Works only for environment panels pulled from analytical model with adjacency assigned.")]
+        [Input("environmentPanel", "Environment panel pulled from Revit analytical model.")]
+        [Output("isShade")]
         public static bool IsShade(this Panel environmentPanel)
         {
             if (environmentPanel == null)

--- a/Revit_Engine/Query/IsTemplate.cs
+++ b/Revit_Engine/Query/IsTemplate.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of GetProperty.")]
         [Description("Returns true if given FloorPlan should be considered as template.")]
         [Input("viewPlan", "ViewPlan")]
         [Output("IsTemplate")]

--- a/Revit_Engine/Query/IsValid.cs
+++ b/Revit_Engine/Query/IsValid.cs
@@ -20,13 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.ComponentModel;
-
-using BH.oM.Reflection.Attributes;
-using BH.oM.Adapters.Revit;
-using BH.oM.Adapters.Revit.Generic;
 using BH.Adapter.Revit;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -36,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Checks if RevitAdapter is valid.")]
-        [Input("revitAdapter", "Revit Adapter")]
-        [Output("IsValid", "True if RevitAdapter is valid")]
+        [Description("Checks if Revit Adapter is valid.")]
+        [Input("revitAdapter", "Revit Adapter to be checked.")]
+        [Output("isValid")]
         public static bool IsValid(this RevitAdapter revitAdapter)
         {
             if (revitAdapter == null)

--- a/Revit_Engine/Query/IsZero.cs
+++ b/Revit_Engine/Query/IsZero.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Reflection.Attributes;
 using System;
 using System.ComponentModel;
-
-using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Adapters.Revit
 {

--- a/Revit_Engine/Query/Location.cs
+++ b/Revit_Engine/Query/Location.cs
@@ -20,11 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
-using BH.oM.Geometry;
 using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,6 +33,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of GetProperty.")]
         [Description("Returns Location (Point or Curve) of given ModelInstance.")]
         [Input("modelInstance", "ModelInstance")]
         [Output("Location")]

--- a/Revit_Engine/Query/MapPropertyInfos.cs
+++ b/Revit_Engine/Query/MapPropertyInfos.cs
@@ -20,9 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Reflection.Attributes;
 using System;
-using System.Reflection;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
 
 
 namespace BH.Engine.Adapters.Revit
@@ -33,6 +35,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Description("Returns a collection of PropertyInfo objects owned by given type, which can be used to map parameters with MapSettings.")]
+        [Input("type", "Type to be queried.")]
+        [Output("mapPropertyInfos")]
         public static IEnumerable<PropertyInfo> MapPropertyInfos(this Type type)
         {
             if (type == null)

--- a/Revit_Engine/Query/MapSettings.cs
+++ b/Revit_Engine/Query/MapSettings.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
-using BH.oM.Reflection.Attributes;
 using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 
 namespace BH.Engine.Adapters.Revit
@@ -34,6 +33,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of GetProperty.")]
         [Description("Returns MapSettings from RevitSettings")]
         [Input("revitSettings", "RevitSettings")]
         [Output("MapSettings")]

--- a/Revit_Engine/Query/Names.cs
+++ b/Revit_Engine/Query/Names.cs
@@ -20,11 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.Revit.Generic;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
-
-using BH.oM.Adapters.Revit.Settings;
-using BH.oM.Adapters.Revit.Generic;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -34,6 +35,11 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Description("Returns a collection of parameter names associated with a given type property inside MapSettings.")]
+        [Input("mapSettings", "MapSettings to be queried.")]
+        [Input("type", "Type to be sought for.")]
+        [Input("name", "Property name to be sought for.")]
+        [Output("names")]
         public static IEnumerable<string> Names(this MapSettings mapSettings, Type type, string name)
         {
             if (mapSettings == null || type == null || string.IsNullOrWhiteSpace(name))

--- a/Revit_Engine/Query/Names.cs
+++ b/Revit_Engine/Query/Names.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns a collection of parameter names associated with a given type property inside MapSettings.")]
+        [Description("Returns a collection of Revit parameter names associated with a given type property inside MapSettings.")]
         [Input("mapSettings", "MapSettings to be queried.")]
         [Input("type", "Type to be sought for.")]
         [Input("name", "Property name to be sought for.")]

--- a/Revit_Engine/Query/OmniClass.cs
+++ b/Revit_Engine/Query/OmniClass.cs
@@ -20,13 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.Revit.Generic;
+using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Xml.Linq;
-
-using BH.oM.Adapters.Revit.Generic;
-using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -36,9 +35,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns OmniClass assigned to Revit Family (RevitFilePreview)")]
-        [Input("revitFilePreview", "RevitFilePreview")]
-        [Output("OmniClass")]
+        [Description("Returns OmniClass assigned to Revit family represented by RevitFilePreview.")]
+        [Input("revitFilePreview", "RevitFilePreview to be queried.")]
+        [Output("omniClass")]
         public static string OmniClass(this RevitFilePreview revitFilePreview)
         {
             if (revitFilePreview == null)
@@ -49,9 +48,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        [Description("Returns OmniClass assigned to Revit Family (RevitFilePreview)")]
-        [Input("xDocument", "XDocument from Header of Revit Family File (*.rfa)")]
-        [Output("OmniClass")]
+        [Description("Returns OmniClass assigned to Revit family stored in XDocument.")]
+        [Input("xDocument", "XDocument from header of Revit family file (*.rfa).")]
+        [Output("omniClass")]
         public static string OmniClass(this XDocument xDocument)
         {
             if (xDocument == null || xDocument.Root == null)

--- a/Revit_Engine/Query/OuterPolyCurves.cs
+++ b/Revit_Engine/Query/OuterPolyCurves.cs
@@ -20,15 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Geometry;
-using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
-using BH.oM.Environment.Elements;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
-using System;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -38,9 +34,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns the outer PolyCurves from list. QUICK CHECK (Centroid)")]
-        [Input("polyCurves", "PolyCurves")]
-        [Output("PolyCurves")]
+        [Description("Returns the PolyCurves from list that lie outside any other PolyCurve. QUICK CHECK (BOUNDING BOX).")]
+        [Input("polyCurves", "Collection of PolyCurves to be queried for containment.")]
+        [Output("outerPolyCurves")]
         public static List<PolyCurve> OuterPolyCurves(this IEnumerable<PolyCurve> polyCurves)
         {
             if (polyCurves == null || polyCurves.Count() == 0)

--- a/Revit_Engine/Query/Paths.cs
+++ b/Revit_Engine/Query/Paths.cs
@@ -20,12 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-using System.Collections.Generic;
-using System.Linq;
-
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -35,9 +34,12 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns all Paths in FamilyLibrary of given Category, Family and Family Type")]
-        [Input("familyLibrary", "FamilyLibrary")]
-        [Output("Paths")]
+        [Description("Returns all file paths in FamilyLibrary that meet given Revit category, family and family type requirements.")]
+        [Input("familyLibrary", "FamilyLibrary to be queried.")]
+        [Input("categoryName", "Name of Revit category to be sought for. Optional: if null, all items to be taken.")]
+        [Input("familyName", "Name of Revit family to be sought for. Optional: if null, all items to be taken.")]
+        [Input("typeName", "Name of Revit family type to be sought for. Optional: if null, all items to be taken.")]
+        [Output("paths")]
         public static IEnumerable<string> Paths(this FamilyLibrary familyLibrary, string categoryName = null, string familyName = null, string typeName = null)
         {
             if (familyLibrary == null || familyLibrary.Dictionary == null || familyLibrary.Dictionary.Keys.Count == 0)

--- a/Revit_Engine/Query/Plane.cs
+++ b/Revit_Engine/Query/Plane.cs
@@ -20,13 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Collections.Generic;
-using System.Linq;
-
-using BH.oM.Base;
-using BH.oM.Adapters.Revit.Settings;
-using System;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -36,6 +34,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Description("Returns a plane in which the PolyCurve lies. Null is returned if the curve is not planar.")]
+        [Input("polyCurve", "PolyCurve to be queried.")]
+        [Input("tolerance", "Geometrical tolerance to be applied to planarity check.")]
+        [Output("plane")]
         public static Plane Plane(this PolyCurve polyCurve, double tolerance = Tolerance.Distance)
         {
             if (polyCurve == null)
@@ -54,6 +56,10 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Description("Returns a plane in which the Polyline lies. Null is returned if the curve is not planar.")]
+        [Input("polyline", "Polyline to be queried.")]
+        [Input("tolerance", "Geometrical tolerance to be applied to planarity check.")]
+        [Output("plane")]
         public static Plane Plane(this Polyline polyline, double tolerance = Tolerance.Distance)
         {
             if (polyline == null)
@@ -70,6 +76,9 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Description("Returns a plane spanned on a collection of points. Null is returned if the point set is not planar.")]
+        [Input("points", "Set of points to be queried.")]
+        [Output("plane")]
         public static Plane Plane(this IEnumerable<Point> points)
         {
             if (points == null || points.Count() < 2)

--- a/Revit_Engine/Query/RevitFilePreviews.cs
+++ b/Revit_Engine/Query/RevitFilePreviews.cs
@@ -20,12 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Linq;
-using System.ComponentModel;
-using System.Collections.Generic;
-
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 
 
 namespace BH.Engine.Adapters.Revit
@@ -36,12 +35,12 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns all RevitFilePreviews for FamilyLibrary of given Category, Family and Family Type Name")]
-        [Input("familyLibrary", "FamilyLibrary")]
-        [Input("categoryName", "Family Category Name")]
-        [Input("familyName", "Family Name")]
-        [Input("familyTypeName", "FamilyTypeName")]
-        [Output("RevitFilePreviews")]
+        [Description("Returns all RevitFilePreviews inside FamilyLibrary that meet Revit category, family and family type name requirements.")]
+        [Input("familyLibrary", "FamilyLibrary to be queried.")]
+        [Input("categoryName", "Name of Revit category to be sought for. Optional: if null, all items to be taken.")]
+        [Input("familyName", "Name of Revit family to be sought for. Optional: if null, all items to be taken.")]
+        [Input("familyTypeName", "Name of Revit family type to be sought for. Optional: if null, all items to be taken.")]
+        [Output("revitFilePreviews")]
         public static List<RevitFilePreview> RevitFilePreviews(this FamilyLibrary familyLibrary, string categoryName = null, string familyName = null, string familyTypeName = null)
         {
             if (familyLibrary == null || familyLibrary.Dictionary == null || familyLibrary.Dictionary.Keys.Count == 0)

--- a/Revit_Engine/Query/SheetNumber.cs
+++ b/Revit_Engine/Query/SheetNumber.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of GetProperty.")]
         [Description("Returns SheetNumber assigned to given Viewport")]
         [Input("viewport", "Viewport")]
         [Output("SheetNumber")]

--- a/Revit_Engine/Query/SpaceId.cs
+++ b/Revit_Engine/Query/SpaceId.cs
@@ -33,9 +33,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("gets integer representation of Space ElementId (stored in CustomData) for given BHoMObject.")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Output("ElementId")]
+        [Description("Gets integer representation of ElementId of Revit space element correspondent to given BHoMObject. This value is stored in CustomData under key SpaceID.")]
+        [Input("bHoMObject", "BHoMObject to be queried.")]
+        [Output("elementId")]
         public static int SpaceId(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Query/TypeMap.cs
+++ b/Revit_Engine/Query/TypeMap.cs
@@ -20,12 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.Revit.Generic;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.ComponentModel;
-
-using BH.oM.Adapters.Revit.Generic;
-using BH.oM.Reflection.Attributes;
-using BH.oM.Adapters.Revit.Settings;
 
 
 namespace BH.Engine.Adapters.Revit
@@ -36,10 +35,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns TypeMap for given type")]
-        [Input("mapSettings", "MapSettings")]
-        [Input("type", "Type")]
-        [Output("TypeMap")]
+        [Description("Returns TypeMap for given type inside MapSettings.")]
+        [Input("mapSettings", "MapSettings to be queried.")]
+        [Input("type", "Type to be sought for.")]
+        [Output("typeMap")]
         public static TypeMap TypeMap(this MapSettings mapSettings, Type type)
         {
             if (mapSettings == null)

--- a/Revit_Engine/Query/UniqueId.cs
+++ b/Revit_Engine/Query/UniqueId.cs
@@ -33,9 +33,9 @@ namespace BH.Engine.Adapters.Revit
         /***************************************************/
 
 
-        [Description("Returns Revit UniqueId of given BHoMObject (stored in CustomData).")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Output("UniqueId")]
+        [Description("Returns UniqueId of Revit element correspondent to given BHoMObject. This value is stored in CustomData under key Revit_id.")]
+        [Input("bHoMObject", "BHoMObject to be queried.")]
+        [Output("uniqueId")]
         public static string UniqueId(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Query/UniqueIds.cs
+++ b/Revit_Engine/Query/UniqueIds.cs
@@ -20,12 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-using System.Collections.Generic;
-
 using BH.oM.Base;
-using BH.oM.Data.Requests;
 using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {

--- a/Revit_Engine/Query/ViewName.cs
+++ b/Revit_Engine/Query/ViewName.cs
@@ -20,9 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -32,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.1", "This method is a duplicate of GetProperty.")]
         [Description("Returns ViewName assigned to Viewport.")]
         [Input("viewport", "Viewport")]
         [Output("ViewName")]

--- a/Revit_Engine/Query/WorksetId.cs
+++ b/Revit_Engine/Query/WorksetId.cs
@@ -20,10 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
-
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -33,9 +32,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns integer represetation of WorksetId for given BHoMObject (stored in CustomData).")]
-        [Input("bHoMObject", "BHoMObject")]
-        [Output("WorksetId")]
+        [Description("Returns integer representation of WorksetId of Revit workset correspondent to given BHoMObject. This value is stored in CustomData under key Revit_worksetId.")]
+        [Input("bHoMObject", "BHoMObject to be queried.")]
+        [Output("worksetId")]
         public static int WorksetId(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)

--- a/Revit_Engine/Query/XDocument.cs
+++ b/Revit_Engine/Query/XDocument.cs
@@ -20,18 +20,17 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Text;
+using BH.oM.Adapters.Revit.Generic;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
 using System.IO.Packaging;
 using System.Linq;
-using System.Collections.Generic;
 using System.Reflection;
-using System.IO;
-using System;
-using System.ComponentModel;
+using System.Text;
 using System.Xml.Linq;
-
-using BH.oM.Reflection.Attributes;
-using BH.oM.Adapters.Revit.Generic;
 
 
 namespace BH.Engine.Adapters.Revit
@@ -42,9 +41,9 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Retrieves. XDocument from RevitFilePreview")]
-        [Input("revitFilePreview", "RevitFilePreview")]
-        [Output("XDocument")]
+        [Description("Retrieves XDocument from header of a Revit family file (.rfa) wrapped by RevitFilePreview.")]
+        [Input("revitFilePreview", "RevitFilePreview to be queried.")]
+        [Output("xDocument")]
         public static XDocument XDocument(this RevitFilePreview revitFilePreview)
         {
             if (revitFilePreview == null)
@@ -102,6 +101,7 @@ namespace BH.Engine.Adapters.Revit
 
             return null;
         }
+
 
         /***************************************************/
         /****              Private Methods              ****/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #595
Closes #617
Closes #618

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed - the changes should be non-breaking.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.Engine.Adapters.Revit.Modify` and `BH.Engine.Adapters.Revit.Query` descriptions added and/or refreshed
- logical duplicates of `GetProperty` and `SetProperty` (i.e. the methods that lead to results achievable with the latter in a single step) have been deprecated
- `BH.Engine.Adapters.Revit.Query.Duplicate` method has been deprecated


### Additional comments
<!-- As required -->
There should be no conflicts with #616, so these can be reviewed independently.