### PR TITLE
Saving enumerable parameters as strings in CustomData fixed

### DIFF
--- a/Engine_Revit_UI/Modify/SetCustomData.cs
+++ b/Engine_Revit_UI/Modify/SetCustomData.cs
@@ -73,6 +73,8 @@ namespace BH.UI.Revit.Engine
                 case StorageType.Integer:
                     if (parameter.Definition.ParameterType == ParameterType.YesNo)
                         value = parameter.AsInteger() == 1;
+                    else if (parameter.Definition.ParameterType == ParameterType.Invalid)
+                        value = parameter.AsValueString();
                     else
                         value = parameter.AsInteger();
                     break;

--- a/Revit_Engine/Query/WorksetId.cs
+++ b/Revit_Engine/Query/WorksetId.cs
@@ -32,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.2", "This method is a duplicate of GetProperty.")]
         [Description("Returns integer representation of WorksetId of Revit workset correspondent to given BHoMObject. This value is stored in CustomData under key Revit_worksetId.")]
         [Input("bHoMObject", "BHoMObject to be queried.")]
         [Output("worksetId")]


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #632
Closes #633
Closes #660


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssues632%2C660%2DEnumerableParameters), using model from [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2F%5FMacro%2FPull%2FRevit%2FRequests)


### Additional comments
<!-- As required -->
Workset name sits under _Workset_ `CustomData` key - it can be easily queried using `GetProperty`.