### PR TITLE
Pulling hidden parameters enabled when pulled Revit element does not expose any public ones

### DIFF
--- a/Revit_Core_Engine/Modify/CopyParameters.cs
+++ b/Revit_Core_Engine/Modify/CopyParameters.cs
@@ -26,6 +26,7 @@ using BH.oM.Adapters.Revit.Parameters;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -63,7 +64,11 @@ namespace BH.Revit.Engine.Core
                 parameterLinks = parameterMap.ParameterLinks.Where(x => !(x is ElementTypeParameterLink));
             }
 
-            foreach (Parameter parameter in element.ParametersMap)
+            IEnumerable elementParams = element.ParametersMap;
+            if (((Autodesk.Revit.DB.ParameterMap)elementParams).IsEmpty)
+                elementParams = element.Parameters;
+
+            foreach (Parameter parameter in elementParams)
             {
                 parameters.Add(parameter.ParameterFromRevit(parameterLinks, false));
             }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #786

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue786%2DPullHiddenParams)
