### PR TITLE
Reference to Common_Engine removed

### DIFF
--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -127,11 +127,6 @@
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Common_Engine">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM_Engine\Build\Common_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Common_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Common_oM.dll</HintPath>

--- a/Engine_Revit_UI/Query/BoundingBox.cs
+++ b/Engine_Revit_UI/Query/BoundingBox.cs
@@ -21,7 +21,7 @@
  */
 
 using Autodesk.Revit.DB;
-using BH.Engine.Common;
+using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Geometry;
 using System.Collections.Generic;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #647

### Test files
<!-- Link to test files to validate the proposed changes -->
Rather not needed.


### Additional comments
<!-- As required -->
The only file using Common_Engine reference was doing a geometrical query that could be replaced with Geometry_Engine. Therefore, Spatial_Engine has not been referenced.