### PR TITLE
Added ability to get identifier and type params using GetRevitParamValue

### DIFF
--- a/Revit_Engine/Query/GetRevitParameterValue.cs
+++ b/Revit_Engine/Query/GetRevitParameterValue.cs
@@ -59,6 +59,14 @@ namespace BH.Engine.Adapters.Revit
                     return param.Value;
             }
 
+            RevitIdentifiers identifierFragment = bHoMObject.Fragments?.FirstOrDefault(x => x is RevitIdentifiers) as RevitIdentifiers;
+            if (identifierFragment != null)
+            {
+                string paramName = string.Concat(parameterName.Where(c => !char.IsWhiteSpace(c)));
+                if (Reflection.Query.PropertyNames(identifierFragment).Contains(paramName))
+                    return Reflection.Query.PropertyValue(identifierFragment, paramName);
+            }
+
             return null;
         }
 

--- a/Revit_Engine/Query/GetRevitParameterValue.cs
+++ b/Revit_Engine/Query/GetRevitParameterValue.cs
@@ -68,16 +68,22 @@ namespace BH.Engine.Adapters.Revit
                     return Reflection.Query.PropertyValue(identifierFragment, paramName);
             }
 
-            List<object> bHoMPropList = Reflection.Query.PropertyObjects(bHoMObject);
-            List<IBHoMObject> bHoMProps = bHoMPropList.OfType<IBHoMObject>().ToList();
-            foreach (IBHoMObject bHoMProp in bHoMProps)
+            Dictionary <string, object> bHoMPropDic = Reflection.Query.PropertyDictionary(bHoMObject);
+            foreach (KeyValuePair<string, object> bHoMPropEntry in bHoMPropDic)
             {
-                RevitPulledParameters typePullFragment = bHoMProp.Fragments?.FirstOrDefault(x => x is RevitPulledParameters) as RevitPulledParameters;
-                if (typePullFragment?.Parameters != null)
+                IBHoMObject bHoMProp = bHoMPropEntry.Value as IBHoMObject;
+                if (bHoMProp != null)
                 {
-                    RevitParameter param = typePullFragment.Parameters.FirstOrDefault(x => x.Name == parameterName);
-                    if (param != null)
-                        return param.Value;
+                    RevitPulledParameters typePullFragment = bHoMProp.Fragments?.FirstOrDefault(x => x is RevitPulledParameters) as RevitPulledParameters;
+                    if (typePullFragment?.Parameters != null)
+                    {
+                        RevitParameter param = typePullFragment.Parameters.FirstOrDefault(x => x.Name == parameterName);
+                        if (param != null)
+                        {
+                            Engine.Reflection.Compute.RecordWarning("The value for parameter " + parameterName + " for the object with BHoM_Guid " + bHoMObject.BHoM_Guid + " has been retrieved from its property " + bHoMPropEntry.Key + ".");
+                            return param.Value;
+                        }
+                    }
                 }
             }
 

--- a/Revit_Engine/Query/GetRevitParameterValue.cs
+++ b/Revit_Engine/Query/GetRevitParameterValue.cs
@@ -25,6 +25,7 @@ using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace BH.Engine.Adapters.Revit
 {
@@ -65,6 +66,19 @@ namespace BH.Engine.Adapters.Revit
                 string paramName = string.Concat(parameterName.Where(c => !char.IsWhiteSpace(c)));
                 if (Reflection.Query.PropertyNames(identifierFragment).Contains(paramName))
                     return Reflection.Query.PropertyValue(identifierFragment, paramName);
+            }
+
+            List<object> bHoMPropList = Reflection.Query.PropertyObjects(bHoMObject);
+            List<IBHoMObject> bHoMProps = bHoMPropList.OfType<IBHoMObject>().ToList();
+            foreach (IBHoMObject bHoMProp in bHoMProps)
+            {
+                RevitPulledParameters typePullFragment = bHoMProp.Fragments?.FirstOrDefault(x => x is RevitPulledParameters) as RevitPulledParameters;
+                if (typePullFragment?.Parameters != null)
+                {
+                    RevitParameter param = typePullFragment.Parameters.FirstOrDefault(x => x.Name == parameterName);
+                    if (param != null)
+                        return param.Value;
+                }
             }
 
             return null;


### PR DESCRIPTION
### Issues addressed by this PR
Closes #789 
Closes #790 

The GetRevitParamValue method can now get identifier and type parameters from objects pulled from Revit, which is a key feature to allow for downstream workflows.


### Test files
[RevitGetParamValueTest.zip](https://github.com/BHoM/Revit_Toolkit/files/4881605/RevitGetParamValueTest.zip)
