### PR TITLE
Bug setting wrong elevation to newly created walls fixed

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Wall.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Wall.cs
@@ -109,7 +109,7 @@ namespace BH.Revit.Engine.Core
                 parameter.Set(height);
             }
 
-            double levelElevation = level.Elevation.ToSI(UnitType.UT_Length);
+            double levelElevation = level.Elevation;
 
             if (System.Math.Abs(bottomElevation - levelElevation) > Tolerance.MacroDistance)
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #831

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue831%2DWallElevationBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- bug setting wrong elevation to newly created walls fixed


### Additional comments
<!-- As required -->
This PR is quite urgent as it concerns one of the core Revit_Toolkit functionalities.