### PR TITLE
BHoM => Revit floor convert bugs fixed

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
@@ -97,15 +97,14 @@ namespace BH.Revit.Engine.Core
                     normal = -slabPlane.Normal;
 
                 double angle = normal.Angle(Vector.ZAxis);
-                BH.oM.Geometry.Line ln = slabPlane.PlaneIntersection(sketchPlane);
-                XYZ start = ln.ClosestPoint(curveArray.get_Item(0).GetEndPoint(0).PointFromRevit(), true).ToRevit();
-                XYZ perp = slabPlane.Normal.ToRevit().CrossProduct(XYZ.BasisZ);
-                XYZ dir = XYZ.BasisZ.CrossProduct(perp).Normalize();
                 double tan = Math.Tan(angle);
 
+                XYZ dir = normal.Project(oM.Geometry.Plane.XY).ToRevit().Normalize();
+                BH.oM.Geometry.Line ln = slabPlane.PlaneIntersection(sketchPlane);
+                XYZ start = ln.ClosestPoint(curveArray.get_Item(0).GetEndPoint(0).PointFromRevit(), true).ToRevit();
                 Autodesk.Revit.DB.Line line = Autodesk.Revit.DB.Line.CreateBound(start, start + dir);
-                revitFloor = document.Create.NewSlab(curveArray, level, line, -tan, true);
 
+                revitFloor = document.Create.NewSlab(curveArray, level, line, -tan, true);
                 revitFloor.SetParameter(BuiltInParameter.ELEM_TYPE_PARAM, floorType.Id);
             }
 

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
@@ -22,6 +22,7 @@
 
 using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
+using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Geometry;
 using System;
@@ -41,21 +42,18 @@ namespace BH.Revit.Engine.Core
             if (floor == null || floor.Construction == null || document == null)
                 return null;
 
-            PlanarSurface planarSurface = floor.Location as PlanarSurface;
-            if (planarSurface == null)
-                return null;
-
             Floor revitFloor = refObjects.GetValue<Floor>(document, floor.BHoM_Guid);
             if (revitFloor != null)
                 return revitFloor;
 
+            PlanarSurface planarSurface = floor.Location as PlanarSurface;
+            if (planarSurface == null)
+                return null;
+
             settings = settings.DefaultIfNull();
 
-            FloorType floorType = null;
-
-            if (floor.Construction != null)
-                floorType = floor.Construction.ToRevitHostObjAttributes(document, settings, refObjects) as FloorType;
-
+            FloorType floorType = floor.Construction?.ToRevitHostObjAttributes(document, settings, refObjects) as FloorType;
+            
             if (floorType == null)
             {
                 string familyTypeName = floor.FamilyTypeName();
@@ -78,28 +76,76 @@ namespace BH.Revit.Engine.Core
                         floorType = floorTypeList.First();
                 }
             }
-
+            
             if (floorType == null)
                 return null;
 
-            double lowElevation = floor.LowElevation();
+            double bottomElevation = floor.Location.IBounds().Min.Z;
+            Level level = document.LevelBelow(bottomElevation.FromSI(UnitType.UT_Length), settings);
 
-            Level level = document.HighLevel(lowElevation);
-
-            double elevation = level.Elevation.ToSI(UnitType.UT_Length);
-
-            oM.Geometry.Plane plane = BH.Engine.Geometry.Create.Plane(BH.Engine.Geometry.Create.Point(0, 0, lowElevation), BH.Engine.Geometry.Create.Vector(0, 0, 1));
-            ICurve curve = BH.Engine.Geometry.Modify.Project(planarSurface.ExternalBoundary as dynamic, plane) as ICurve;
+            oM.Geometry.Plane sketchPlane = new oM.Geometry.Plane { Origin = new BH.oM.Geometry.Point { Z = bottomElevation }, Normal = Vector.ZAxis };
+            ICurve curve = planarSurface.ExternalBoundary.IProject(sketchPlane);
             CurveArray curveArray = Create.CurveArray(curve.IToRevitCurves());
 
-            revitFloor = document.Create.NewFloor(curveArray, floorType, level, false);
+            BH.oM.Geometry.Plane slabPlane = planarSurface.FitPlane();
+            if (1 - Math.Abs(Vector.ZAxis.DotProduct(slabPlane.Normal)) <= settings.AngleTolerance)
+                revitFloor = document.Create.NewFloor(curveArray, floorType, level, true);
+            else
+            {
+                Vector normal = slabPlane.Normal;
+                if (normal.Z < 0)
+                    normal = -slabPlane.Normal;
+
+                double angle = normal.Angle(Vector.ZAxis);
+                BH.oM.Geometry.Line ln = slabPlane.PlaneIntersection(sketchPlane);
+                XYZ start = ln.ClosestPoint(curveArray.get_Item(0).GetEndPoint(0).PointFromRevit(), true).ToRevit();
+                XYZ perp = slabPlane.Normal.ToRevit().CrossProduct(XYZ.BasisZ);
+                XYZ dir = XYZ.BasisZ.CrossProduct(perp).Normalize();
+                double tan = Math.Tan(angle);
+
+                Autodesk.Revit.DB.Line line = Autodesk.Revit.DB.Line.CreateBound(start, start + dir);
+                revitFloor = document.Create.NewSlab(curveArray, level, line, -tan, true);
+
+                revitFloor.SetParameter(BuiltInParameter.ELEM_TYPE_PARAM, floorType.Id);
+            }
 
             revitFloor.CheckIfNullPush(floor);
             if (revitFloor == null)
                 return null;
 
+            document.Regenerate();
+
+            foreach (ICurve hole in planarSurface.InternalBoundaries)
+            {
+                document.Create.NewOpening(revitFloor, Create.CurveArray(hole.IToRevitCurves()), true);
+            }
+
+            foreach (BH.oM.Physical.Elements.IOpening opening in floor.Openings)
+            {
+                PlanarSurface openingLocation = opening.Location as PlanarSurface;
+                if (openingLocation == null)
+                {
+                    BH.Engine.Reflection.Compute.RecordWarning(String.Format("Conversion of a floor opening to Revit failed because its location is not a planar surface. Floor BHoM_Guid: {0}, Opening BHoM_Guid: {1}", floor.BHoM_Guid, opening.BHoM_Guid));
+                    continue;
+                }
+
+                document.Create.NewOpening(revitFloor, Create.CurveArray(openingLocation.ExternalBoundary.IToRevitCurves()), true);
+
+                if (!(opening is BH.oM.Physical.Elements.Void))
+                    BH.Engine.Reflection.Compute.RecordWarning(String.Format("Revit allows only void openings in floors, therefore the BHoM opening of type {0} has been converted to a void opening. Floor BHoM_Guid: {1}, Opening BHoM_Guid: {2}", opening.GetType().Name, floor.BHoM_Guid, opening.BHoM_Guid));
+            }
+
             // Copy parameters from BHoM object to Revit element
             revitFloor.CopyParameters(floor, settings);
+
+            // Update the offset in case the level had been overwritten.
+            if (revitFloor.LevelId.IntegerValue != level.Id.IntegerValue)
+            {
+                Level newLevel = document.GetElement(revitFloor.LevelId) as Level;
+                double offset = revitFloor.LookupParameterDouble(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM);
+                offset += (level.ProjectElevation - newLevel.ProjectElevation).ToSI(UnitType.UT_Length);
+                revitFloor.SetParameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM, offset);
+            }
 
             refObjects.AddOrReplace(floor, revitFloor);
             return revitFloor;

--- a/Revit_Core_Engine/Query/LevelAbove.cs
+++ b/Revit_Core_Engine/Query/LevelAbove.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static Level LevelAbove(this Document document, double elevation, RevitSettings settings, bool closestIfNotFound = true)
+        {
+            settings = settings.DefaultIfNull();
+
+            List<Level> levels = new FilteredElementCollector(document).OfClass(typeof(Level)).Cast<Level>().OrderBy(x => x.Elevation).ToList();
+            if (levels.Count == 0)
+                return null;
+
+            Level level = levels.FirstOrDefault(x => x.Elevation + settings.DistanceTolerance >= elevation);
+            if (level == null && closestIfNotFound)
+                level = levels[levels.Count - 1];
+
+            return level;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Query/LevelBelow.cs
+++ b/Revit_Core_Engine/Query/LevelBelow.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static Level LevelBelow(this Document document, double elevation, RevitSettings settings, bool closestIfNotFound = true)
+        {
+            settings = settings.DefaultIfNull();
+
+            List<Level> levels = new FilteredElementCollector(document).OfClass(typeof(Level)).Cast<Level>().OrderByDescending(x => x.Elevation).ToList();
+            if (levels.Count == 0)
+                return null;
+
+            Level level = levels.FirstOrDefault(x => x.Elevation - settings.DistanceTolerance <= elevation);
+            if (level == null && closestIfNotFound)
+                level = levels[levels.Count - 1];
+
+            return level;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -307,6 +307,8 @@
     <Compile Include="Query\CurtainPanels.cs" />
     <Compile Include="Query\FramingOffsetVectors.cs" />
     <Compile Include="Query\Identifiers.cs" />
+    <Compile Include="Query\LevelAbove.cs" />
+    <Compile Include="Query\LevelBelow.cs" />
     <Compile Include="Query\OpeningSurface.cs" />
     <Compile Include="Query\PanelPlanes.cs" />
     <Compile Include="Query\PanelSurfaces.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #421 
Closes #429

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue421%2C429%2DPushFloorBugs&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - can be run in an empty model.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Handling of openings on BHoM => Revit convert fixed
- BHoM => Revit convert of sloped floors enabled

