### PR TITLE
Pull of mesh representations implemented

### DIFF
--- a/Adapter_Revit_UI/Adapter_Revit_UI.csproj
+++ b/Adapter_Revit_UI/Adapter_Revit_UI.csproj
@@ -166,6 +166,10 @@
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Graphics_oM">
+      <HintPath>..\..\BHoM\Build\Graphics_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Physical_oM.dll</HintPath>
@@ -237,6 +241,7 @@
     <Compile Include="CRUD\Delete.cs" />
     <Compile Include="AdapterActions\Push.cs" />
     <Compile Include="CRUD\Read.cs" />
+    <Compile Include="CRUD\RenderMesh.cs" />
     <Compile Include="CRUD\Update.cs" />
     <Compile Include="FailuresProcessing.cs" />
     <Compile Include="Messages\Errors.cs" />

--- a/Adapter_Revit_UI/CRUD/Read.cs
+++ b/Adapter_Revit_UI/CRUD/Read.cs
@@ -162,7 +162,7 @@ namespace BH.UI.Revit.Adapter
 
             bool[] activePulls = new bool[] { geometryConfig.PullEdges, geometryConfig.PullSurfaces, geometryConfig.PullMeshes, representationConfig.PullRenderMesh };
             if (activePulls.Count(x => x == true) > 1)
-                BH.Engine.Reflection.Compute.RecordError("Pull of more than one geometry/representation type has been specified in RevitPullConfig. Please consider this can be time consuming due to the amount of conversions.");
+                BH.Engine.Reflection.Compute.RecordWarning("Pull of more than one geometry/representation type has been specified in RevitPullConfig. Please consider this can be time consuming due to the amount of conversions.");
 
             return result;
         }

--- a/Adapter_Revit_UI/CRUD/RenderMesh.cs
+++ b/Adapter_Revit_UI/CRUD/RenderMesh.cs
@@ -1,0 +1,12 @@
+﻿namespace BH.UI.Revit.Adapter
+{
+    internal class RenderMesh
+    {
+        public RenderMesh()
+        {
+        }
+
+        public object Faces { get; set; }
+        public object Vertices { get; set; }
+    }
+}

--- a/Engine_Revit_UI/Convert/Geometry/FromRevit/Mesh.cs
+++ b/Engine_Revit_UI/Convert/Geometry/FromRevit/Mesh.cs
@@ -20,25 +20,30 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-namespace BH.Engine.Adapters.Revit
+using Autodesk.Revit.DB;
+using System.Linq;
+
+namespace BH.UI.Revit.Engine
 {
-    public partial class Convert
+    public static partial class Convert
     {
         /***************************************************/
-        /****           Public Fields                   ****/
+        /****               Public Methods              ****/
         /***************************************************/
-        
-        public const string AdapterIdName = "Revit_id";
-        public const string ElementId = "Revit_elementId";
-        public const string FamilyName = "Revit_familyName";
-        public const string FamilyTypeName = "Revit_familyTypeName";
-        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
-        public const string CategoryName = "Revit_categoryName";
-        public const string ViewName = "Revit_viewName";
-        public const string ViewTemplate = "View Template";
-        public const string Edges = "Revit_edges";
-        public const string Surfaces = "Revit_surfaces";
-        public const string Representation = "MeshRepresentation";
+
+        public static oM.Geometry.Mesh FromRevit(this Mesh mesh)
+        {
+            if (mesh == null)
+                return null;
+
+            oM.Geometry.Mesh bHoMMesh = new oM.Geometry.Mesh { Vertices = mesh.Vertices.Select(x => x.PointFromRevit()).ToList() };
+            for (int i = 0; i < mesh.NumTriangles; i++)
+            {
+                bHoMMesh.Faces.Add(mesh.get_Triangle(i).FromRevit());
+            }
+
+            return bHoMMesh;
+        }
 
         /***************************************************/
     }

--- a/Engine_Revit_UI/Convert/Geometry/FromRevit/MeshFace.cs
+++ b/Engine_Revit_UI/Convert/Geometry/FromRevit/MeshFace.cs
@@ -20,25 +20,23 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-namespace BH.Engine.Adapters.Revit
+using Autodesk.Revit.DB;
+
+namespace BH.UI.Revit.Engine
 {
-    public partial class Convert
+    public static partial class Convert
     {
         /***************************************************/
-        /****           Public Fields                   ****/
+        /****               Public Methods              ****/
         /***************************************************/
-        
-        public const string AdapterIdName = "Revit_id";
-        public const string ElementId = "Revit_elementId";
-        public const string FamilyName = "Revit_familyName";
-        public const string FamilyTypeName = "Revit_familyTypeName";
-        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
-        public const string CategoryName = "Revit_categoryName";
-        public const string ViewName = "Revit_viewName";
-        public const string ViewTemplate = "View Template";
-        public const string Edges = "Revit_edges";
-        public const string Surfaces = "Revit_surfaces";
-        public const string Representation = "MeshRepresentation";
+
+        public static oM.Geometry.Face FromRevit(this MeshTriangle triangle)
+        {
+            if (triangle == null)
+                return null;
+
+            return new oM.Geometry.Face { A = (int)triangle.get_Index(0), B = (int)triangle.get_Index(1), C = (int)triangle.get_Index(2) };
+        }
 
         /***************************************************/
     }

--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -333,7 +333,7 @@
     <Compile Include="Objects\WarningSwallower.cs" />
     <Compile Include="Query\ArbitraryPlane.cs" />
     <Compile Include="Query\BoundingBox.cs" />
-    <Compile Include="Query\LevelOfDetail.cs" />
+    <Compile Include="Query\FaceTriangulationFactor.cs" />
     <Compile Include="Query\Representation.cs" />
     <Compile Include="Query\Surfaces.cs" />
     <Compile Include="Query\ElementIds\ElementIds.cs" />

--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -243,6 +243,8 @@
     <Compile Include="Convert\Architecture\FromRevit\Room.cs" />
     <Compile Include="Convert\Environment\FromRevit\EnergyAnalysisModel.cs" />
     <Compile Include="Convert\Environment\ToRevit\Space.cs" />
+    <Compile Include="Convert\Geometry\FromRevit\Mesh.cs" />
+    <Compile Include="Convert\Geometry\FromRevit\MeshFace.cs" />
     <Compile Include="Convert\Geometry\FromRevit\SurfaceList.cs" />
     <Compile Include="Convert\Geometry\FromRevit\Surface.cs" />
     <Compile Include="Convert\Geometry\FromRevit\Curve.cs" />
@@ -331,6 +333,8 @@
     <Compile Include="Objects\WarningSwallower.cs" />
     <Compile Include="Query\ArbitraryPlane.cs" />
     <Compile Include="Query\BoundingBox.cs" />
+    <Compile Include="Query\LevelOfDetail.cs" />
+    <Compile Include="Query\Representation.cs" />
     <Compile Include="Query\Surfaces.cs" />
     <Compile Include="Query\ElementIds\ElementIds.cs" />
     <Compile Include="Query\ElementIds\ElementIdsByBHoMType.cs" />
@@ -379,6 +383,7 @@
     <Compile Include="Query\View.cs" />
     <Compile Include="Query\UpdatePanelTypeByCustomData.cs" />
     <Compile Include="Query\LowElevation.cs" />
+    <Compile Include="Query\ViewDetailLevel.cs" />
     <Compile Include="Query\ViewType.cs" />
     <Compile Include="Query\Name.cs" />
     <Compile Include="Query\LowLevel.cs" />

--- a/Engine_Revit_UI/Engine_Revit_UI.csproj
+++ b/Engine_Revit_UI/Engine_Revit_UI.csproj
@@ -334,7 +334,7 @@
     <Compile Include="Query\ArbitraryPlane.cs" />
     <Compile Include="Query\BoundingBox.cs" />
     <Compile Include="Query\FaceTriangulationFactor.cs" />
-    <Compile Include="Query\Representation.cs" />
+    <Compile Include="Query\Meshes.cs" />
     <Compile Include="Query\Surfaces.cs" />
     <Compile Include="Query\ElementIds\ElementIds.cs" />
     <Compile Include="Query\ElementIds\ElementIdsByBHoMType.cs" />

--- a/Engine_Revit_UI/Query/FaceTriangulationFactor.cs
+++ b/Engine_Revit_UI/Query/FaceTriangulationFactor.cs
@@ -20,26 +20,30 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-namespace BH.Engine.Adapters.Revit
+using Autodesk.Revit.DB;
+
+namespace BH.UI.Revit.Engine
 {
-    public partial class Convert
+    public static partial class Query
     {
         /***************************************************/
-        /****           Public Fields                   ****/
+        /****              Public methods               ****/
         /***************************************************/
-        
-        public const string AdapterIdName = "Revit_id";
-        public const string ElementId = "Revit_elementId";
-        public const string FamilyName = "Revit_familyName";
-        public const string FamilyTypeName = "Revit_familyTypeName";
-        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
-        public const string CategoryName = "Revit_categoryName";
-        public const string ViewName = "Revit_viewName";
-        public const string ViewTemplate = "View Template";
-        public const string Edges = "Revit_edges";
-        public const string Surfaces = "Revit_surfaces";
-        public const string Representation = "MeshRepresentation";
+
+        public static double FaceTriangulationFactor(this ViewDetailLevel viewDetailLevel)
+        {
+            switch (viewDetailLevel)
+            {
+                case Autodesk.Revit.DB.ViewDetailLevel.Coarse:
+                    return 0;
+                case Autodesk.Revit.DB.ViewDetailLevel.Fine:
+                    return 1;
+                default:
+                    return 0.5;
+            }
+        }
 
         /***************************************************/
     }
 }
+

--- a/Engine_Revit_UI/Query/Meshes.cs
+++ b/Engine_Revit_UI/Query/Meshes.cs
@@ -33,7 +33,7 @@ namespace BH.UI.Revit.Engine
         /****              Public methods               ****/
         /***************************************************/
 
-        public static List<oM.Geometry.IGeometry> Representation(this GeometryElement geometryElement, Transform transform = null, Options options = null, RevitSettings settings = null)
+        public static List<oM.Geometry.IGeometry> Meshes(this GeometryElement geometryElement, Transform transform = null, Options options = null, RevitSettings settings = null)
         {
             if (geometryElement == null)
                 return null;
@@ -52,16 +52,16 @@ namespace BH.UI.Revit.Engine
                     if (transform != null)
                         geometryTransform = geometryTransform.Multiply(transform.Inverse);
 
-                    List<oM.Geometry.IGeometry> representation = null;
+                    List<oM.Geometry.IGeometry> mesh = null;
                     GeometryElement geomElement = null;
 
                     geomElement = geometryInstance.GetInstanceGeometry(geometryTransform);
                     if (geomElement == null)
                         continue;
 
-                    representation = geomElement.Representation(null, options, settings);
-                    if (representation != null && representation.Count != 0)
-                        result.AddRange(representation);
+                    mesh = geomElement.Meshes(null, options, settings);
+                    if (mesh != null && mesh.Count != 0)
+                        result.AddRange(mesh);
                 }
                 else if (geometryObject is Solid)
                 {
@@ -95,7 +95,7 @@ namespace BH.UI.Revit.Engine
 
         /***************************************************/
 
-        public static List<oM.Geometry.IGeometry> Representation(this Element element, Options options, RevitSettings settings = null)
+        public static List<oM.Geometry.IGeometry> Meshes(this Element element, Options options, RevitSettings settings = null)
         {
             GeometryElement geometryElement = element.get_Geometry(options);
 
@@ -103,7 +103,7 @@ namespace BH.UI.Revit.Engine
             if (element is FamilyInstance)
                 transform = ((FamilyInstance)element).GetTotalTransform();
 
-            return geometryElement.Representation(transform, options, settings);
+            return geometryElement.Meshes(transform, options, settings);
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Query/ViewDetailLevel.cs
+++ b/Engine_Revit_UI/Query/ViewDetailLevel.cs
@@ -20,26 +20,22 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-namespace BH.Engine.Adapters.Revit
+using Autodesk.Revit.DB;
+
+namespace BH.UI.Revit.Engine
 {
-    public partial class Convert
+    public static partial class Query
     {
         /***************************************************/
-        /****           Public Fields                   ****/
+        /****              Public methods               ****/
         /***************************************************/
-        
-        public const string AdapterIdName = "Revit_id";
-        public const string ElementId = "Revit_elementId";
-        public const string FamilyName = "Revit_familyName";
-        public const string FamilyTypeName = "Revit_familyTypeName";
-        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
-        public const string CategoryName = "Revit_categoryName";
-        public const string ViewName = "Revit_viewName";
-        public const string ViewTemplate = "View Template";
-        public const string Edges = "Revit_edges";
-        public const string Surfaces = "Revit_surfaces";
-        public const string Representation = "MeshRepresentation";
+
+        public static ViewDetailLevel ViewDetailLevel(this oM.Adapters.Revit.Enums.DetailLevel detailLevel)
+        {
+            return (ViewDetailLevel)(detailLevel);
+        }
 
         /***************************************************/
     }
 }
+

--- a/Revit_Adapter/Revit_Adapter.csproj
+++ b/Revit_Adapter/Revit_Adapter.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Revit_Engine/Convert/Aliases.cs
+++ b/Revit_Engine/Convert/Aliases.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Adapters.Revit
         public const string ViewTemplate = "View Template";
         public const string Edges = "Revit_edges";
         public const string Surfaces = "Revit_surfaces";
-        public const string Representation = "MeshRepresentation";
+        public const string Meshes = "Revit_meshes";
+        public const string RenderMesh = "RenderMesh";
 
         /***************************************************/
     }

--- a/Revit_Engine/Convert/Aliases.cs
+++ b/Revit_Engine/Convert/Aliases.cs
@@ -22,7 +22,7 @@
 
 namespace BH.Engine.Adapters.Revit
 {
-    public partial class Convert
+    public static partial class Convert
     {
         /***************************************************/
         /****           Public Fields                   ****/

--- a/Revit_Engine/Create/Config/RevitPullConfig.cs
+++ b/Revit_Engine/Create/Config/RevitPullConfig.cs
@@ -36,12 +36,12 @@ namespace BH.Engine.Adapters.Revit
         [Description("Creates a pull action-specific configuration used for adapter interaction with Revit.")]
         [InputFromProperty("discipline")]
         [InputFromProperty("includeClosedWorksets")]
-        [InputFromProperty("pullEdges")]
-        [InputFromProperty("includeNonVisible")]
+        [InputFromProperty("geometryConfig")]
+        [InputFromProperty("representationConfig")]
         [Output("revitPullConfig")]
-        public static RevitPullConfig RevitPullConfig(Discipline discipline = Discipline.Undefined, bool includeClosedWorksets = false, bool pullEdges = false, bool pullSurfaces = false, bool includeNonVisible = false)
+        public static RevitPullConfig RevitPullConfig(Discipline discipline = Discipline.Undefined, bool includeClosedWorksets = false, PullGeometryConfig geometryConfig = null, PullRepresentationConfig representationConfig = null)
         {
-            return new RevitPullConfig { Discipline = discipline, IncludeClosedWorksets = includeClosedWorksets, PullEdges = pullEdges, PullSurfaces = pullSurfaces, IncludeNonVisible = includeNonVisible };
+            return new RevitPullConfig { Discipline = discipline, IncludeClosedWorksets = includeClosedWorksets, GeometryConfig = geometryConfig, RepresentationConfig = representationConfig };
         }
 
         /***************************************************/

--- a/Revit_Engine/Create/Config/RevitPullConfig.cs
+++ b/Revit_Engine/Create/Config/RevitPullConfig.cs
@@ -45,5 +45,21 @@ namespace BH.Engine.Adapters.Revit
         }
 
         /***************************************************/
+
+        [ToBeRemoved("3.2", "Non-applicable due to the changes in RevitPullConfig class.")]
+        [Description("Creates a pull action-specific configuration used for adapter interaction with Revit.")]
+        [InputFromProperty("discipline")]
+        [InputFromProperty("includeClosedWorksets")]
+        [InputFromProperty("pullEdges")]
+        [InputFromProperty("includeNonVisible")]
+        [Output("revitPullConfig")]
+        public static RevitPullConfig RevitPullConfig(Discipline discipline = Discipline.Undefined, bool includeClosedWorksets = false, bool pullEdges = false, bool pullSurfaces = false, bool includeNonVisible = false)
+        {
+            PullGeometryConfig geometryConfig = new PullGeometryConfig { PullEdges = pullEdges, PullSurfaces = pullSurfaces, IncludeNonVisible = includeNonVisible };
+            PullRepresentationConfig representationConfig = new PullRepresentationConfig();
+            return new RevitPullConfig { Discipline = discipline, IncludeClosedWorksets = includeClosedWorksets, GeometryConfig = geometryConfig, RepresentationConfig = representationConfig };
+        }
+
+        /***************************************************/
     }
 }

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Revit_oM/Config/PullGeometryConfig.cs
+++ b/Revit_oM/Config/PullGeometryConfig.cs
@@ -20,25 +20,26 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-namespace BH.Engine.Adapters.Revit
+using BH.oM.Adapter;
+using System.ComponentModel;
+
+namespace BH.oM.Adapters.Revit
 {
-    public partial class Convert
+    [Description("Configuration used to specify which geometry should be pulled and passed to CustomData.")]
+    public class PullGeometryConfig
     {
         /***************************************************/
-        /****           Public Fields                   ****/
+        /****             Public Properties             ****/
         /***************************************************/
-        
-        public const string AdapterIdName = "Revit_id";
-        public const string ElementId = "Revit_elementId";
-        public const string FamilyName = "Revit_familyName";
-        public const string FamilyTypeName = "Revit_familyTypeName";
-        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
-        public const string CategoryName = "Revit_categoryName";
-        public const string ViewName = "Revit_viewName";
-        public const string ViewTemplate = "View Template";
-        public const string Edges = "Revit_edges";
-        public const string Surfaces = "Revit_surfaces";
-        public const string Representation = "MeshRepresentation";
+
+        [Description("If true, edges of elements will be pulled and stored under Revit_edges in CustomData.")]
+        public virtual bool PullEdges { get; set; } = false;
+
+        [Description("If true, surfaces of elements will be pulled and stored under Revit_surfaces in CustomData.")]
+        public virtual bool PullSurfaces { get; set; } = false;
+
+        [Description("Invisible element parts will be pulled and passed to CustomData if true. PullEdges or PullSurfaces switched to true needed for this to activate.")]
+        public virtual bool IncludeNonVisible { get; set; } = false;
 
         /***************************************************/
     }

--- a/Revit_oM/Config/PullGeometryConfig.cs
+++ b/Revit_oM/Config/PullGeometryConfig.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Adapter;
+using BH.oM.Adapters.Revit.Enums;
 using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit
@@ -37,6 +38,12 @@ namespace BH.oM.Adapters.Revit
 
         [Description("If true, surfaces of elements will be pulled and stored under Revit_surfaces in CustomData.")]
         public virtual bool PullSurfaces { get; set; } = false;
+
+        [Description("If true, meshed surfaces of elements will be pulled and stored under Revit_meshes in CustomData.")]
+        public virtual bool PullMeshes { get; set; } = false;
+
+        [Description("Detail level of mesh to be pulled, correspondent to level of detail in Revit.")]
+        public virtual DetailLevel MeshDetailLevel { get; set; } = DetailLevel.Medium;
 
         [Description("Invisible element parts will be pulled and passed to CustomData if true. PullEdges or PullSurfaces switched to true needed for this to activate.")]
         public virtual bool IncludeNonVisible { get; set; } = false;

--- a/Revit_oM/Config/PullRepresentationConfig.cs
+++ b/Revit_oM/Config/PullRepresentationConfig.cs
@@ -20,25 +20,27 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-namespace BH.Engine.Adapters.Revit
+using BH.oM.Adapter;
+using BH.oM.Adapters.Revit.Enums;
+using System.ComponentModel;
+
+namespace BH.oM.Adapters.Revit
 {
-    public partial class Convert
+    [Description("Configuration used to specify representation to be pulled and passed to CustomData.")]
+    public class PullRepresentationConfig
     {
         /***************************************************/
-        /****           Public Fields                   ****/
+        /****             Public Properties             ****/
         /***************************************************/
-        
-        public const string AdapterIdName = "Revit_id";
-        public const string ElementId = "Revit_elementId";
-        public const string FamilyName = "Revit_familyName";
-        public const string FamilyTypeName = "Revit_familyTypeName";
-        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
-        public const string CategoryName = "Revit_categoryName";
-        public const string ViewName = "Revit_viewName";
-        public const string ViewTemplate = "View Template";
-        public const string Edges = "Revit_edges";
-        public const string Surfaces = "Revit_surfaces";
-        public const string Representation = "MeshRepresentation";
+
+        [Description("If true, representation of elements will be pulled and stored under MeshRepresentation in CustomData.")]
+        public virtual bool PullRepresentation { get; set; } = false;
+
+        [Description("Detail level of representation, correspondent to level of detail in Revit.")]
+        public virtual DetailLevel DetailLevel { get; set; } = DetailLevel.Medium;
+
+        [Description("Invisible element parts will be pulled and passed to CustomData if true. PullRepresentation switched to true needed for this to activate.")]
+        public virtual bool IncludeNonVisible { get; set; } = false;
 
         /***************************************************/
     }

--- a/Revit_oM/Config/PullRepresentationConfig.cs
+++ b/Revit_oM/Config/PullRepresentationConfig.cs
@@ -33,8 +33,8 @@ namespace BH.oM.Adapters.Revit
         /****             Public Properties             ****/
         /***************************************************/
 
-        [Description("If true, representation of elements will be pulled and stored under MeshRepresentation in CustomData.")]
-        public virtual bool PullRepresentation { get; set; } = false;
+        [Description("If true, representation of elements will be pulled and stored under RenderMesh in CustomData.")]
+        public virtual bool PullRenderMesh { get; set; } = false;
 
         [Description("Detail level of representation, correspondent to level of detail in Revit.")]
         public virtual DetailLevel DetailLevel { get; set; } = DetailLevel.Medium;

--- a/Revit_oM/Config/RevitPullConfig.cs
+++ b/Revit_oM/Config/RevitPullConfig.cs
@@ -41,14 +41,11 @@ namespace BH.oM.Adapters.Revit
         [Description("Elements from closed worksets will be processed if true.")]
         public virtual bool IncludeClosedWorksets { get; set; } = false;
 
-        [Description("If true, edges of elements will be pulled and stored under Revit_edges in CustomData.")]
-        public virtual bool PullEdges { get; set; } = false;
+        [Description("Configuration specifying which geometry should be pulled and passed to CustomData.")]
+        public virtual PullGeometryConfig GeometryConfig { get; set; } = new PullGeometryConfig();
 
-        [Description("If true, surfaces of elements will be pulled and stored under Revit_surfaces in CustomData.")]
-        public virtual bool PullSurfaces { get; set; } = false;
-
-        [Description("Invisible element edges will be pulled and passed to CustomData if true. PullEdges switched to true needed for this to activate.")]
-        public virtual bool IncludeNonVisible { get; set; } = false;
+        [Description("Configuration specifying representation to be pulled and passed to CustomData.")]
+        public virtual PullRepresentationConfig RepresentationConfig { get; set; } = new PullRepresentationConfig();
 
         /***************************************************/
     }

--- a/Revit_oM/Enums/DetailLevel.cs
+++ b/Revit_oM/Enums/DetailLevel.cs
@@ -20,26 +20,22 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-namespace BH.Engine.Adapters.Revit
-{
-    public partial class Convert
-    {
-        /***************************************************/
-        /****           Public Fields                   ****/
-        /***************************************************/
-        
-        public const string AdapterIdName = "Revit_id";
-        public const string ElementId = "Revit_elementId";
-        public const string FamilyName = "Revit_familyName";
-        public const string FamilyTypeName = "Revit_familyTypeName";
-        public const string FamilyPlacementTypeName = "Revit_familyPlacementTypeName";
-        public const string CategoryName = "Revit_categoryName";
-        public const string ViewName = "Revit_viewName";
-        public const string ViewTemplate = "View Template";
-        public const string Edges = "Revit_edges";
-        public const string Surfaces = "Revit_surfaces";
-        public const string Representation = "MeshRepresentation";
+using System.ComponentModel;
 
-        /***************************************************/
+namespace BH.oM.Adapters.Revit.Enums
+{
+    /***************************************************/
+
+    [Description("Enum specifying detail level of representation, correspondent to level of detail in Revit.")]
+    public enum DetailLevel
+    {
+        [Description("Coarse - correspondent to Revit level of detail with same name.")]
+        Coarse = 1,
+        [Description("Medium - correspondent to Revit level of detail with same name.")]
+        Medium = 2,
+        [Description("Fine - correspondent to Revit level of detail with same name.")]
+        Fine = 3
     }
+
+    /***************************************************/
 }

--- a/Revit_oM/Revit_oM.csproj
+++ b/Revit_oM/Revit_oM.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Revit_oM/Revit_oM.csproj
+++ b/Revit_oM/Revit_oM.csproj
@@ -71,6 +71,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config\PullGeometryConfig.cs" />
+    <Compile Include="Config\PullRepresentationConfig.cs" />
     <Compile Include="Config\RevitRemoveConfig.cs" />
     <Compile Include="Elements\DraftingInstance.cs" />
     <Compile Include="Elements\Family.cs" />
@@ -78,6 +80,7 @@
     <Compile Include="Elements\ModelInstance.cs" />
     <Compile Include="Elements\Viewport.cs" />
     <Compile Include="Enums\AdapterMode.cs" />
+    <Compile Include="Enums\DetailLevel.cs" />
     <Compile Include="Enums\Discipline.cs" />
     <Compile Include="Enums\NumberComparisonType.cs" />
     <Compile Include="Enums\RevitViewType.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #681
Closes #685

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue685%2DPullRepresentations).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `PullGeometryConfig` and `PullRepresentationConfig` have been implemented
- the above replaced `PullEdges`, `PullSurfaces` and `IncludeNonVisible` properties of `RevitPullConfig`
- Convert of Autodesk.Revit.DB.Mesh to BHoM has been implemented

### Additional comments
<!-- As required -->
This PR will break all existing scripts that used `RevitPullConfig`. I am unhappy about that, but could not think of versioning for a type that lost its `bool` properties in favour of newly implemented types.

To finish with a positive, the outcome is promising:
![image](https://user-images.githubusercontent.com/26874773/80989368-24cc4880-8e35-11ea-901c-341e891700fe.png)

**EDIT**: RenderMesh is a bit of a workaround atm, needs to be further refined - issue to be raised after this PR gets merged.