### PR TITLE
RevitTypes method supported with a private dictionary to avoid Reflection overhead

### DIFF
--- a/Engine_Revit_UI/Query/RevitTypes.cs
+++ b/Engine_Revit_UI/Query/RevitTypes.cs
@@ -36,7 +36,10 @@ namespace BH.UI.Revit.Engine
 
         public static IEnumerable<Type> RevitTypes(this Type type)
         {
-            HashSet<Type> types = new HashSet<Type>();
+            if (m_revitTypes.ContainsKey(type))
+                return m_revitTypes[type];
+
+            HashSet<Type> revitTypes = new HashSet<Type>();
             BindingFlags bindingBHoM = BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Static;
             foreach (Type t in Assembly.GetExecutingAssembly().GetTypes())
             {
@@ -51,13 +54,21 @@ namespace BH.UI.Revit.Engine
                     {
                         Type parameterType = mi.GetParameters().First().ParameterType;
                         if (parameterType != typeof(Element) && typeof(Element).IsAssignableFrom(parameterType))
-                            types.Add(parameterType);
+                            revitTypes.Add(parameterType);
                     }
                 }
             }
 
-            return types;
+            m_revitTypes.Add(type, revitTypes);
+            return revitTypes;
         }
+
+
+        /***************************************************/
+        /****              Private Fields               ****/
+        /***************************************************/
+
+        private static Dictionary<Type, HashSet<Type>> m_revitTypes = new Dictionary<Type, HashSet<Type>>();
 
         /***************************************************/
     }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #600

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue600%2DSupportRevitTypesWithDictionary&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - open an empty Revit doc and look up the time of an empty run (please remember the 1st run is not representative due to Revit Listener startup). On this branch it should be ~20% faster than on master.

Any column can be modelled in Revit and pulled to check if the functionality itself is still valid.