### PR TITLE
Pull fixed not to unselect Revit elements in the process

### DIFF
--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -48,6 +48,8 @@ namespace BH.Revit.Adapter.Core
             Autodesk.Revit.UI.UIDocument uiDocument = this.UIDocument;
             Document document = this.Document;
 
+            ICollection<ElementId> selected = uiDocument.Selection.GetElementIds();
+
             if (request == null)
             {
                 BH.Engine.Reflection.Compute.RecordError("BHoM objects could not be read because provided IRequest is null.");
@@ -149,6 +151,8 @@ namespace BH.Revit.Adapter.Core
             bool[] activePulls = new bool[] { geometryConfig.PullEdges, geometryConfig.PullSurfaces, geometryConfig.PullMeshes, representationConfig.PullRenderMesh };
             if (activePulls.Count(x => x == true) > 1)
                 BH.Engine.Reflection.Compute.RecordWarning("Pull of more than one geometry/representation type has been specified in RevitPullConfig. Please consider this can be time consuming due to the amount of conversions.");
+
+            uiDocument.Selection.SetElementIds(selected);
 
             return result;
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #700

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue700%2DKeepSelectionAfterPull&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

