### PR TITLE
PlanarSurfaceDictionary method replaced with PanelSurfaces in CeilingPattern query

### DIFF
--- a/Revit_Core_Engine/Query/CeilingPattern.cs
+++ b/Revit_Core_Engine/Query/CeilingPattern.cs
@@ -65,7 +65,7 @@ namespace BH.Revit.Engine.Core
             if (surface == null)
             {
                 //This would need to be extended to take openings from Values into account
-                foreach (PlanarSurface srf in ceiling.PlanarSurfaceDictionary(false, settings).Keys)
+                foreach (PlanarSurface srf in ceiling.PanelSurfaces(ceiling.FindInserts(true, true, true, true), settings).Keys)
                 {
                     result.AddRange(material.CeilingPattern(srf, settings));
                 }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #801

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not possible to test from UI level actually - the line changed in this PR is never reached as it always hits `else` in the statement below:
https://github.com/BHoM/Revit_Toolkit/blob/e6613da7f5d89d2b1171d72d27abc008060988dc/Revit_Core_Engine/Query/CeilingPattern.cs#L64-L74

So the change is actually purely cosmetical and replaces a legacy `PlanarSurfaceDictionary` method with the currently supported one, `PanelSurfaces`.

To test the general functionality one can use the script from [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue801%2DRefactorCeilingPatterns&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) in combination with any model that has ceiling patterns, e.g. _C:\Program Files\Autodesk\Revit 2018\Samples\rac_advanced_sample_project.rvt_.