### PR TITLE
BH.Revit.Engine.Core.Query.Outlines renamed to AnalyticalOutlines

### DIFF
--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Panels.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Panels.cs
@@ -74,7 +74,7 @@ namespace BH.Revit.Engine.Core
             if (property2D == null)
                 BH.Engine.Reflection.Compute.RecordError(String.Format("Conversion of Revit panel's construction to BHoM ISurfaceProperty failed. A panel without property is returned. Revit ElementId : {0}", hostObjAttributes.Id));
 
-            List<ICurve> outlines = hostObject.Outlines(settings);
+            List<ICurve> outlines = hostObject.AnalyticalOutlines(settings);
             if (outlines != null && outlines.Count != 0)
             {
                 hostObject.AnalyticalPullWarning();

--- a/Revit_Core_Engine/Query/AnalyticalOutlines.cs
+++ b/Revit_Core_Engine/Query/AnalyticalOutlines.cs
@@ -37,7 +37,7 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        public static List<ICurve> Outlines(this HostObject hostObject, RevitSettings settings = null)
+        public static List<ICurve> AnalyticalOutlines(this HostObject hostObject, RevitSettings settings = null)
         {
             AnalyticalModel analyticalModel = hostObject.GetAnalyticalModel();
             if (analyticalModel == null)

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -438,7 +438,7 @@
     <Compile Include="Query\Element.cs" />
     <Compile Include="Query\ElementId.cs" />
     <Compile Include="Query\MaterialGrade.cs" />
-    <Compile Include="Query\Outlines.cs" />
+    <Compile Include="Query\AnalyticalOutlines.cs" />
     <Compile Include="Query\Level.cs" />
     <Compile Include="Query\LookupParameter.cs" />
     <Compile Include="Query\Perimeter.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #837

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not really needed (simple renaming), but one can run try pulling structural panels from [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2F%5FMacro%2FPull%2FStructure&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
Both this PR and #828 modify same .csproj file, but they can merge into each other so no conflict should occur.