### PR TITLE
All type parameters stopped from being copied over to the BHoM objects on pull with type parameter mapping

### DIFF
--- a/Revit_Core_Engine/Convert/Revit/FromRevit/Parameter.cs
+++ b/Revit_Core_Engine/Convert/Revit/FromRevit/Parameter.cs
@@ -32,9 +32,17 @@ namespace BH.Revit.Engine.Core
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static RevitParameter ParameterFromRevit(this Parameter parameter, IEnumerable<IParameterLink> parameterLinks = null)
+        public static RevitParameter ParameterFromRevit(this Parameter parameter, IEnumerable<IParameterLink> parameterLinks = null, bool onlyLinked = false)
         {
             if (parameter == null)
+                return null;
+
+            string name = parameter.Definition.Name;
+
+            IParameterLink parameterLink = parameterLinks.ParameterLink(parameter);
+            if (parameterLink != null)
+                name = parameterLink.PropertyName;
+            else if (onlyLinked)
                 return null;
 
             object value = null;
@@ -63,12 +71,6 @@ namespace BH.Revit.Engine.Core
                     value = parameter.AsValueString();
                     break;
             }
-
-            string name = parameter.Definition.Name;
-
-            IParameterLink parameterLink = parameterLinks.ParameterLink(parameter);
-            if (parameterLink != null)
-                name = parameterLink.PropertyName;
 
             return new RevitParameter { Name = name, Value = value };
         }

--- a/Revit_Core_Engine/Modify/CopyParameters.cs
+++ b/Revit_Core_Engine/Modify/CopyParameters.cs
@@ -54,7 +54,9 @@ namespace BH.Revit.Engine.Core
                 {
                     foreach (Parameter parameter in elementType.ParametersMap)
                     {
-                        parameters.Add(parameter.ParameterFromRevit(typeParameterLinks));
+                        RevitParameter bHoMParameter = parameter.ParameterFromRevit(typeParameterLinks, true);
+                        if (bHoMParameter != null)
+                            parameters.Add(bHoMParameter);
                     }
                 }
 
@@ -63,7 +65,7 @@ namespace BH.Revit.Engine.Core
 
             foreach (Parameter parameter in element.ParametersMap)
             {
-                parameters.Add(parameter.ParameterFromRevit(parameterLinks));
+                parameters.Add(parameter.ParameterFromRevit(parameterLinks, false));
             }
 
             bHoMObject.Fragments.Add(new RevitPulledParameters(parameters));


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #755

<!-- Add short description of what has been fixed -->


#### Test file(s):
<!-- Link to test files to help reproduce the bug and validate the proposed fixes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue755%2DAllParametersBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

