### PR TITLE
Irrelevant warnings and errors stopped from being thrown on update

### DIFF
--- a/Revit_Core_Engine/Modify/SetLocation.cs
+++ b/Revit_Core_Engine/Modify/SetLocation.cs
@@ -32,6 +32,7 @@ using System;
 using System.Linq;
 using BH.oM.Physical.FramingProperties;
 using BH.oM.Reflection;
+using System.Collections.Generic;
 
 namespace BH.Revit.Engine.Core
 {
@@ -261,7 +262,10 @@ namespace BH.Revit.Engine.Core
 
         public static bool SetLocation(this Element element, IGeometry geometry, RevitSettings settings)
         {
-            BH.Engine.Reflection.Compute.RecordError(String.Format("Setting Revit element location based on BHoM geometry of type {0} is currently not supported. Revit ElementId: {1}", geometry.GetType(), element.Id));
+            Type type = element.GetType();
+            if (AbstractRevitTypes.All(x => !x.IsAssignableFrom(type)))
+                BH.Engine.Reflection.Compute.RecordError(String.Format("Setting Revit element location based on BHoM geometry of type {0} is currently not supported. Only parameters were updated. Revit ElementId: {1}", geometry.GetType(), element.Id));
+
             return false;
         }
 
@@ -269,7 +273,10 @@ namespace BH.Revit.Engine.Core
 
         public static bool SetLocation(this Element element, IBHoMObject bHoMObject, RevitSettings settings)
         {
-            BH.Engine.Reflection.Compute.RecordError(String.Format("Unable to set location of Revit element of type {0} based on BHoM object of type {1} beacuse no suitable method could be found. Revit ElementId: {2} BHoM_Guid: {3}", element.GetType(), bHoMObject.GetType(), element.Id, bHoMObject.BHoM_Guid));
+            Type type = element.GetType();
+            if (AbstractRevitTypes.All(x => !x.IsAssignableFrom(type)))
+                BH.Engine.Reflection.Compute.RecordError(String.Format("Unable to set location of Revit element of type {0} based on BHoM object of type {1} beacuse no suitable method could be found. Only parameters were updated. Revit ElementId: {2} BHoM_Guid: {3}", element.GetType(), bHoMObject.GetType(), element.Id, bHoMObject.BHoM_Guid));
+
             return false;
         }
 
@@ -285,7 +292,20 @@ namespace BH.Revit.Engine.Core
 
             return SetLocation(element as dynamic, bHoMObject as dynamic, settings);
         }
-        
+
+
+        /***************************************************/
+        /****            Private collections            ****/
+        /***************************************************/
+
+        private static readonly Type[] AbstractRevitTypes = new Type[]
+        {
+            typeof(Autodesk.Revit.DB.Family),
+            typeof(ElementType),
+            typeof(Material),
+            typeof(View)
+        };
+
         /***************************************************/
     }
 }

--- a/Revit_Core_Engine/Modify/SetType.cs
+++ b/Revit_Core_Engine/Modify/SetType.cs
@@ -106,7 +106,10 @@ namespace BH.Revit.Engine.Core
 
         public static bool SetType(this Element element, IBHoMObject bHoMObject, RevitSettings settings)
         {
-            BH.Engine.Reflection.Compute.RecordWarning(String.Format("Element type has not been updated based on the BHoM object due to the lacking convert method. Revit ElementId: {0} BHoM_Guid: {1}", element.Id, bHoMObject.BHoM_Guid));
+            Type type = element.GetType();
+            if (type != typeof(Autodesk.Revit.DB.Family) && !typeof(ElementType).IsAssignableFrom(type))
+                BH.Engine.Reflection.Compute.RecordWarning(String.Format("Element type has not been updated based on the BHoM object due to the lacking convert method. Revit ElementId: {0} BHoM_Guid: {1}", element.Id, bHoMObject.BHoM_Guid));
+
             return false;
         }
         


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #781

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue781%2DUpdateWarnings&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - open an empty document and run the script.

