### PR TITLE
CustomData handling cleanup vol. 1

### DIFF
--- a/Adapter_Revit_UI/CRUD/Read.cs
+++ b/Adapter_Revit_UI/CRUD/Read.cs
@@ -21,6 +21,7 @@
  */
 
 using Autodesk.Revit.DB;
+using BH.Adapter.Revit;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapter;
 using BH.oM.Adapters.Revit;
@@ -102,7 +103,7 @@ namespace BH.UI.Revit.Adapter
                         List<ICurve> edges = element.Curves(options, revitSettings);
                         foreach (IBHoMObject iBHoMObject in iBHoMObjects)
                         {
-                            iBHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.Edges] = edges;
+                            iBHoMObject.CustomData[RevitAdapter.Edges] = edges;
                         }
                     }
 

--- a/Adapter_Revit_UI/Modify/SetIdentifiers.cs
+++ b/Adapter_Revit_UI/Modify/SetIdentifiers.cs
@@ -22,6 +22,7 @@
 
 using Autodesk.Revit.DB;
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.UI.Revit.Engine;
 
@@ -38,17 +39,17 @@ namespace BH.UI.Revit.Adapter
             if (bHoMObject == null || element == null)
                 return;
 
-            bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.ElementId] = element.Id.IntegerValue;
-            bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.AdapterIdName] = element.UniqueId;
+            bHoMObject.CustomData[RevitAdapter.ElementId] = element.Id.IntegerValue;
+            bHoMObject.CustomData[RevitAdapter.AdapterIdName] = element.UniqueId;
 
             if (element is Family)
             {
                 Family family = (Family)element;
 
-                bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyPlacementTypeName] = family.FamilyPlacementTypeName();
-                bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyName] = family.Name;
+                bHoMObject.CustomData[RevitAdapter.FamilyPlacementTypeName] = family.FamilyPlacementTypeName();
+                bHoMObject.CustomData[RevitAdapter.FamilyName] = family.Name;
                 if (family.FamilyCategory != null)
-                    bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.CategoryName] = family.FamilyCategory.Name;
+                    bHoMObject.CustomData[RevitAdapter.CategoryName] = family.FamilyCategory.Name;
             }
             else
             {
@@ -59,7 +60,6 @@ namespace BH.UI.Revit.Adapter
                     if (revitWorksetID != null)
                         worksetID = revitWorksetID.IntegerValue;
                 }
-                bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.WorksetId] = worksetID;
 
                 Parameter parameter = null;
 
@@ -68,7 +68,7 @@ namespace BH.UI.Revit.Adapter
                 {
                     string value = parameter.AsValueString();
                     if (!string.IsNullOrEmpty(value))
-                        bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyName] = value;
+                        bHoMObject.CustomData[RevitAdapter.FamilyName] = value;
                 }
 
 
@@ -77,7 +77,7 @@ namespace BH.UI.Revit.Adapter
                 {
                     string value = parameter.AsValueString();
                     if (!string.IsNullOrEmpty(value))
-                        bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyTypeName] = value;
+                        bHoMObject.CustomData[RevitAdapter.FamilyTypeName] = value;
                 }
 
 
@@ -86,7 +86,7 @@ namespace BH.UI.Revit.Adapter
                 {
                     string value = parameter.AsValueString();
                     if (!string.IsNullOrEmpty(value))
-                        bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.CategoryName] = value;
+                        bHoMObject.CustomData[RevitAdapter.CategoryName] = value;
                 }
             }
 

--- a/Adapter_Revit_UI/RevitUIAdapter.cs
+++ b/Adapter_Revit_UI/RevitUIAdapter.cs
@@ -50,7 +50,7 @@ namespace BH.UI.Revit.Adapter
         public RevitUIAdapter(UIControlledApplication uIControlledApplication, Document document)
             : base()
         {
-            AdapterIdName = BH.Engine.Adapters.Revit.Convert.AdapterIdName;
+            AdapterIdName = RevitAdapter.AdapterIdName;
             m_AdapterSettings.UseAdapterId = false;
 
             m_Document = document;

--- a/Engine_Revit_UI/Compute/Warnings.cs
+++ b/Engine_Revit_UI/Compute/Warnings.cs
@@ -22,14 +22,14 @@
 
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
+using BH.Adapter.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Adapters.Revit.Enums;
 using BH.oM.Base;
-using BH.oM.Structure.Elements;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Linq;
+using System.Reflection;
 
 namespace BH.UI.Revit.Engine
 {
@@ -398,8 +398,8 @@ namespace BH.UI.Revit.Engine
             {
                 message = string.Format("{0} BHoM Guid: {1}", message, viewPlan.BHoM_Guid);
 
-                if(viewPlan.CustomData.ContainsKey(BH.Engine.Adapters.Revit.Convert.ViewTemplate))
-                    message = string.Format("{0} View Template Name: {1}", message, viewPlan.CustomData[BH.Engine.Adapters.Revit.Convert.ViewTemplate]);
+                if(viewPlan.CustomData.ContainsKey(RevitAdapter.ViewTemplate))
+                    message = string.Format("{0} View Template Name: {1}", message, viewPlan.CustomData[RevitAdapter.ViewTemplate]);
             }
 
             BH.Engine.Reflection.Compute.RecordError(message);

--- a/Engine_Revit_UI/Convert/Revit/FromRevit/BHoMObject.cs
+++ b/Engine_Revit_UI/Convert/Revit/FromRevit/BHoMObject.cs
@@ -21,6 +21,7 @@
  */
 
 using Autodesk.Revit.DB;
+using BH.Adapter.Revit;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Adapters.Revit.Enums;
@@ -67,7 +68,7 @@ namespace BH.UI.Revit.Engine
                 iBHoMObject = new BHoMObject();
 
             if (!(iBHoMObject is DraftingInstance) && element.ViewSpecific)
-                iBHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.ViewName] = element.Document.GetElement(element.OwnerViewId).Name;
+                iBHoMObject.CustomData[RevitAdapter.ViewName] = element.Document.GetElement(element.OwnerViewId).Name;
 
             iBHoMObject.Name = element.Name;
             iBHoMObject.SetIdentifiers(element);

--- a/Engine_Revit_UI/Convert/Revit/FromRevit/InstanceProperties.cs
+++ b/Engine_Revit_UI/Convert/Revit/FromRevit/InstanceProperties.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Adapters.Revit.Settings;
@@ -47,8 +48,8 @@ namespace BH.UI.Revit.Engine
             //Set identifiers & custom data
             instanceProperties.SetIdentifiers(elementType);
             instanceProperties.SetCustomData(elementType);
-            instanceProperties.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyName] = elementType.FamilyName;
-            instanceProperties.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyTypeName] = elementType.Name;
+            instanceProperties.CustomData[RevitAdapter.FamilyName] = elementType.FamilyName;
+            instanceProperties.CustomData[RevitAdapter.FamilyTypeName] = elementType.Name;
 
             instanceProperties.UpdateValues(settings, elementType);
 
@@ -72,7 +73,7 @@ namespace BH.UI.Revit.Engine
             //Set identifiers & custom data
             instanceProperties.SetIdentifiers(graphicStyle);
             instanceProperties.SetCustomData(graphicStyle);
-            instanceProperties.CustomData[BH.Engine.Adapters.Revit.Convert.CategoryName] = graphicStyle.GraphicsStyleCategory.Parent.Name;
+            instanceProperties.CustomData[RevitAdapter.CategoryName] = graphicStyle.GraphicsStyleCategory.Parent.Name;
 
             instanceProperties.UpdateValues(settings, graphicStyle);
 

--- a/Engine_Revit_UI/Convert/Revit/ToRevit/ViewPlan.cs
+++ b/Engine_Revit_UI/Convert/Revit/ToRevit/ViewPlan.cs
@@ -21,6 +21,7 @@
  */
 
 using Autodesk.Revit.DB;
+using BH.Adapter.Revit;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using System;
@@ -89,7 +90,7 @@ namespace BH.UI.Revit.Engine
             revitViewPlan.SetParameters(viewPlan, null);
 
             object value = null;
-            if (viewPlan.CustomData.TryGetValue(BH.Engine.Adapters.Revit.Convert.ViewTemplate, out value))
+            if (viewPlan.CustomData.TryGetValue(RevitAdapter.ViewTemplate, out value))
             {
                 if (value is string)
                 {

--- a/Engine_Revit_UI/Modify/AddAdjacentSpaceId.cs
+++ b/Engine_Revit_UI/Modify/AddAdjacentSpaceId.cs
@@ -22,8 +22,7 @@
 
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Analysis;
-
-using BH.oM.Environment.Elements;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.UI.Revit.Engine
 {
@@ -32,14 +31,15 @@ namespace BH.UI.Revit.Engine
         /***************************************************/
         /****              Public methods               ****/
         /***************************************************/
-        
+
+        [Deprecated("3.2", "BH.UI.Revit.Engine.Modify.AddAdjacentSpaceId is not used any more.")]
         public static oM.Environment.Elements.Panel AddAdjacentSpaceId(this oM.Environment.Elements.Panel panel, EnergyAnalysisSurface energyAnalysisSurface)
         {
             if (panel == null)
                 return null;
 
             oM.Environment.Elements.Panel returnPanel = panel.GetShallowClone() as oM.Environment.Elements.Panel;
-            returnPanel.CustomData.Add(BH.Engine.Adapters.Revit.Convert.AdjacentSpaceId, -1);
+            returnPanel.CustomData.Add("AdjacentSpaceID", -1);
 
             if (energyAnalysisSurface == null)
                 return returnPanel;
@@ -52,7 +52,7 @@ namespace BH.UI.Revit.Engine
             if (spatialElement == null)
                 return returnPanel;
 
-            returnPanel.CustomData[BH.Engine.Adapters.Revit.Convert.AdjacentSpaceId] = spatialElement.Id.IntegerValue;
+            returnPanel.CustomData["AdjacentSpaceID"] = spatialElement.Id.IntegerValue;
 
             return returnPanel;
         }

--- a/Engine_Revit_UI/Modify/AddSpaceId.cs
+++ b/Engine_Revit_UI/Modify/AddSpaceId.cs
@@ -22,8 +22,7 @@
 
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Analysis;
-
-using BH.oM.Environment.Elements;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.UI.Revit.Engine
 {
@@ -32,14 +31,15 @@ namespace BH.UI.Revit.Engine
         /***************************************************/
         /****              Public methods               ****/
         /***************************************************/
-        
+
+        [Deprecated("3.2", "BH.UI.Revit.Engine.Modify.AddSpaceId is not used any more.")]
         public static oM.Environment.Elements.Panel AddSpaceId(this oM.Environment.Elements.Panel panel, EnergyAnalysisSurface energyAnalysisSurface)
         {
             if (panel == null)
                 return null;
 
             oM.Environment.Elements.Panel returnPanel = panel.GetShallowClone() as oM.Environment.Elements.Panel;
-            returnPanel.CustomData.Add(BH.Engine.Adapters.Revit.Convert.SpaceId, -1);
+            returnPanel.CustomData.Add("SpaceID", -1);
 
             if (energyAnalysisSurface == null)
                 return returnPanel;
@@ -52,7 +52,7 @@ namespace BH.UI.Revit.Engine
             if (spatialElement == null)
                 return returnPanel;
 
-            returnPanel.CustomData[BH.Engine.Adapters.Revit.Convert.SpaceId] = spatialElement.Id.IntegerValue;
+            returnPanel.CustomData["SpaceID"] = spatialElement.Id.IntegerValue;
 
             return returnPanel;
         }

--- a/Engine_Revit_UI/Modify/SetIdentifiers.cs
+++ b/Engine_Revit_UI/Modify/SetIdentifiers.cs
@@ -22,6 +22,7 @@
 
 using Autodesk.Revit.DB;
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 
 namespace BH.UI.Revit.Engine
@@ -37,8 +38,8 @@ namespace BH.UI.Revit.Engine
             if (bHoMObject == null || element == null)
                 return;
 
-            bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.ElementId] = element.Id.IntegerValue;
-            bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.AdapterIdName] = element.UniqueId;
+            bHoMObject.CustomData[RevitAdapter.ElementId] = element.Id.IntegerValue;
+            bHoMObject.CustomData[RevitAdapter.AdapterIdName] = element.UniqueId;
 
             int worksetID = WorksetId.InvalidWorksetId.IntegerValue;
             if (element.Document != null && element.Document.IsWorkshared)
@@ -47,7 +48,6 @@ namespace BH.UI.Revit.Engine
                 if (revitWorksetID != null)
                     worksetID = revitWorksetID.IntegerValue;
             }
-            bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.WorksetId] = worksetID;
 
             Parameter parameter = null;
 
@@ -55,26 +55,26 @@ namespace BH.UI.Revit.Engine
             {
                 Family family = (Family)element;
 
-                bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyName] = family.Name;
+                bHoMObject.CustomData[RevitAdapter.FamilyName] = family.Name;
 
                 if (family.FamilyCategory != null)
-                    bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.CategoryName] = family.FamilyCategory.Name;
+                    bHoMObject.CustomData[RevitAdapter.CategoryName] = family.FamilyCategory.Name;
 
-                bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyPlacementTypeName] = family.FamilyPlacementTypeName();
+                bHoMObject.CustomData[RevitAdapter.FamilyPlacementTypeName] = family.FamilyPlacementTypeName();
             }
             else
             {
                 parameter = element.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM);
                 if (parameter != null)
-                    bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyName] = parameter.AsValueString();
+                    bHoMObject.CustomData[RevitAdapter.FamilyName] = parameter.AsValueString();
 
                 parameter = element.get_Parameter(BuiltInParameter.ELEM_TYPE_PARAM);
                 if (parameter != null)
-                    bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.FamilyTypeName] = parameter.AsValueString();
+                    bHoMObject.CustomData[RevitAdapter.FamilyTypeName] = parameter.AsValueString();
 
                 parameter = element.get_Parameter(BuiltInParameter.ELEM_CATEGORY_PARAM);
                 if (parameter != null)
-                    bHoMObject.CustomData[BH.Engine.Adapters.Revit.Convert.CategoryName] = parameter.AsValueString();
+                    bHoMObject.CustomData[RevitAdapter.CategoryName] = parameter.AsValueString();
             }
         }
 

--- a/Engine_Revit_UI/Query/WorksetId.cs
+++ b/Engine_Revit_UI/Query/WorksetId.cs
@@ -38,7 +38,7 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(BH.Engine.Adapters.Revit.Convert.WorksetId, out value))
+            if (bHoMObject.CustomData.TryGetValue("Revit_worksetId", out value))
             {
                 if (value is string)
                 {

--- a/Revit_Adapter/Aliases.cs
+++ b/Revit_Adapter/Aliases.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -20,27 +20,26 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-namespace BH.Engine.Adapters.Revit
+namespace BH.Adapter.Revit
 {
-    public static partial class Convert
+    public partial class RevitAdapter
     {
-        /***************************************************/
-        /****             Public Properties             ****/
-        /***************************************************/
-        
-        public const string AdapterIdName = "Revit_id";
-        public const string ElementId = "Revit_elementId";
-        public const string WorksetId = "Revit_worksetId";
-        public const string SpaceId = "SpaceID"; //FG Change per #191 - ongoing discussion on best use of this still ongoing
-        public const string AdjacentSpaceId = "AdjacentSpaceID"; //FG Change per #191 - ongoing discussion on best use of this still ongoing
-        public const string FamilyName = "Revit_familyName";
-        public const string FamilyTypeName = "Revit_familyTypeName";
-        public const string CategoryName = "Revit_categoryName";
-        public const string ViewName = "Revit_viewName";
-        public const string Edges = "Revit_edges";
-        public const string ViewTemplate = "View Template";
-        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
 
         /***************************************************/
+        /****           Public Fields                   ****/
+        /***************************************************/
+        
+        public new const string AdapterIdName = "Revit_id";
+        public const string ElementId = "Revit_elementId";
+        public const string FamilyName = "Revit_familyName";
+        public const string FamilyTypeName = "Revit_familyTypeName";
+        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
+        public const string CategoryName = "Revit_categoryName";
+        public const string ViewName = "Revit_viewName";
+        public const string ViewTemplate = "View Template";
+        public const string Edges = "Revit_edges";
+
+        /***************************************************/
+
     }
 }

--- a/Revit_Adapter/Revit_Adapter.csproj
+++ b/Revit_Adapter/Revit_Adapter.csproj
@@ -89,6 +89,7 @@
     <Compile Include="AdapterActions\Remove.cs" />
     <Compile Include="AdapterActions\Pull.cs" />
     <Compile Include="AdapterActions\Push.cs" />
+    <Compile Include="Aliases.cs" />
     <Compile Include="IInternalRevitAdapter.cs" />
     <Compile Include="PackageType.cs" />
     <Compile Include="RevitAdapter.cs" />

--- a/Revit_Engine/Create/Elements/BHoMObject.cs
+++ b/Revit_Engine/Create/Elements/BHoMObject.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -40,7 +41,7 @@ namespace BH.Engine.Adapters.Revit
         {
             BHoMObject obj = new BHoMObject();
 
-            obj.CustomData.Add(Convert.ElementId, elementId);
+            obj.CustomData.Add(RevitAdapter.ElementId, elementId);
 
             return obj;
         }
@@ -55,7 +56,7 @@ namespace BH.Engine.Adapters.Revit
         {
             BHoMObject obj = new BHoMObject();
 
-            obj.CustomData.Add(Convert.AdapterIdName, uniqueId);
+            obj.CustomData.Add(RevitAdapter.AdapterIdName, uniqueId);
 
             return obj;
         }

--- a/Revit_Engine/Create/Elements/DraftingInstance.cs
+++ b/Revit_Engine/Create/Elements/DraftingInstance.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Adapters.Revit.Properties;
@@ -110,7 +111,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             InstanceProperties instanceProperties = new InstanceProperties();
-            instanceProperties.CustomData.Add(Convert.CategoryName, "Lines");
+            instanceProperties.CustomData.Add(RevitAdapter.CategoryName, "Lines");
 
             DraftingInstance draftingInstance = new DraftingInstance()
             {
@@ -119,7 +120,7 @@ namespace BH.Engine.Adapters.Revit
                 ViewName = viewName,
                 Location = location
             };
-            draftingInstance.CustomData.Add(Convert.CategoryName, "Lines");
+            draftingInstance.CustomData.Add(RevitAdapter.CategoryName, "Lines");
 
             return draftingInstance;
         }
@@ -138,7 +139,7 @@ namespace BH.Engine.Adapters.Revit
 
             InstanceProperties instanceProperties = new InstanceProperties();
             instanceProperties.Name = name;
-            instanceProperties.CustomData.Add(Convert.CategoryName, "Lines");
+            instanceProperties.CustomData.Add(RevitAdapter.CategoryName, "Lines");
 
             DraftingInstance draftingInstance = new DraftingInstance()
             {
@@ -147,7 +148,7 @@ namespace BH.Engine.Adapters.Revit
                 ViewName = viewName,
                 Location = location
             };
-            draftingInstance.CustomData.Add(Convert.CategoryName, "Lines");
+            draftingInstance.CustomData.Add(RevitAdapter.CategoryName, "Lines");
 
             return draftingInstance;
         }

--- a/Revit_Engine/Create/Elements/ModelInstance.cs
+++ b/Revit_Engine/Create/Elements/ModelInstance.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Geometry;
@@ -115,7 +116,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             InstanceProperties instanceProperties = new InstanceProperties();
-            instanceProperties.CustomData.Add(Convert.CategoryName, "Lines");
+            instanceProperties.CustomData.Add(RevitAdapter.CategoryName, "Lines");
 
             ModelInstance modelInstance = new ModelInstance()
             {
@@ -123,7 +124,7 @@ namespace BH.Engine.Adapters.Revit
                 Name = "Detail Lines",
                 Location = location
             };
-            modelInstance.CustomData.Add(Convert.CategoryName, "Lines");
+            modelInstance.CustomData.Add(RevitAdapter.CategoryName, "Lines");
 
             return modelInstance;
         }
@@ -141,7 +142,7 @@ namespace BH.Engine.Adapters.Revit
 
             InstanceProperties instanceProperties = new InstanceProperties();
             instanceProperties.Name = name;
-            instanceProperties.CustomData.Add(Convert.CategoryName, "Lines");
+            instanceProperties.CustomData.Add(RevitAdapter.CategoryName, "Lines");
 
             ModelInstance modelInstance = new ModelInstance()
             {
@@ -149,7 +150,7 @@ namespace BH.Engine.Adapters.Revit
                 Name = "Detail Lines",
                 Location = location
             };
-            modelInstance.CustomData.Add(Convert.CategoryName, "Lines");
+            modelInstance.CustomData.Add(RevitAdapter.CategoryName, "Lines");
 
             return modelInstance;
         }
@@ -166,7 +167,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             InstanceProperties instanceProperties = new InstanceProperties();
-            instanceProperties.CustomData.Add(Convert.CategoryName, categoryName);
+            instanceProperties.CustomData.Add(RevitAdapter.CategoryName, categoryName);
 
             ModelInstance modelInstance = new ModelInstance()
             {
@@ -174,7 +175,7 @@ namespace BH.Engine.Adapters.Revit
                 Name = "Surface",
                 Location = location
             };
-            modelInstance.CustomData.Add(Convert.CategoryName, categoryName);
+            modelInstance.CustomData.Add(RevitAdapter.CategoryName, categoryName);
 
             return modelInstance;
         }
@@ -191,7 +192,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             InstanceProperties instanceProperties = new InstanceProperties();
-            instanceProperties.CustomData.Add(Convert.CategoryName, categoryName);
+            instanceProperties.CustomData.Add(RevitAdapter.CategoryName, categoryName);
 
             ModelInstance modelInstance = new ModelInstance()
             {
@@ -199,7 +200,7 @@ namespace BH.Engine.Adapters.Revit
                 Name = "Solid",
                 Location = location
             };
-            modelInstance.CustomData.Add(Convert.CategoryName, categoryName);
+            modelInstance.CustomData.Add(RevitAdapter.CategoryName, categoryName);
 
             return modelInstance;
         }

--- a/Revit_Engine/Create/Elements/Panel.cs
+++ b/Revit_Engine/Create/Elements/Panel.cs
@@ -30,6 +30,7 @@ using BH.oM.Environment.Elements;
 using BH.oM.Environment.Fragments;
 using System.Linq;
 
+using BH.Adapter.Revit;
 using BH.Engine.Environment;
 
 namespace BH.Engine.Adapters.Revit
@@ -65,12 +66,12 @@ namespace BH.Engine.Adapters.Revit
             PolyCurve polycurve = Geometry.Create.PolyCurve(new ICurve[] { curve, Geometry.Create.Line(minPoint1, maxPoint1) , crv, Geometry.Create.Line(maxPoint2, minPoint2) });
 
             OriginContextFragment originContext = new OriginContextFragment();
-            originContext.Origin = Convert.AdapterIdName;
+            originContext.Origin = RevitAdapter.AdapterIdName;
             originContext.TypeName = familyTypeName;
 
             Panel panel = Environment.Create.Panel(type: PanelType.Wall, externalEdges: polycurve.ToEdges());
             panel.Name = familyTypeName;
-            panel.CustomData.Add(Convert.CategoryName, "Walls");
+            panel.CustomData.Add(RevitAdapter.CategoryName, "Walls");
 
             panel.AddFragment(originContext);
 

--- a/Revit_Engine/Create/Elements/Sheet.cs
+++ b/Revit_Engine/Create/Elements/Sheet.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -46,9 +47,9 @@ namespace BH.Engine.Adapters.Revit
             sheet.CustomData.Add("Sheet Name", name);
             sheet.CustomData.Add("Sheet Number", number);
 
-            sheet.CustomData.Add(Convert.FamilyName, "Sheet");
-            sheet.CustomData.Add(Convert.FamilyTypeName, "Sheet");
-            sheet.CustomData.Add(Convert.CategoryName, "Sheets");
+            sheet.CustomData.Add(RevitAdapter.FamilyName, "Sheet");
+            sheet.CustomData.Add(RevitAdapter.FamilyTypeName, "Sheet");
+            sheet.CustomData.Add(RevitAdapter.CategoryName, "Sheets");
 
             return sheet;
         }

--- a/Revit_Engine/Create/Elements/ViewPlan.cs
+++ b/Revit_Engine/Create/Elements/ViewPlan.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -47,8 +48,8 @@ namespace BH.Engine.Adapters.Revit
 
             viewPlan.CustomData.Add("View Name", name);
 
-            viewPlan.CustomData.Add(Convert.CategoryName, "Views");
-            viewPlan.CustomData.Add(Convert.FamilyName, "Floor Plan");
+            viewPlan.CustomData.Add(RevitAdapter.CategoryName, "Views");
+            viewPlan.CustomData.Add(RevitAdapter.FamilyName, "Floor Plan");
 
             return viewPlan;
         }
@@ -69,8 +70,8 @@ namespace BH.Engine.Adapters.Revit
 
             viewPlan.CustomData.Add("View Name", name);
 
-            viewPlan.CustomData.Add(Convert.CategoryName, "Views");
-            viewPlan.CustomData.Add(Convert.FamilyName, "Floor Plan");
+            viewPlan.CustomData.Add(RevitAdapter.CategoryName, "Views");
+            viewPlan.CustomData.Add(RevitAdapter.FamilyName, "Floor Plan");
 
             return viewPlan;
         }
@@ -93,9 +94,9 @@ namespace BH.Engine.Adapters.Revit
 
             viewPlan.CustomData.Add("View Name", name);
 
-            viewPlan.CustomData.Add(Convert.CategoryName, "Views");
-            viewPlan.CustomData.Add(Convert.FamilyName, "Floor Plan");
-            viewPlan.CustomData.Add(Convert.ViewTemplate, viewTemplateName);
+            viewPlan.CustomData.Add(RevitAdapter.CategoryName, "Views");
+            viewPlan.CustomData.Add(RevitAdapter.FamilyName, "Floor Plan");
+            viewPlan.CustomData.Add(RevitAdapter.ViewTemplate, viewTemplateName);
 
             return viewPlan;
         }

--- a/Revit_Engine/Create/Elements/Viewport.cs
+++ b/Revit_Engine/Create/Elements/Viewport.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
@@ -48,8 +49,8 @@ namespace BH.Engine.Adapters.Revit
             viewport.CustomData.Add("Sheet Number", sheetNumber);
             viewport.CustomData.Add("View Name", viewName);
 
-            viewport.CustomData.Add(Convert.FamilyName, "Viewport");
-            viewport.CustomData.Add(Convert.CategoryName, "Viewports");
+            viewport.CustomData.Add(RevitAdapter.FamilyName, "Viewport");
+            viewport.CustomData.Add(RevitAdapter.CategoryName, "Viewports");
 
             return viewport;
         }

--- a/Revit_Engine/Create/Properties/InstanceProperties.cs
+++ b/Revit_Engine/Create/Properties/InstanceProperties.cs
@@ -22,6 +22,7 @@
 
 using System.ComponentModel;
 
+using BH.Adapter.Revit;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Adapters.Revit.Properties;
 
@@ -44,8 +45,8 @@ namespace BH.Engine.Adapters.Revit
                 Name = Query.FamilyTypeFullName(familyName, familyTypeName),
             };
 
-            instanceProperties.CustomData.Add(Convert.FamilyName, familyName);
-            instanceProperties.CustomData.Add(Convert.FamilyTypeName, familyTypeName);
+            instanceProperties.CustomData.Add(RevitAdapter.FamilyName, familyName);
+            instanceProperties.CustomData.Add(RevitAdapter.FamilyTypeName, familyTypeName);
 
             return instanceProperties;
         }

--- a/Revit_Engine/Modify/RemoveIdentifiers.cs
+++ b/Revit_Engine/Modify/RemoveIdentifiers.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -42,8 +43,8 @@ namespace BH.Engine.Adapters.Revit
 
             IBHoMObject obj = bHoMObject.GetShallowClone();
 
-            obj.CustomData.Remove(Convert.AdapterIdName);
-            obj.CustomData.Remove(Convert.ElementId);
+            obj.CustomData.Remove(RevitAdapter.AdapterIdName);
+            obj.CustomData.Remove(RevitAdapter.ElementId);
 
             return obj;
         }

--- a/Revit_Engine/Query/AdjacentSpaceId.cs
+++ b/Revit_Engine/Query/AdjacentSpaceId.cs
@@ -32,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.2", "BH.Engine.Adapters.Revit.Query.AdjacentSpaceId is not used any more.")]
         [Description("Gets integer representation of adjacent space Revit ElementId (stored in CustomData) for given BHoMObject.")]
         [Input("bHoMObject", "BHoMObject to be queried.")]
         [Output("elementId")]
@@ -41,7 +42,7 @@ namespace BH.Engine.Adapters.Revit
                 return -1;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(Convert.AdjacentSpaceId, out value))
+            if (bHoMObject.CustomData.TryGetValue("AdjacentSpaceID", out value))
             {
                 if (value is string)
                 {

--- a/Revit_Engine/Query/CategoryName.cs
+++ b/Revit_Engine/Query/CategoryName.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
@@ -94,7 +95,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(Convert.CategoryName, out value))
+            if (bHoMObject.CustomData.TryGetValue(RevitAdapter.CategoryName, out value))
             {
                 if (value == null)
                     return null;

--- a/Revit_Engine/Query/Duplicate.cs
+++ b/Revit_Engine/Query/Duplicate.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -43,8 +44,8 @@ namespace BH.Engine.Adapters.Revit
 
             IBHoMObject obj = bHoMObject.GetShallowClone();
 
-            obj.CustomData.Remove(Convert.ElementId);
-            obj.CustomData.Remove(Convert.AdapterIdName);
+            obj.CustomData.Remove(RevitAdapter.ElementId);
+            obj.CustomData.Remove(RevitAdapter.AdapterIdName);
 
 
             return obj;

--- a/Revit_Engine/Query/Edges.cs
+++ b/Revit_Engine/Query/Edges.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
@@ -43,7 +44,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(Convert.Edges, out value))
+            if (bHoMObject.CustomData.TryGetValue(RevitAdapter.Edges, out value))
             {
                 if(value is IEnumerable<oM.Geometry.ICurve>)
                     return (value as IEnumerable<oM.Geometry.ICurve>).ToList();

--- a/Revit_Engine/Query/ElementId.cs
+++ b/Revit_Engine/Query/ElementId.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -41,7 +42,7 @@ namespace BH.Engine.Adapters.Revit
                 return -1;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(Convert.ElementId, out value))
+            if (bHoMObject.CustomData.TryGetValue(RevitAdapter.ElementId, out value))
             {
                 if (value is string)
                 {

--- a/Revit_Engine/Query/Family.cs
+++ b/Revit_Engine/Query/Family.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
@@ -61,7 +62,7 @@ namespace BH.Engine.Adapters.Revit
                         continue;
 
                     oM.Adapters.Revit.Properties.InstanceProperties instanceProps = Create.InstanceProperties(familyName, familyTypeName);
-                    instanceProps.CustomData[Convert.CategoryName] = categoryName;
+                    instanceProps.CustomData[RevitAdapter.CategoryName] = categoryName;
                     instanceProperties.Add(instanceProps);
                 }
             }
@@ -71,9 +72,9 @@ namespace BH.Engine.Adapters.Revit
                 PropertiesList = instanceProperties
             };
 
-            family.CustomData[Convert.FamilyName] = familyName;
-            family.CustomData[Convert.CategoryName] = categoryName;
-            family.CustomData[Convert.FamilyPlacementTypeName] = revitFilePreview.CustomDataValue(Convert.FamilyPlacementTypeName);
+            family.CustomData[RevitAdapter.FamilyName] = familyName;
+            family.CustomData[RevitAdapter.CategoryName] = categoryName;
+            family.CustomData[RevitAdapter.FamilyPlacementTypeName] = revitFilePreview.CustomDataValue(RevitAdapter.FamilyPlacementTypeName);
 
             return family;
         }

--- a/Revit_Engine/Query/FamilyName.cs
+++ b/Revit_Engine/Query/FamilyName.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -41,7 +42,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(Convert.FamilyName, out value))
+            if (bHoMObject.CustomData.TryGetValue(RevitAdapter.FamilyName, out value))
             {
                 if (value == null)
                     return null;

--- a/Revit_Engine/Query/FamilyPlacementTypeName.cs
+++ b/Revit_Engine/Query/FamilyPlacementTypeName.cs
@@ -21,6 +21,7 @@
  */
 
 
+using BH.Adapter.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -42,7 +43,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             object value = null;
-            if (!revitFilePreview.CustomData.TryGetValue(Convert.FamilyPlacementTypeName, out value))
+            if (!revitFilePreview.CustomData.TryGetValue(RevitAdapter.FamilyPlacementTypeName, out value))
                 return null;
 
             return value as string;
@@ -59,7 +60,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             object value = null;
-            if (!family.CustomData.TryGetValue(Convert.FamilyPlacementTypeName, out value))
+            if (!family.CustomData.TryGetValue(RevitAdapter.FamilyPlacementTypeName, out value))
                 return null;
 
             return value as string;

--- a/Revit_Engine/Query/FamilyTypeName.cs
+++ b/Revit_Engine/Query/FamilyTypeName.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -41,7 +42,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(Convert.FamilyTypeName, out value))
+            if (bHoMObject.CustomData.TryGetValue(RevitAdapter.FamilyTypeName, out value))
             {
                 if (value == null)
                     return null;

--- a/Revit_Engine/Query/SpaceId.cs
+++ b/Revit_Engine/Query/SpaceId.cs
@@ -33,6 +33,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [Deprecated("3.2", "BH.Engine.Adapters.Revit.Query.SpaceId is not used any more.")]
         [Description("Gets integer representation of ElementId of Revit space element correspondent to given BHoMObject. This value is stored in CustomData under key SpaceID.")]
         [Input("bHoMObject", "BHoMObject to be queried.")]
         [Output("elementId")]
@@ -42,7 +43,7 @@ namespace BH.Engine.Adapters.Revit
                 return -1;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(Convert.SpaceId, out value))
+            if (bHoMObject.CustomData.TryGetValue("SpaceID", out value))
             {
                 if (value is string)
                 {

--- a/Revit_Engine/Query/UniqueId.cs
+++ b/Revit_Engine/Query/UniqueId.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -42,7 +43,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(Convert.AdapterIdName, out value))
+            if (bHoMObject.CustomData.TryGetValue(RevitAdapter.AdapterIdName, out value))
             {
                 if (value is string)
                     return (string)value;

--- a/Revit_Engine/Query/WorksetId.cs
+++ b/Revit_Engine/Query/WorksetId.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Adapter.Revit;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -42,7 +43,7 @@ namespace BH.Engine.Adapters.Revit
                 return -1;
 
             object value = null;
-            if (bHoMObject.CustomData.TryGetValue(Convert.WorksetId, out value))
+            if (bHoMObject.CustomData.TryGetValue("Revit_worksetId", out value))
             {
                 if (value is string)
                 {

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -119,7 +119,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compute\SortByPerformance.cs" />
-    <Compile Include="Convert\AdapterIdName.cs" />
     <Compile Include="Create\Config\RevitPushConfig.cs" />
     <Compile Include="Create\Config\RevitPullConfig.cs" />
     <Compile Include="Create\Config\RevitRemoveConfig.cs" />
@@ -212,7 +211,9 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Convert\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #664
Closes #665
Closes #668
Closes #669

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[BEnv macro pull script](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2F%5FMacro%2FPull%2FEnvironment%2FFrom%20MajaLindroth) is possibly the best way to test, project scripts are also welcome.


### Changelog
- constant `CustomData` keys have been moved from `BH.Engine.Adapters.Revit.Convert` to `BH.Adapter.Revit.RevitAdapter` in _Aliases.cs_ file
- above keys under `WorksetId`, `SpaceId` and `AdjacentSpaceId` have been deleted as discussed in #664 and #668
- methods calling `SpaceId` and `AdjacentSpaceId` have been deprecated (in _Revit_Engine_) or deleted (in _Engine_Revit_UI_) - the latter was possible as _Engine_Revit_UI_ is not exposed in UIs + the methods were ones that are meant to be eliminated based on #670


### Additional comments
<!-- As required -->
Despite the number of changed files and closed issues, I believe this PR is rather easy to review, so please do not be scared 😆 