### PR TITLE
Pulling of geometry enabled for DetailItems

### DIFF
--- a/Revit_Core_Engine/Query/GeometryPrimitives.cs
+++ b/Revit_Core_Engine/Query/GeometryPrimitives.cs
@@ -71,6 +71,14 @@ namespace BH.Revit.Engine.Core
             if (element == null)
                 return null;
 
+            if (element.ViewSpecific)
+            {
+                bool includeNonVisible = options.IncludeNonVisibleObjects;
+                options = new Options();
+                options.IncludeNonVisibleObjects = includeNonVisible;
+                options.View = element.Document.GetElement(element.OwnerViewId) as View;
+            }
+
             GeometryElement geometryElement = element.get_Geometry(options);
             if (geometryElement == null)
                 return new List<GeometryObject>();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #778

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](http://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FRevit_Toolkit%2FRevit_Toolkit-Issue778-ViewSpecificGeometry&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - simply open the doc and go to the only view in it.
