### PR TITLE
Ellipse conversion error changed to a sensible warning

### DIFF
--- a/Engine_Revit_UI/Compute/Warnings.cs
+++ b/Engine_Revit_UI/Compute/Warnings.cs
@@ -470,7 +470,7 @@ namespace BH.UI.Revit.Engine
 
         internal static void CurveToBHoMNotImplemented(this Curve curve)
         {
-            BH.Engine.Reflection.Compute.RecordError(string.Format("Conversion of curve type {0} to BHoM is not implemented, an approximated Polyline is returned instead.", curve.GetType().ToString().Split('.').Last()));
+            BH.Engine.Reflection.Compute.RecordError(string.Format("Conversion for curve type {0} to BHoM is not implemented.", curve.GetType().ToString().Split('.').Last()));
         }
 
         /***************************************************/

--- a/Engine_Revit_UI/Convert/Geometry/FromRevit/Curve.cs
+++ b/Engine_Revit_UI/Convert/Geometry/FromRevit/Curve.cs
@@ -78,7 +78,7 @@ namespace BH.UI.Revit.Engine
                 return new oM.Geometry.Ellipse { Centre = curve.Center.PointFromRevit(), Axis1 = curve.XDirection.VectorFromRevit().Normalise(), Radius1 = curve.RadiusX.ToSI(UnitType.UT_Length), Axis2 = curve.YDirection.VectorFromRevit().Normalise(), Radius2 = curve.RadiusY.ToSI(UnitType.UT_Length) };
             else
             {
-                BH.Engine.Reflection.Compute.RecordError("Conversion of open ellipses to BHoM is currently not supported.");
+                BH.Engine.Reflection.Compute.RecordWarning("Conversion of open ellipses is currently not supported because of lack of support for such type in BHoM.");
                 return null;
             }
         }
@@ -191,14 +191,13 @@ namespace BH.UI.Revit.Engine
 
             if (result == null)
             {
+                BH.Engine.Reflection.Compute.RecordWarning("Curve types without conversion support have been tesellated and converted into Polylines.");
+
                 IList<XYZ> xyzList = curve.Tessellate();
                 if (xyzList == null || xyzList.Count < 2)
                     result = null;
                 else
-                {
-                    BH.Engine.Reflection.Compute.RecordWarning("The curve types without conversion support have been tesellated and converted into Polylines.");
                     result = new BH.oM.Geometry.Polyline { ControlPoints = xyzList.Select(x => x.PointFromRevit()).ToList() };
-                }
             }
 
             return result;

--- a/Engine_Revit_UI/Convert/Geometry/FromRevit/Curve.cs
+++ b/Engine_Revit_UI/Convert/Geometry/FromRevit/Curve.cs
@@ -191,7 +191,7 @@ namespace BH.UI.Revit.Engine
 
             if (result == null)
             {
-                BH.Engine.Reflection.Compute.RecordWarning("Curve types without conversion support have been tesellated and converted into Polylines.");
+                BH.Engine.Reflection.Compute.RecordWarning("Curve types without conversion support have been tessellated and converted into Polylines.");
 
                 IList<XYZ> xyzList = curve.Tessellate();
                 if (xyzList == null || xyzList.Count < 2)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #719

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
<!-- Link to test files to help reproduce the bug and validate the proposed fixes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue719%2DEllipseBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Additional comments
<!-- As required -->
#719 states that it is a conversion bug - apparently, the conversion method is correct (it takes out as much as it can), the problem is error being raised instead of a warning. This has been fixed by this PR, further work can possibly be done as a part of https://github.com/BHoM/Revit_Toolkit/issues/445 (conversion of 2 Revit half-circles <=> 1 BHoM circle, same for ellypses).