### PR TITLE
SurfacePropertyFromRevit fixed not to crash on Revit panel types without any layers

### DIFF
--- a/Revit_Core_Engine/Convert/Structure/FromRevit/SurfaceProperty.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/SurfaceProperty.cs
@@ -50,13 +50,13 @@ namespace BH.Revit.Engine.Core
             IMaterialFragment materialFragment = null;
             double thickness = 0;
 
-            CompoundStructure compoundStructure = hostObjAttributes.GetCompoundStructure();
+            IList<CompoundStructureLayer> compoundStructure = hostObjAttributes.GetCompoundStructure()?.GetLayers();
             if (compoundStructure != null)
             {
                 bool composite = false;
                 bool nonStructuralLayers = false;
 
-                foreach (CompoundStructureLayer csl in hostObjAttributes.GetCompoundStructure().GetLayers())
+                foreach (CompoundStructureLayer csl in compoundStructure)
                 {
                     if (csl.Function == MaterialFunctionAssignment.Structure)
                     {

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/SurfaceProperty.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/SurfaceProperty.cs
@@ -26,6 +26,7 @@ using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SurfaceProperties;
+using System;
 using System.Collections.Generic;
 
 namespace BH.Revit.Engine.Core
@@ -46,63 +47,66 @@ namespace BH.Revit.Engine.Core
             if (constantThickness != null)
                 return constantThickness;
 
-            double thickness = 0;
             IMaterialFragment materialFragment = null;
+            double thickness = 0;
 
-            bool composite = false;
-            foreach (CompoundStructureLayer csl in hostObjAttributes.GetCompoundStructure().GetLayers())
+            CompoundStructure compoundStructure = hostObjAttributes.GetCompoundStructure();
+            if (compoundStructure != null)
             {
-                if (csl.Function == MaterialFunctionAssignment.Structure)
+                bool composite = false;
+                bool nonStructuralLayers = false;
+
+                foreach (CompoundStructureLayer csl in hostObjAttributes.GetCompoundStructure().GetLayers())
                 {
-                    if (thickness != 0)
+                    if (csl.Function == MaterialFunctionAssignment.Structure)
                     {
-                        composite = true;
-                        thickness = 0;
-                        break;
-                    }
+                        if (thickness != 0)
+                        {
+                            composite = true;
+                            thickness = 0;
+                            break;
+                        }
 
-                    thickness = csl.Width.ToSI(UnitType.UT_Section_Dimension);
+                        thickness = csl.Width.ToSI(UnitType.UT_Section_Dimension);
 
-                    Material revitMaterial = document.GetElement(csl.MaterialId) as Material;
-                    if (revitMaterial == null)
-                    {
-                        BH.Engine.Reflection.Compute.RecordWarning("There is a structural layer in wall/floor type without material assigned. A default empty material is returned. ElementId: " + hostObjAttributes.Id.IntegerValue.ToString());
-                        materialFragment = Autodesk.Revit.DB.Structure.StructuralMaterialType.Undefined.EmptyMaterialFragment();
+                        Material revitMaterial = document.GetElement(csl.MaterialId) as Material;
+                        if (revitMaterial == null)
+                        {
+                            BH.Engine.Reflection.Compute.RecordWarning("There is a structural layer in wall/floor type without material assigned. A default empty material is returned. ElementId: " + hostObjAttributes.Id.IntegerValue.ToString());
+                            materialFragment = Autodesk.Revit.DB.Structure.StructuralMaterialType.Undefined.EmptyMaterialFragment();
+                        }
+                        else
+                        {
+                            Autodesk.Revit.DB.Structure.StructuralMaterialType structuralMaterialType = revitMaterial.MaterialClass.StructuralMaterialType();
+                            materialFragment = structuralMaterialType.LibraryMaterial(materialGrade);
+
+                            if (materialFragment == null)
+                                materialFragment = revitMaterial.MaterialFragmentFromRevit(null, settings, refObjects);
+
+                            if (materialFragment == null)
+                            {
+                                Compute.InvalidDataMaterialWarning(hostObjAttributes);
+                                materialFragment = structuralMaterialType.EmptyMaterialFragment();
+                            }
+                        }
+
                     }
+                    else if (csl.Function == MaterialFunctionAssignment.StructuralDeck)
+                        BH.Engine.Reflection.Compute.RecordWarning(String.Format("A structural deck layer has been found in the Revit compound structure, but was ignored on convert. Revit ElementId: {0}", hostObjAttributes.Id));
                     else
-                    {
-                        Autodesk.Revit.DB.Structure.StructuralMaterialType structuralMaterialType = revitMaterial.MaterialClass.StructuralMaterialType();
-                        materialFragment = structuralMaterialType.LibraryMaterial(materialGrade);
-                        
-                        if (materialFragment == null)
-                        {
-                            //Compute.MaterialNotInLibraryNote(familyInstance);
-                            materialFragment = revitMaterial.MaterialFragmentFromRevit(null, settings, refObjects);
-                        }
+                        nonStructuralLayers = true;
+                }
 
-                        if (materialFragment == null)
-                        {
-                            Compute.InvalidDataMaterialWarning(hostObjAttributes);
-                            materialFragment = structuralMaterialType.EmptyMaterialFragment();
-                        }
-                    }
+                if (nonStructuralLayers)
+                    BH.Engine.Reflection.Compute.RecordWarning(String.Format("Layers marked as nonstructural have been found in the Revit compound structure and were ignored on convert. Revit ElementId: {0}", hostObjAttributes.Id));
 
-                }
-                else if (csl.Function == MaterialFunctionAssignment.StructuralDeck)
-                {
-                    //TODO: warning that a composite deck here + action appropriately
-                }
-                else
-                {
-                    //TODO: warning that nonstructural layers exist and are skipped
-                }
+                if (composite)
+                    hostObjAttributes.CompositePanelWarning();
+                else if (thickness == 0)
+                    BH.Engine.Reflection.Compute.RecordWarning(string.Format("A zero thickness panel is created. Element type Id: {0}", hostObjAttributes.Id.IntegerValue));
             }
-
-            //TODO: Clean it up!
-            if (composite)
-                hostObjAttributes.CompositePanelWarning();
-            else if (thickness == 0)
-                BH.Engine.Reflection.Compute.RecordWarning(string.Format("A zero thickness panel is created. Element type Id: {0}", hostObjAttributes.Id.IntegerValue));
+            else
+                BH.Engine.Reflection.Compute.RecordWarning(String.Format("Revit panel type does not contain any layers (possibly it is a curtain panel). A BHoM panel type with zero thickness and no material is returned. Revit ElementId: {0}", hostObjAttributes.Id));
 
             oM.Structure.SurfaceProperties.PanelType panelType = oM.Structure.SurfaceProperties.PanelType.Undefined;
             if (hostObjAttributes is WallType)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #783

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Script on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue783%2DHandleCurtainPanelTypes&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - the easiest way to test is to run it on an empty model (any model has a curtain wall type).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- #783 fixed
- `SurfacePropertyFromRevit` method cleaned up