### PR TITLE
OriginContext fragment removed from non-BEnv converts from Revit

### DIFF
--- a/Revit_Core_Engine/Convert/Architecture/FromRevit/Room.cs
+++ b/Revit_Core_Engine/Convert/Architecture/FromRevit/Room.cs
@@ -24,7 +24,6 @@ using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
-using BH.oM.Environment.Fragments;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -53,14 +52,7 @@ namespace BH.Revit.Engine.Core
             //Set location
             if (spatialElement.Location != null && spatialElement.Location is LocationPoint)
                 room.Location = ((LocationPoint)spatialElement.Location).FromRevit();
-
-            //Set ExtendedProperties
-            OriginContextFragment originContext = new OriginContextFragment();
-            originContext.ElementID = spatialElement.Id.IntegerValue.ToString();
-            originContext.TypeName = Query.Name(spatialElement);
-            originContext.SetProperties(spatialElement, settings.ParameterSettings);
-            room.Fragments.Add(originContext);
-
+            
             //Set identifiers, parameters & custom data
             room.SetIdentifiers(spatialElement);
             room.CopyParameters(spatialElement, settings.ParameterSettings);

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
@@ -63,7 +63,6 @@ namespace BH.Revit.Engine.Core
             }
 
             door = new Door { Location = location, Name = familyInstance.FamilyTypeFullName() };
-            ElementType elementType = familyInstance.Document.GetElement(familyInstance.GetTypeId()) as ElementType;
             
             //Set identifiers, parameters & custom data
             door.SetIdentifiers(familyInstance);

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
@@ -24,7 +24,6 @@ using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
-using BH.oM.Environment.Fragments;
 using BH.oM.Physical.Elements;
 using System;
 using System.Collections.Generic;
@@ -65,15 +64,7 @@ namespace BH.Revit.Engine.Core
 
             door = new Door { Location = location, Name = familyInstance.FamilyTypeFullName() };
             ElementType elementType = familyInstance.Document.GetElement(familyInstance.GetTypeId()) as ElementType;
-
-            //Set ExtendedProperties
-            OriginContextFragment originContext = new OriginContextFragment();
-            originContext.ElementID = familyInstance.Id.IntegerValue.ToString();
-            originContext.TypeName = familyInstance.FamilyTypeFullName();
-            originContext.SetProperties(familyInstance, settings.ParameterSettings);
-            originContext.SetProperties(elementType, settings.ParameterSettings);
-            door.Fragments.Add(originContext);
-
+            
             //Set identifiers, parameters & custom data
             door.SetIdentifiers(familyInstance);
             door.CopyParameters(familyInstance, settings.ParameterSettings);

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
@@ -24,7 +24,6 @@ using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
-using BH.oM.Environment.Fragments;
 using BH.oM.Physical.Elements;
 using System;
 using System.Collections.Generic;
@@ -65,15 +64,7 @@ namespace BH.Revit.Engine.Core
 
             window = new Window { Location = location, Name = familyInstance.FamilyTypeFullName() };
             ElementType elementType = familyInstance.Document.GetElement(familyInstance.GetTypeId()) as ElementType;
-
-            //Set ExtendedProperties
-            OriginContextFragment originContext = new OriginContextFragment();
-            originContext.ElementID = familyInstance.Id.IntegerValue.ToString();
-            originContext.TypeName = familyInstance.FamilyTypeFullName();
-            originContext.SetProperties(familyInstance, settings.ParameterSettings);
-            originContext.SetProperties(elementType, settings.ParameterSettings);
-            window.Fragments.Add(originContext);
-
+            
             //Set identifiers, parameters & custom data
             window.SetIdentifiers(familyInstance);
             window.CopyParameters(familyInstance, settings.ParameterSettings);

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
@@ -63,7 +63,6 @@ namespace BH.Revit.Engine.Core
             }
 
             window = new Window { Location = location, Name = familyInstance.FamilyTypeFullName() };
-            ElementType elementType = familyInstance.Document.GetElement(familyInstance.GetTypeId()) as ElementType;
             
             //Set identifiers, parameters & custom data
             window.SetIdentifiers(familyInstance);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #794

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed, that should not change any functionality.


### Additional comments
<!-- As required -->
That issue has been investigated by @FraserGreenroyd in https://github.com/BHoM/Revit_Toolkit/issues/794, so should be safe to merge straight away as long as the discussion in the issue is still valid.