### PR TITLE
Unit converts made robust and informative 

### DIFF
--- a/Engine_Revit_UI/Query/BHoMUnitType.cs
+++ b/Engine_Revit_UI/Query/BHoMUnitType.cs
@@ -66,7 +66,7 @@ namespace BH.UI.Revit.Engine
             }
             else
             {
-                BH.Engine.Reflection.Compute.RecordError(String.Format("Unit type {0} has not been recognized and has not been converted - as a result, the value in BHoM can be wrong.", LabelUtils.GetLabelFor(unitType)));
+                BH.Engine.Reflection.Compute.RecordError(String.Format("Unit type {0} has not been recognized and has not been converted - as a result, the output value can be wrong.", LabelUtils.GetLabelFor(unitType)));
                 return DisplayUnitType.DUT_GENERAL;
             }
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #656
Closes #657


### Test files
<!-- Link to test files to validate the proposed changes -->
Test set on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssues656%2C657%2DUnitConverts).


### Additional comments
<!-- As required -->
The method is supported by two `private` arrays and a `private` dictionary - this is in order to get as close to unitless SI as possible. Could not come up with anything neater. Happy to discuss other approaches if any proposed.