### PR TITLE
Copying of .addin file fixed

### DIFF
--- a/Revit_Core_Adapter/Revit_Core_Adapter.csproj
+++ b/Revit_Core_Adapter/Revit_Core_Adapter.csproj
@@ -263,16 +263,21 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018'">
-    <PostBuildEvent>C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2018.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2018\" /Y /I /E</PostBuildEvent>
+    <PostBuildEvent>
+		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2018.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2018\" /Y /I /E
+		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
+	</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
-    <PostBuildEvent>C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2019.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2019\" /Y /I /E</PostBuildEvent>
+    <PostBuildEvent>
+		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2019.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2019\" /Y /I /E
+		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
+	</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
-    <PostBuildEvent>C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2020.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2020\" /Y /I /E</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\\ProgramData\\BHoM\\Assemblies" /Y</PostBuildEvent>
+    <PostBuildEvent>
+		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2020.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2020\" /Y /I /E
+		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #748

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed, actions to take:
- go to _%appdata%\Autodesk\Revit\Addins\20XX_ and delete _BHoM_20XX.Addin_ file
- go to _C:\ProgramData\BHoM\Assemblies_ and delete _Revit_Core_Adapter_20XX.dll_ and _Revit_Core_Engine_20XX.dll_ files
- Rebuild Revit_Toolkit on _Debug20XX_ config and see if the files are back

