### PR TITLE
SetRevitParameters issues resolved

### DIFF
--- a/Revit_Engine/Modify/SetRevitParameter.cs
+++ b/Revit_Engine/Modify/SetRevitParameter.cs
@@ -101,27 +101,6 @@ namespace BH.Engine.Adapters.Revit
             obj.Fragments = new FragmentSet(bHoMObject.Fragments.Where(x => !(x is RevitParametersToPush)).ToList());
             obj.Fragments.Add(fragment);
             return obj;
-
-            //IBHoMObject obj = bHoMObject.GetShallowClone();
-            //obj.Fragments = new FragmentSet(bHoMObject.Fragments.Where(x => !(x is RevitParametersToPush)).ToList());
-
-            //RevitParametersToPush fragment = bHoMObject.Fragments.FirstOrDefault(x => x is RevitParametersToPush) as RevitParametersToPush;
-            //if (fragment == null)
-            //    fragment = new RevitParametersToPush();
-
-            //for (int i = 0; i < paramNames.Count; i++)
-            //{
-            //    RevitParameter param = new RevitParameter { Name = paramNames[i], Value = values[i] };
-
-            //    RevitParameter existingParam = fragment.Parameters.FirstOrDefault(x => x.Name == paramNames[i]);
-            //    if (existingParam != null)
-            //        fragment.Parameters[fragment.Parameters.IndexOf(existingParam)] = param;
-            //    else
-            //        fragment.Parameters.Add(param);
-            //}
-
-            //obj.Fragments.Add(fragment);
-            return obj;
         }
 
         /***************************************************/

--- a/Revit_Engine/Modify/SetRevitParameter.cs
+++ b/Revit_Engine/Modify/SetRevitParameter.cs
@@ -45,21 +45,22 @@ namespace BH.Engine.Adapters.Revit
             if (bHoMObject == null)
                 return null;
 
+            List<RevitParameter> parameters = new List<RevitParameter> { new RevitParameter { Name = paramName, Value = value } };
+
+            RevitParametersToPush existingFragment = bHoMObject.Fragments.FirstOrDefault(x => x is RevitParametersToPush) as RevitParametersToPush;
+            if (existingFragment != null)
+            {
+                foreach (RevitParameter parameter in existingFragment.Parameters)
+                {
+                    if (parameter.Name != paramName)
+                        parameters.Add(parameter);
+                }
+            }
+            
+            RevitParametersToPush fragment = new RevitParametersToPush { Parameters = parameters };
+
             IBHoMObject obj = bHoMObject.GetShallowClone();
             obj.Fragments = new FragmentSet(bHoMObject.Fragments.Where(x => !(x is RevitParametersToPush)).ToList());
-
-            RevitParametersToPush fragment = bHoMObject.Fragments.FirstOrDefault(x => x is RevitParametersToPush) as RevitParametersToPush;
-            if (fragment == null)
-                fragment = new RevitParametersToPush();
-
-            RevitParameter param = new RevitParameter { Name = paramName, Value = value };
-
-            RevitParameter existingParam = fragment.Parameters.FirstOrDefault(x => x.Name == paramName);
-            if (existingParam != null)
-                fragment.Parameters[fragment.Parameters.IndexOf(existingParam)] = param;
-            else
-                fragment.Parameters.Add(param);
-
             obj.Fragments.Add(fragment);
             return obj;
         }
@@ -82,25 +83,44 @@ namespace BH.Engine.Adapters.Revit
                 return bHoMObject;
             }
 
-            IBHoMObject obj = bHoMObject.GetShallowClone();
-            obj.Fragments = new FragmentSet(bHoMObject.Fragments.Where(x => !(x is RevitParametersToPush)).ToList());
+            List<RevitParameter> parameters = paramNames.Zip(values, (x, y) => new RevitParameter { Name = x, Value = y }).ToList();
 
-            RevitParametersToPush fragment = bHoMObject.Fragments.FirstOrDefault(x => x is RevitParametersToPush) as RevitParametersToPush;
-            if (fragment == null)
-                fragment = new RevitParametersToPush();
-
-            for (int i = 0; i < paramNames.Count; i++)
+            RevitParametersToPush existingFragment = bHoMObject.Fragments.FirstOrDefault(x => x is RevitParametersToPush) as RevitParametersToPush;
+            if (existingFragment != null)
             {
-                RevitParameter param = new RevitParameter { Name = paramNames[i], Value = values[i] };
-
-                RevitParameter existingParam = fragment.Parameters.FirstOrDefault(x => x.Name == paramNames[i]);
-                if (existingParam != null)
-                    fragment.Parameters[fragment.Parameters.IndexOf(existingParam)] = param;
-                else
-                    fragment.Parameters.Add(param);
+                foreach (RevitParameter parameter in existingFragment.Parameters)
+                {
+                    if (paramNames.All(x => parameter.Name != x))
+                        parameters.Add(parameter);
+                }
             }
 
+            RevitParametersToPush fragment = new RevitParametersToPush { Parameters = parameters };
+
+            IBHoMObject obj = bHoMObject.GetShallowClone();
+            obj.Fragments = new FragmentSet(bHoMObject.Fragments.Where(x => !(x is RevitParametersToPush)).ToList());
             obj.Fragments.Add(fragment);
+            return obj;
+
+            //IBHoMObject obj = bHoMObject.GetShallowClone();
+            //obj.Fragments = new FragmentSet(bHoMObject.Fragments.Where(x => !(x is RevitParametersToPush)).ToList());
+
+            //RevitParametersToPush fragment = bHoMObject.Fragments.FirstOrDefault(x => x is RevitParametersToPush) as RevitParametersToPush;
+            //if (fragment == null)
+            //    fragment = new RevitParametersToPush();
+
+            //for (int i = 0; i < paramNames.Count; i++)
+            //{
+            //    RevitParameter param = new RevitParameter { Name = paramNames[i], Value = values[i] };
+
+            //    RevitParameter existingParam = fragment.Parameters.FirstOrDefault(x => x.Name == paramNames[i]);
+            //    if (existingParam != null)
+            //        fragment.Parameters[fragment.Parameters.IndexOf(existingParam)] = param;
+            //    else
+            //        fragment.Parameters.Add(param);
+            //}
+
+            //obj.Fragments.Add(fragment);
             return obj;
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #759
Closes #766

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[#759](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue759%2DSetRevitParametersBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)
[#766](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue766%2DSetRevitParameterUpstreamBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `SetRevitParameter` method has been added to handle single parameter assignment
- bug causing the objects being modified upstream on SetRevitParameter has been fixed


### Additional comments
<!-- As required -->
This PR to some extent may fall into _Feature_ label, but I believe the UI glitch that the issue is causing justifies this PR even at this moment. Plus the implementation is a mere copy paste 🙈 