### PR TITLE
Nurbs-based framing stopped from crashing on push

### DIFF
--- a/Revit_Core_Engine/Query/AdjustedLocationCurve.cs
+++ b/Revit_Core_Engine/Query/AdjustedLocationCurve.cs
@@ -42,7 +42,7 @@ namespace BH.Revit.Engine.Core
             settings = settings.DefaultIfNull();
 
             ICurve curve = framingElement?.Location;
-            if (curve == null || curve.ILength() <= settings.DistanceTolerance)
+            if (curve == null || (!(curve is NurbsCurve) && curve.ILength() <= settings.DistanceTolerance))
             {
                 framingElement.FramingCurveNotFoundWarning();
                 return null;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #763

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue763%2DPushNurbsBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

