### PR TITLE
Type parameters get copied over to Physical.IFramingElement.Property on pull

### DIFF
--- a/Revit_Core_Engine/Query/FramingElementProperty.cs
+++ b/Revit_Core_Engine/Query/FramingElementProperty.cs
@@ -21,13 +21,11 @@
  */
 
 using Autodesk.Revit.DB;
-using BH.oM.Adapters.Revit.Parameters;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Physical.FramingProperties;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace BH.Revit.Engine.Core
 {

--- a/Revit_Core_Engine/Query/FramingElementProperty.cs
+++ b/Revit_Core_Engine/Query/FramingElementProperty.cs
@@ -21,11 +21,13 @@
  */
 
 using Autodesk.Revit.DB;
+using BH.oM.Adapters.Revit.Parameters;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Physical.FramingProperties;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BH.Revit.Engine.Core
 {
@@ -57,11 +59,17 @@ namespace BH.Revit.Engine.Core
             IProfile profile = familyInstance.Symbol.ProfileFromRevit(settings, refObjects);
             if (profile == null)
                 familyInstance.Symbol.NotConvertedWarning();
-
-            //TODO: check category of familyInstance to recognize which rotation query to use
+            
             double rotation = familyInstance.OrientationAngle(settings);
             
-            return BH.Engine.Physical.Create.ConstantFramingProperty(profile, material, rotation, familyInstance.Symbol.Name);
+            ConstantFramingProperty framingProperty = BH.Engine.Physical.Create.ConstantFramingProperty(profile, material, rotation, familyInstance.Symbol.Name);
+
+            //Set identifiers, parameters & custom data
+            framingProperty.SetIdentifiers(familyInstance.Symbol);
+            framingProperty.CopyParameters(familyInstance.Symbol, settings.ParameterSettings);
+            framingProperty.SetProperties(familyInstance.Symbol, settings.ParameterSettings);
+
+            return framingProperty;
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #756

<!-- Add short description of what has been fixed -->


#### Test file(s):
<!-- Link to test files to help reproduce the bug and validate the proposed fixes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue756%2DCopyParametersToProperty&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

### Additional comments
<!-- As required -->
With the current approach the parameters of Revit element type will be copied over to both to BHoM `Property` and `Profile`. Although a bit confusing, this is best I could come up with (please see #756).

@rwemay @IsakNaslundBh FYI