### PR TITLE
Cross section rotation limited to the range accepted by Revit (-360 to +360 deg.)

### DIFF
--- a/Revit_Core_Engine/Modify/NormalizeAngleDomain.cs
+++ b/Revit_Core_Engine/Modify/NormalizeAngleDomain.cs
@@ -31,7 +31,7 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        public static double NormalizeAngleDomain(this double orientationAngle, RevitSettings settings)
+        public static double NormalizeAngleDomain(this double orientationAngle)
         {
             orientationAngle = orientationAngle % (2 * Math.PI);
 

--- a/Revit_Core_Engine/Modify/SetLocation.cs
+++ b/Revit_Core_Engine/Modify/SetLocation.cs
@@ -129,12 +129,12 @@ namespace BH.Revit.Engine.Core
                 double rotationParamValue = element.LookupParameterDouble(BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE);
                 if (double.IsNaN(rotationParamValue))
                 {
-                    ElementTransformUtils.RotateElement(element.Document, element.Id, columnLine.ToRevit(), -rotationDifference.NormalizeAngleDomain(settings));
+                    ElementTransformUtils.RotateElement(element.Document, element.Id, columnLine.ToRevit(), -rotationDifference.NormalizeAngleDomain());
                     updated = true;
                 }
                 else
                 {
-                    double newRotation = (rotationParamValue + rotationDifference).NormalizeAngleDomain(settings);
+                    double newRotation = (rotationParamValue + rotationDifference).NormalizeAngleDomain();
                     updated |= element.SetParameter(BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE, newRotation);
                 }
             }
@@ -169,7 +169,7 @@ namespace BH.Revit.Engine.Core
             double rotationDifference = element.OrientationAngleFraming(settings) - rotation;
             if (Math.Abs(rotationDifference) > settings.AngleTolerance)
             {
-                double newRotation = (element.LookupParameterDouble(BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE) + rotationDifference).NormalizeAngleDomain(settings);
+                double newRotation = (element.LookupParameterDouble(BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE) + rotationDifference).NormalizeAngleDomain();
                 updated |= element.SetParameter(BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE, newRotation);
                 element.Document.Regenerate();
             }

--- a/Revit_Core_Engine/Modify/SetParameter.cs
+++ b/Revit_Core_Engine/Modify/SetParameter.cs
@@ -195,7 +195,12 @@ namespace BH.Revit.Engine.Core
                             }
 
                             if (!double.IsNaN(dbl))
+                            {
+                                if (parameter.Id.IntegerValue == (int)BuiltInParameter.STRUCTURAL_BEND_DIR_ANGLE)
+                                    dbl = dbl.NormalizeAngleDomain();
+
                                 return parameter.Set(dbl);
+                            }
                         }
                         break;
                     }

--- a/Revit_Core_Engine/Query/OrientationAngle.cs
+++ b/Revit_Core_Engine/Query/OrientationAngle.cs
@@ -68,7 +68,7 @@ namespace BH.Revit.Engine.Core
                     rotation = XYZ.BasisZ.AngleOnPlaneTo(transform.BasisY, transform.BasisZ);
             }
 
-            return rotation;
+            return rotation.NormalizeAngleDomain();
         }
 
         /***************************************************/
@@ -97,7 +97,7 @@ namespace BH.Revit.Engine.Core
                     rotation *= -1;
             }
 
-            return rotation.NormalizeAngleDomain(settings);
+            return rotation.NormalizeAngleDomain();
         }
         
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #765

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue765%2DPushSlantedColumnRotationBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)