### PR TITLE
BHoM => Revit conversion failure warning changed to error

### DIFF
--- a/Revit_Core_Engine/Compute/Errors.cs
+++ b/Revit_Core_Engine/Compute/Errors.cs
@@ -32,6 +32,18 @@ namespace BH.Revit.Engine.Core
         /****               Internal methods            ****/
         /***************************************************/
 
+        internal static void NotConvertedError(this IBHoMObject obj)
+        {
+            string message = String.Format("BHoM object conversion to Revit failed.");
+
+            if (obj != null)
+                message += string.Format(" BHoM object type: {0}, BHoM Guid: {1}", obj.GetType(), obj.BHoM_Guid);
+
+            BH.Engine.Reflection.Compute.RecordError(message);
+        }
+
+        /***************************************************/
+
         internal static void NullDocumentError()
         {
             BH.Engine.Reflection.Compute.RecordError("BHoM object could not be read because Revit document does not exist.");

--- a/Revit_Core_Engine/Compute/Warnings.cs
+++ b/Revit_Core_Engine/Compute/Warnings.cs
@@ -22,12 +22,10 @@
 
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
-using BH.Adapter.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Adapters.Revit.Enums;
 using BH.oM.Base;
 using BH.oM.Physical.Elements;
-using BH.oM.Physical.FramingProperties;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,16 +38,6 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
         /****             Internal methods              ****/
         /***************************************************/
-
-        internal static void NotConvertedWarning(this IBHoMObject obj)
-        {
-            string message = String.Format("BHoM object conversion to Revit failed.");
-
-            if (obj != null)
-                message += string.Format(" BHoM object type: {0}, BHoM Guid: {1}", obj.GetType(), obj.BHoM_Guid);
-
-            BH.Engine.Reflection.Compute.RecordWarning(message);
-        }
 
         internal static void NotConvertedWarning(this Element element, Discipline discipline)
         {

--- a/Revit_Core_Engine/Convert/ToRevit.cs
+++ b/Revit_Core_Engine/Convert/ToRevit.cs
@@ -204,7 +204,7 @@ namespace BH.Revit.Engine.Core
 
             Element result = ToRevit(obj as dynamic, document, settings, refObjects);
             if (result == null)
-                obj.NotConvertedWarning();
+                obj.NotConvertedError();
 
             return result;
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #815

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue815%2DThrowErrorOnConvertFailure&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - can be tested on any Revit file.
