### PR TITLE
Pull of BEnv elements stopped from returning duplicate elements

### DIFF
--- a/Revit_Core_Engine/Modify/RemoveDuplicateAnalyticalElements.cs
+++ b/Revit_Core_Engine/Modify/RemoveDuplicateAnalyticalElements.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Analysis;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static List<ElementId> RemoveDuplicateAnalyticalElements(this IEnumerable<ElementId> ids, Document document)
+        {
+            List<ElementId> result = new List<ElementId>(ids);
+            List<Element> elements = ids.Select(x => document.GetElement(x)).ToList();
+
+            for (int i = result.Count - 1; i >= 0; i--)
+            {
+                Element element = elements[i];
+
+                //if (element is EnergyAnalysisSpace)
+                //{
+                //    Element e = document.GetElement(((EnergyAnalysisSpace)element).CADObjectUniqueId);
+                //    if (e != null)
+                //    {
+                //        int id = e.Id.IntegerValue;
+                //        bool foo = elements.Any(x => x.Id.IntegerValue == id);
+
+                //        if (foo == true)
+                //        {
+                //            //
+                //        }
+                //    }
+                //}
+
+                
+                if (element is EnergyAnalysisOpening && elements.Any(x => x.UniqueId == ((EnergyAnalysisOpening)element).CADObjectUniqueId))
+                {
+                    result.RemoveAt(i);
+                    continue;
+                }
+                else if (element is EnergyAnalysisSpace && elements.Any(x => x.UniqueId == ((EnergyAnalysisSpace)element).CADObjectUniqueId))
+                {
+                    result.RemoveAt(i);
+                    continue;
+                }
+                else if (element is EnergyAnalysisSurface && elements.Any(x => x.UniqueId == ((EnergyAnalysisSurface)element).CADObjectUniqueId))
+                {
+                    result.RemoveAt(i);
+                    continue;
+                }
+            }
+
+            return result;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Modify/RemoveDuplicateAnalyticalElements.cs
+++ b/Revit_Core_Engine/Modify/RemoveDuplicateAnalyticalElements.cs
@@ -41,22 +41,6 @@ namespace BH.Revit.Engine.Core
             for (int i = result.Count - 1; i >= 0; i--)
             {
                 Element element = elements[i];
-
-                //if (element is EnergyAnalysisSpace)
-                //{
-                //    Element e = document.GetElement(((EnergyAnalysisSpace)element).CADObjectUniqueId);
-                //    if (e != null)
-                //    {
-                //        int id = e.Id.IntegerValue;
-                //        bool foo = elements.Any(x => x.Id.IntegerValue == id);
-
-                //        if (foo == true)
-                //        {
-                //            //
-                //        }
-                //    }
-                //}
-
                 
                 if (element is EnergyAnalysisOpening && elements.Any(x => x.UniqueId == ((EnergyAnalysisOpening)element).CADObjectUniqueId))
                 {

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByBHoMType.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByBHoMType.cs
@@ -105,6 +105,10 @@ namespace BH.Revit.Engine.Core
             if (type == typeof(BH.oM.Structure.Elements.Panel))
                 elementIds = elementIds.RemoveNonStructuralPanels(document);
 
+            // Filter out analytical spaces that are already pulled as non-analytical
+            if (type == typeof(BH.oM.Environment.Elements.Space) || type == typeof(BH.oM.Environment.Elements.Panel))
+                elementIds = new HashSet<ElementId>(elementIds.RemoveDuplicateAnalyticalElements(document));
+
             // Filter out walls that are parts of stacked wall
             if (types.Any(x => typeof(Autodesk.Revit.DB.Wall).IsAssignableFrom(x)))
                 elementIds = elementIds.RemoveStackedWallParts(document);

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -298,6 +298,7 @@
     <Compile Include="Convert\Revit\ToRevit\Family.cs" />
     <Compile Include="Convert\Revit\ToRevit\CurveElement.cs" />
     <Compile Include="Convert\Structure\FromRevit\Bars.cs" />
+    <Compile Include="Modify\RemoveDuplicateAnalyticalElements.cs" />
     <Compile Include="Modify\SetProperties.cs" />
     <Compile Include="Modify\SetTags.cs" />
     <Compile Include="Query\ParameterLink.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #739

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Model](https://burohappold.sharepoint.com/sites/Direction/designtechnology/Script%20Library/Forms/AllItems.aspx?csf=1&web=1&e=NiBGLn&cid=c7288618%2Ddbe3%2D46c6%2Dbdac%2D240283593d9d&RootFolder=%2Fsites%2FDirection%2Fdesigntechnology%2FScript%20Library%2F00339%5FBEnv%20Model%20Laundry%20Workflows%2F03%20Test%2FKHN&FolderCTID=0x012000877674B0FB94234BB2F1C82F2331EE6F) and [script](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue739%2DDuplicateBEnvPull&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).
