### PR TITLE
Minor bugs fixed

### DIFF
--- a/Engine_Revit_UI/Query/ElementIds/ElementIdsByDBType.cs
+++ b/Engine_Revit_UI/Query/ElementIds/ElementIdsByDBType.cs
@@ -44,12 +44,15 @@ namespace BH.UI.Revit.Engine
         [Output("elementIds", "Collection of filtered ElementIds.")]
         public static IEnumerable<ElementId> ElementIdsByDBType(this Document document, string currentDomainAssembly, string typeName, IEnumerable<ElementId> ids = null)
         {
-            if (document == null || string.IsNullOrEmpty(currentDomainAssembly) || string.IsNullOrEmpty(typeName))
+            if (document == null || string.IsNullOrWhiteSpace(currentDomainAssembly) || string.IsNullOrWhiteSpace(typeName))
                 return null;
             
             Assembly assembly = BH.Engine.Adapters.Revit.Query.CurrentDomainAssembly(currentDomainAssembly);
             if (assembly == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError(String.Format("Assembly {0} could not be found.", currentDomainAssembly));
                 return null;
+            }
 
             string fullTypeName = null; ;
 
@@ -60,9 +63,6 @@ namespace BH.UI.Revit.Engine
                 else
                     fullTypeName = typeName;
             }
-
-            if (string.IsNullOrEmpty(fullTypeName))
-                return null;
 
             Type type = null;
 
@@ -85,6 +85,12 @@ namespace BH.UI.Revit.Engine
                         break;
                     }
                 }
+            }
+
+            if (type == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError(String.Format("Type {0} could not be found in the assembly.", typeName));
+                return new List<ElementId>();
             }
 
             if (ids != null && ids.Count() == 0)

--- a/Engine_Revit_UI/Query/Faces.cs
+++ b/Engine_Revit_UI/Query/Faces.cs
@@ -37,7 +37,7 @@ namespace BH.UI.Revit.Engine
         {
             List<GeometryObject> geometryPrimitives = element.GeometryPrimitives(options, settings);
             if (geometryPrimitives == null)
-                return null;
+                return new List<Face>();
 
             List<Face> result = geometryPrimitives.Where(x => x is Face).Cast<Face>().ToList();
             foreach (Solid solid in geometryPrimitives.Where(x => x is Solid))

--- a/Engine_Revit_UI/Query/Faces.cs
+++ b/Engine_Revit_UI/Query/Faces.cs
@@ -37,7 +37,7 @@ namespace BH.UI.Revit.Engine
         {
             List<GeometryObject> geometryPrimitives = element.GeometryPrimitives(options, settings);
             if (geometryPrimitives == null)
-                return new List<Face>();
+                return null;
 
             List<Face> result = geometryPrimitives.Where(x => x is Face).Cast<Face>().ToList();
             foreach (Solid solid in geometryPrimitives.Where(x => x is Solid))

--- a/Engine_Revit_UI/Query/GeometryPrimitives.cs
+++ b/Engine_Revit_UI/Query/GeometryPrimitives.cs
@@ -72,6 +72,8 @@ namespace BH.UI.Revit.Engine
                 return null;
 
             GeometryElement geometryElement = element.get_Geometry(options);
+            if (geometryElement == null)
+                return new List<GeometryObject>();
 
             Transform transform = null;
             if (element is FamilyInstance)

--- a/Revit_Engine/Query/Edges.cs
+++ b/Revit_Engine/Query/Edges.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Base;
+using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -37,7 +38,7 @@ namespace BH.Engine.Adapters.Revit
         [Description("Returns edges of given BHoMObject captured on Pull. This value is stored in CustomData under key Revit_edges.")]
         [Input("bHoMObject", "BHoMObject to be queried.")]
         [Output("edges")]
-        public static List<oM.Geometry.ICurve> Edges(this IBHoMObject bHoMObject)
+        public static List<ICurve> Edges(this IBHoMObject bHoMObject)
         {
             if (bHoMObject == null)
                 return null;
@@ -45,8 +46,9 @@ namespace BH.Engine.Adapters.Revit
             object value = null;
             if (bHoMObject.CustomData.TryGetValue(Convert.Edges, out value))
             {
-                if(value is IEnumerable<oM.Geometry.ICurve>)
-                    return (value as IEnumerable<oM.Geometry.ICurve>).ToList();
+                IEnumerable<object> curves = value as IEnumerable<object>;
+                if (curves != null && curves.All(x => x is ICurve))
+                    return curves.Cast<ICurve>().ToList();
             }
 
             return null;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #432
Closes #712
Closes #713

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[#432](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue432%2DQueryEdges&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)
[#712](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue712%2DDBTypeCrash&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)
[#713](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue713%2DGenericModelSurfaces&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- BH.Engine.Adapters.Revit.Query.Edges method has been fixed to return values
- `FilterByDBTypeName` has been stopped from crashing on nonexistent type names
- `BH.UI.Revit.Engine.Query.GeometryPrimitives(Element)` fixed not to return null when the element exists but has no geometry

