### PR TITLE
Ceiling pattern query stopped from throwing red error when there is no pattern on Revit ceiling

### DIFF
--- a/Revit_Core_Engine/Query/CeilingPattern.cs
+++ b/Revit_Core_Engine/Query/CeilingPattern.cs
@@ -52,13 +52,16 @@ namespace BH.Revit.Engine.Core
                 material = ceiling.Document.GetElement(comStruct.GetLayers().Last().MaterialId) as Material;
             else
             {
-                List<ElementId> materialIds = ceiling.GetMaterialIds(false).ToList();
-                if (materialIds.Count == 0)
-                {
-                    BH.Engine.Reflection.Compute.RecordError("Ceiling patterns could not be pulled for ceiling element with the ID " + ceiling.Id);
-                    return new List<oM.Geometry.Line>();
-                }
-                material = ceiling.Document.GetElement(materialIds[0]) as Material;
+                ElementId materialId = ceiling.GetMaterialIds(false)?.FirstOrDefault();
+
+                if (materialId != null)
+                    material = ceiling.Document.GetElement(materialId) as Material;
+            }
+
+            if (material == null)
+            {
+                BH.Engine.Reflection.Compute.RecordWarning(String.Format("Ceiling patterns could not be pulled because there is no material assigned to the ceiling. Revit ElementId: {0}", ceiling.Id));
+                return new List<oM.Geometry.Line>();
             }
 
             List<oM.Geometry.Line> result = new List<oM.Geometry.Line>();


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #813

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue813%2DCeilingPatternError&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)
