### PR TITLE
Minor BHoM => Revit framing convert bugs fixed

### DIFF
--- a/Revit_Core_Engine/Query/AdjustedLocationCurve.cs
+++ b/Revit_Core_Engine/Query/AdjustedLocationCurve.cs
@@ -74,10 +74,19 @@ namespace BH.Revit.Engine.Core
                 Vector zOffsetStart = new Vector { X = transform.BasisZ.X * startOffset.Z, Y = transform.BasisZ.Y * startOffset.Z, Z = transform.BasisZ.Z * startOffset.Z };
                 Vector yOffsetEnd = new Vector { X = transform.BasisY.X * endOffset.Y, Y = transform.BasisY.Y * endOffset.Y, Z = transform.BasisY.Z * endOffset.Y };
                 Vector zOffsetEnd = new Vector { X = transform.BasisZ.X * endOffset.Z, Y = transform.BasisZ.Y * endOffset.Z, Z = transform.BasisZ.Z * endOffset.Z };
-                curve = new BH.oM.Geometry.Line { Start = line.Start.Translate(yOffsetStart + zOffsetStart), End = line.End.Translate(yOffsetEnd + zOffsetEnd) };
+                line = new BH.oM.Geometry.Line { Start = line.Start.Translate(yOffsetStart + zOffsetStart), End = line.End.Translate(yOffsetEnd + zOffsetEnd) };
             }
 
-            return curve;
+            Vector dir = line.Direction();
+            double startExtension = familyInstance.LookupParameterDouble(BuiltInParameter.START_EXTENSION);
+            if (!double.IsNaN(startExtension))
+                line.Start = line.Start + dir * startExtension;
+
+            double endExtension = familyInstance.LookupParameterDouble(BuiltInParameter.END_EXTENSION);
+            if (!double.IsNaN(endExtension))
+                line.End = line.End - dir * endExtension;
+
+            return line;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/LocationCurve.cs
+++ b/Revit_Core_Engine/Query/LocationCurve.cs
@@ -76,7 +76,17 @@ namespace BH.Revit.Engine.Core
             BH.oM.Geometry.Plane startPlane = new oM.Geometry.Plane { Origin = line.Start, Normal = dir };
             BH.oM.Geometry.Plane endPlane = new oM.Geometry.Plane { Origin = line.End, Normal = dir };
             BH.oM.Geometry.Line transformedLine = BH.Engine.Geometry.Create.Line(transform.Origin.PointFromRevit(), transform.BasisX.VectorFromRevit());
-            return new BH.oM.Geometry.Line { Start = transformedLine.PlaneIntersection(startPlane, true), End = transformedLine.PlaneIntersection(endPlane, true) };
+            line = new BH.oM.Geometry.Line { Start = transformedLine.PlaneIntersection(startPlane, true), End = transformedLine.PlaneIntersection(endPlane, true) };
+
+            double startExtension = familyInstance.LookupParameterDouble(BuiltInParameter.START_EXTENSION);
+            if (!double.IsNaN(startExtension))
+                line.Start = line.Start - dir * startExtension;
+
+            double endExtension = familyInstance.LookupParameterDouble(BuiltInParameter.END_EXTENSION);
+            if (!double.IsNaN(endExtension))
+                line.End = line.End + dir * endExtension;
+
+            return line;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/OrientationAngle.cs
+++ b/Revit_Core_Engine/Query/OrientationAngle.cs
@@ -76,7 +76,9 @@ namespace BH.Revit.Engine.Core
         public static double OrientationAngleFraming(this FamilyInstance familyInstance, RevitSettings settings = null)
         {
             double rotation;
-            Curve locationCurve = ((LocationCurve)familyInstance.Location).Curve;
+            Curve locationCurve = (familyInstance.Location as LocationCurve)?.Curve;
+            if (locationCurve == null)
+                return double.NaN;
 
             if (locationCurve is Autodesk.Revit.DB.Line)
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #489
Closes #775

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[#489](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue489%2DNoLocationWarning&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)
[#775](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue775%2DFramingExtension&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
- Revit => BHoM convert of steel framing fixed to take into account _Extension_ parameters
- Revit => BHoM convert of unrecognized framing fixed not to crash but raise appropriate warnings about lack of location curve or profile