### PR TITLE
Curve push and convert bugs fixed

### DIFF
--- a/Revit_Core_Engine/Convert/Geometry/ToRevit/CurveList.cs
+++ b/Revit_Core_Engine/Convert/Geometry/ToRevit/CurveList.cs
@@ -80,8 +80,8 @@ namespace BH.Revit.Engine.Core
             XYZ centre = curve.Centre.ToRevit();
             double radius1 = curve.Radius1.FromSI(UnitType.UT_Length);
             double radius2 = curve.Radius2.FromSI(UnitType.UT_Length);
-            XYZ axis1 = curve.Axis1.ToRevit();
-            XYZ axis2 = curve.Axis2.ToRevit();
+            XYZ axis1 = curve.Axis1.ToRevit().Normalize();
+            XYZ axis2 = curve.Axis2.ToRevit().Normalize();
             return new List<Curve> { Ellipse.CreateCurve(centre, radius1, radius2, axis1, axis2, 0, Math.PI), Ellipse.CreateCurve(centre, radius1, radius2, axis1, axis2, Math.PI, Math.PI * 2) };
         }
 

--- a/Revit_Engine/Create/Elements/ModelInstance.cs
+++ b/Revit_Engine/Create/Elements/ModelInstance.cs
@@ -120,7 +120,7 @@ namespace BH.Engine.Adapters.Revit
             ModelInstance modelInstance = new ModelInstance()
             {
                 Properties = instanceProperties,
-                Name = "Detail Lines",
+                Name = "Lines",
                 Location = location
             };
             modelInstance.CustomData.Add(Convert.CategoryName, "Lines");
@@ -146,7 +146,7 @@ namespace BH.Engine.Adapters.Revit
             ModelInstance modelInstance = new ModelInstance()
             {
                 Properties = instanceProperties,
-                Name = "Detail Lines",
+                Name = "Lines",
                 Location = location
             };
             modelInstance.CustomData.Add(Convert.CategoryName, "Lines");

--- a/Revit_Engine/Query/CategoryName.cs
+++ b/Revit_Engine/Query/CategoryName.cs
@@ -90,7 +90,8 @@ namespace BH.Engine.Adapters.Revit
         [Output("categoryName")]
         public static string CategoryName(this IBHoMObject bHoMObject)
         {
-            return bHoMObject?.GetRevitIdentifiers()?.CategoryName;
+            string name = bHoMObject?.GetRevitIdentifiers()?.CategoryName;
+            return name ?? bHoMObject.CustomDataValue(Convert.CategoryName) as string;
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #807
Closes #808

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue808%2DCurveConvertBugs&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - can be run on an empty Revit file.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- pushing of Model Curves using `ModelInstance` reenabled
- BHoM => Revit curve convert bugs fixed for 2-noded `Polyline`, single-segment `PolyCurve` and `Ellipse`
- handling of Nurbs curves on Push slightly improved (could not get any better due to Revit limiations)
