### PR TITLE
Profile extraction bugs fixed

### DIFF
--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -138,13 +138,13 @@ namespace BH.Revit.Engine.Core
             else if (section is StructuralSectionConcreteRound)
                 diameter = (section as StructuralSectionConcreteRound).Diameter.ToSI(UnitType.UT_Section_Dimension);
             else
-                diameter = familySymbol.LookupParameterDouble(diameterNames);
+                diameter = familySymbol.LookupParameterDouble(diameterNames, dimensionGroups);
 
             if (!double.IsNaN(diameter))
                 return BHG.Create.CircleProfile(diameter);
             else
             {
-                double radius = familySymbol.LookupParameterDouble(radiusNames);
+                double radius = familySymbol.LookupParameterDouble(radiusNames, dimensionGroups);
                 if (!double.IsNaN(radius))
                     return BHG.Create.CircleProfile(radius * 2);
             }
@@ -171,18 +171,18 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                height = familySymbol.LookupParameterDouble(heightNames);
-                topFlangeWidth = familySymbol.LookupParameterDouble(topFlangeWidthNames);
-                botFlangeWidth = familySymbol.LookupParameterDouble(botFlangeWidthNames);
-                webThickness = familySymbol.LookupParameterDouble(webThicknessNames);
-                topFlangeThickness = familySymbol.LookupParameterDouble(topFlangeThicknessNames);
-                botFlangeThickness = familySymbol.LookupParameterDouble(botFlangeThicknessNames);
-                weldSize = familySymbol.LookupParameterDouble(weldSizeNames1);
+                height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
+                topFlangeWidth = familySymbol.LookupParameterDouble(topFlangeWidthNames, dimensionGroups);
+                botFlangeWidth = familySymbol.LookupParameterDouble(botFlangeWidthNames, dimensionGroups);
+                webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
+                topFlangeThickness = familySymbol.LookupParameterDouble(topFlangeThicknessNames, dimensionGroups);
+                botFlangeThickness = familySymbol.LookupParameterDouble(botFlangeThicknessNames, dimensionGroups);
+                weldSize = familySymbol.LookupParameterDouble(weldSizeNames1, dimensionGroups);
             }
 
             if (double.IsNaN(weldSize))
             {
-                weldSize = familySymbol.LookupParameterDouble(weldSizeNames2);
+                weldSize = familySymbol.LookupParameterDouble(weldSizeNames2, dimensionGroups);
                 if (!double.IsNaN(weldSize) && !double.IsNaN(webThickness))
                     weldSize = (weldSize - webThickness) / (Math.Sqrt(2));
                 else
@@ -224,9 +224,9 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                height = familySymbol.LookupParameterDouble(heightNames);
-                width = familySymbol.LookupParameterDouble(widthNames);
-                cornerRadius = familySymbol.LookupParameterDouble(cornerRadiusNames);
+                height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
+                width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
+                cornerRadius = familySymbol.LookupParameterDouble(cornerRadiusNames, dimensionGroups);
             }
 
             if (double.IsNaN(cornerRadius))
@@ -267,12 +267,12 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                height = familySymbol.LookupParameterDouble(heightNames);
-                width = familySymbol.LookupParameterDouble(widthNames);
-                webThickness = familySymbol.LookupParameterDouble(webThicknessNames);
-                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames);
-                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames);
-                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames);
+                height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
+                width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
+                webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
+                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames, dimensionGroups);
+                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames, dimensionGroups);
+                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames, dimensionGroups);
             }
 
             if (double.IsNaN(rootRadius))
@@ -304,11 +304,11 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                height = familySymbol.LookupParameterDouble(heightNames);
-                width = familySymbol.LookupParameterDouble(widthNames);
-                thickness = familySymbol.LookupParameterDouble(wallThicknessNames);
-                outerRadius = familySymbol.LookupParameterDouble(outerRadiusNames);
-                innerRadius = familySymbol.LookupParameterDouble(innerRadiusNames);
+                height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
+                width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
+                thickness = familySymbol.LookupParameterDouble(wallThicknessNames, dimensionGroups);
+                outerRadius = familySymbol.LookupParameterDouble(outerRadiusNames, dimensionGroups);
+                innerRadius = familySymbol.LookupParameterDouble(innerRadiusNames, dimensionGroups);
             }
 
             if (double.IsNaN(outerRadius))
@@ -352,12 +352,12 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                height = familySymbol.LookupParameterDouble(heightNames);
-                flangeWidth = familySymbol.LookupParameterDouble(widthNames);
-                webThickness = familySymbol.LookupParameterDouble(webThicknessNames);
-                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames);
-                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames);
-                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames);
+                height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
+                flangeWidth = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
+                webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
+                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames, dimensionGroups);
+                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames, dimensionGroups);
+                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames, dimensionGroups);
             }
 
             if (double.IsNaN(rootRadius))
@@ -400,12 +400,12 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                height = familySymbol.LookupParameterDouble(heightNames);
-                width = familySymbol.LookupParameterDouble(widthNames);
-                webThickness = familySymbol.LookupParameterDouble(webThicknessNames);
-                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames);
-                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames);
-                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames);
+                height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
+                width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
+                webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
+                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames, dimensionGroups);
+                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames, dimensionGroups);
+                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames, dimensionGroups);
             }
 
             if (double.IsNaN(rootRadius))
@@ -459,12 +459,12 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                height = familySymbol.LookupParameterDouble(heightNames);
-                width = familySymbol.LookupParameterDouble(widthNames);
-                webThickness = familySymbol.LookupParameterDouble(webThicknessNames);
-                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames);
-                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames);
-                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames);
+                height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
+                width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
+                webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
+                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames, dimensionGroups);
+                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames, dimensionGroups);
+                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames, dimensionGroups);
             }
 
             if (double.IsNaN(rootRadius))
@@ -497,12 +497,12 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                height = familySymbol.LookupParameterDouble(heightNames);
-                flangeWidth = familySymbol.LookupParameterDouble(widthNames);
-                webThickness = familySymbol.LookupParameterDouble(webThicknessNames);
-                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames);
-                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames);
-                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames);
+                height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
+                flangeWidth = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
+                webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
+                flangeThickness = familySymbol.LookupParameterDouble(flangeThicknessNames, dimensionGroups);
+                rootRadius = familySymbol.LookupParameterDouble(rootRadiusNames, dimensionGroups);
+                toeRadius = familySymbol.LookupParameterDouble(toeRadiusNames, dimensionGroups);
             }
 
             if (double.IsNaN(rootRadius))
@@ -537,14 +537,14 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                thickness = familySymbol.LookupParameterDouble(wallThicknessNames);
-                diameter = familySymbol.LookupParameterDouble(diameterNames);
+                thickness = familySymbol.LookupParameterDouble(wallThicknessNames, dimensionGroups);
+                diameter = familySymbol.LookupParameterDouble(diameterNames, dimensionGroups);
             }
 
             if (!double.IsNaN(diameter) && !double.IsNaN(thickness))
                 return BHG.Create.TubeProfile(diameter, thickness);
 
-            double radius = familySymbol.LookupParameterDouble(radiusNames);
+            double radius = familySymbol.LookupParameterDouble(radiusNames, dimensionGroups);
             if (!double.IsNaN(radius) && !double.IsNaN(thickness))
                 return BHG.Create.TubeProfile(radius * 2, thickness);
 
@@ -702,6 +702,8 @@ namespace BH.Revit.Engine.Core
         /****              Private helpers              ****/
         /***************************************************/
 
+        private static readonly BuiltInParameterGroup[] dimensionGroups = { BuiltInParameterGroup.PG_STRUCTURAL_SECTION_GEOMETRY, BuiltInParameterGroup.PG_GEOMETRY };
+
         private static readonly string[] diameterNames = { "BHE_Diameter", "Diameter", "d", "D", "OD" };
         private static readonly string[] radiusNames = { "BHE_Radius", "Radius", "r", "R" };
         private static readonly string[] heightNames = { "BHE_Height", "BHE_Depth", "Height", "Depth", "d", "h", "D", "H", "Ht", "b" };
@@ -715,9 +717,9 @@ namespace BH.Revit.Engine.Core
         private static readonly string[] flangeThicknessNames = { "Flange Thickness", "Slab Depth", "tf", "T", "t" };
         private static readonly string[] weldSizeNames1 = { "Weld Size" };                                            // weld size, diagonal
         private static readonly string[] weldSizeNames2 = { "k" };                                                    // weld size counted from bar's vertical axis
-        private static readonly string[] rootRadiusNames = { "Web Fillet", "Root Radius", "r", "r1", "tr", "kr", "R1", "R", "t" };
-        private static readonly string[] toeRadiusNames = { "Flange Fillet", "Toe Radius", "r2", "R2", "t" };
-        private static readonly string[] innerRadiusNames = { "Inner Fillet", "Inner Radius", "r1", "R1", "ri", "t" };
+        private static readonly string[] rootRadiusNames = { "Web Fillet", "Root Radius", "r", "r1", "tr", "kr", "R1", "R" };
+        private static readonly string[] toeRadiusNames = { "Flange Fillet", "Toe Radius", "r2", "R2" };
+        private static readonly string[] innerRadiusNames = { "Inner Fillet", "Inner Radius", "r1", "R1", "ri" };
         private static readonly string[] outerRadiusNames = { "Outer Fillet", "Outer Radius", "r2", "R2", "ro", "tr" };
         private static readonly string[] wallThicknessNames = { "Wall Nominal Thickness", "Wall Thickness", "t", "T" };
 

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -733,7 +733,7 @@ namespace BH.Revit.Engine.Core
         private static readonly string[] rootRadiusNames = { "Web Fillet", "Root Radius", "r", "r1", "tr", "kr", "R1", "R" };
         private static readonly string[] toeRadiusNames = { "Flange Fillet", "Toe Radius", "r2", "R2" };
         private static readonly string[] innerRadiusNames = { "Inner Fillet", "Inner Radius", "r1", "R1", "ri", "t" };
-        private static readonly string[] outerRadiusNames = { "Outer Fillet", "Outer Radius", "r2", "R2", "ro", "tr" };
+        private static readonly string[] outerRadiusNames = { "Outer Fillet", "Outer Radius", "r2", "R2", "ro", "tr", "kr" };
         private static readonly string[] wallThicknessNames = { "Wall Nominal Thickness", "Wall Thickness", "t", "T" };
 
         /***************************************************/

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -731,7 +731,7 @@ namespace BH.Revit.Engine.Core
         private static readonly string[] weldSizeNames2 = { "k" };                                                    // weld size counted from bar's vertical axis
         private static readonly string[] rootRadiusNames = { "Web Fillet", "Root Radius", "r", "r1", "tr", "kr", "R1", "R" };
         private static readonly string[] toeRadiusNames = { "Flange Fillet", "Toe Radius", "r2", "R2" };
-        private static readonly string[] innerRadiusNames = { "Inner Fillet", "Inner Radius", "r1", "R1", "ri" };
+        private static readonly string[] innerRadiusNames = { "Inner Fillet", "Inner Radius", "r1", "R1", "ri", "t" };
         private static readonly string[] outerRadiusNames = { "Outer Fillet", "Outer Radius", "r2", "R2", "ro", "tr" };
         private static readonly string[] wallThicknessNames = { "Wall Nominal Thickness", "Wall Thickness", "t", "T" };
 

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -721,8 +721,8 @@ namespace BH.Revit.Engine.Core
         private static readonly string[] heightNames = { "BHE_Height", "BHE_Depth", "Height", "Depth", "d", "h", "D", "H", "Ht", "b" };
         private static readonly string[] widthNames = { "BHE_Width", "Width", "b", "B", "bf", "w", "W", "D" };
         private static readonly string[] cornerRadiusNames = { "Corner Radius", "r", "r1" };
-        private static readonly string[] topFlangeWidthNames = { "Top Flange Width", "bt", "bf_t", "bft", "b1", "b", "B", "Bt" };
-        private static readonly string[] botFlangeWidthNames = { "Bottom Flange Width", "bb", "bf_b", "bfb", "b2", "b", "B", "Bb" };
+        private static readonly string[] topFlangeWidthNames = { "Top Flange Width", "bt", "bf_t", "bft", "b1", "b", "B", "Bt", "bf" };
+        private static readonly string[] botFlangeWidthNames = { "Bottom Flange Width", "bb", "bf_b", "bfb", "b2", "b", "B", "Bb", "bf" };
         private static readonly string[] webThicknessNames = { "Web Thickness", "Stem Width", "tw", "t", "T" };
         private static readonly string[] topFlangeThicknessNames = { "Top Flange Thickness", "tft", "tf_t", "tf", "T", "t" };
         private static readonly string[] botFlangeThicknessNames = { "Bottom Flange Thickness", "tfb", "tf_b", "tf", "T", "t" };

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -618,7 +618,7 @@ namespace BH.Revit.Engine.Core
             Autodesk.Revit.DB.Face face = null;
             foreach (Autodesk.Revit.DB.Face f in solid.Faces)
             {
-                if (f is PlanarFace && (f as PlanarFace).FaceNormal.Normalize().IsAlmostEqualTo(direction, 0.001))
+                if (f is PlanarFace && (f as PlanarFace).FaceNormal.Normalize().IsAlmostEqualTo(-direction, 0.001))
                 {
                     if (face == null)
                         face = f;
@@ -665,7 +665,7 @@ namespace BH.Revit.Engine.Core
                 if (familySymbol.Family.FamilyPlacementType == FamilyPlacementType.CurveDrivenStructural)
                 {
                     // First rotate the profile to align its local plane with global XY, then rotate to align its local Z with global Y.
-                    double angle = -Math.PI * 0.5;
+                    double angle = Math.PI * 0.5;
                     profileCurves = profileCurves.Select(x => x.IRotate(oM.Geometry.Point.Origin, Vector.YAxis, angle)).ToList();
                     profileCurves = profileCurves.Select(x => x.IRotate(oM.Geometry.Point.Origin, Vector.ZAxis, angle)).ToList();
                 }

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -188,7 +188,7 @@ namespace BH.Revit.Engine.Core
             {
                 weldSize = familySymbol.LookupParameterDouble(weldSizeNames2, dimensionGroups);
                 if (!double.IsNaN(weldSize) && !double.IsNaN(webThickness))
-                    weldSize = (weldSize - webThickness) / (Math.Sqrt(2));
+                    weldSize = (weldSize - webThickness / 2) / (Math.Sqrt(2));
                 else
                     weldSize = 0;
             }

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -581,6 +581,7 @@ namespace BH.Revit.Engine.Core
             // Check if one and only one solid exists to make sure that the column is a single piece
             Solid solid = null;
             Options options = new Options();
+            options.DetailLevel = ViewDetailLevel.Fine;
             options.IncludeNonVisibleObjects = false;
 
             // Activate the symbol temporarily if not active, then extract its geometry (open either transaction or subtransaction, depending on whether one is already open).

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -138,7 +138,10 @@ namespace BH.Revit.Engine.Core
             else if (section is StructuralSectionConcreteRound)
                 diameter = (section as StructuralSectionConcreteRound).Diameter.ToSI(UnitType.UT_Section_Dimension);
             else
+            {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 diameter = familySymbol.LookupParameterDouble(diameterNames, dimensionGroups);
+            }
 
             if (!double.IsNaN(diameter))
                 return BHG.Create.CircleProfile(diameter);
@@ -171,6 +174,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
                 topFlangeWidth = familySymbol.LookupParameterDouble(topFlangeWidthNames, dimensionGroups);
                 botFlangeWidth = familySymbol.LookupParameterDouble(botFlangeWidthNames, dimensionGroups);
@@ -224,6 +228,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
                 width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
                 cornerRadius = familySymbol.LookupParameterDouble(cornerRadiusNames, dimensionGroups);
@@ -267,6 +272,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
                 width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
                 webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
@@ -304,6 +310,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
                 width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
                 thickness = familySymbol.LookupParameterDouble(wallThicknessNames, dimensionGroups);
@@ -352,6 +359,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
                 flangeWidth = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
                 webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
@@ -400,6 +408,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
                 width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
                 webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
@@ -459,6 +468,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
                 width = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
                 webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
@@ -497,6 +507,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 height = familySymbol.LookupParameterDouble(heightNames, dimensionGroups);
                 flangeWidth = familySymbol.LookupParameterDouble(widthNames, dimensionGroups);
                 webThickness = familySymbol.LookupParameterDouble(webThicknessNames, dimensionGroups);
@@ -537,6 +548,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
+                BH.Engine.Reflection.Compute.RecordWarning($"Dimensions of section profile {familySymbol.Name} (Revit ElementId {familySymbol.Id.IntegerValue}) were extracted using name matching and may be incorrect in some cases.");
                 thickness = familySymbol.LookupParameterDouble(wallThicknessNames, dimensionGroups);
                 diameter = familySymbol.LookupParameterDouble(diameterNames, dimensionGroups);
             }

--- a/Revit_Core_Engine/Query/LookupParameter.cs
+++ b/Revit_Core_Engine/Query/LookupParameter.cs
@@ -37,6 +37,28 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
+        public static Parameter LookupParameter(this Element element, IEnumerable<string> parameterNames, IEnumerable<BuiltInParameterGroup> parameterGroups = null)
+        {
+            if (parameterNames == null || !parameterNames.Any())
+                return null;
+
+            foreach (string name in parameterNames)
+            {
+                foreach (Parameter p in element.Parameters)
+                {
+                    if (p != null && p.HasValue && p.Definition.Name == name)
+                    {
+                        if (parameterGroups == null || parameterGroups.Any(x => x == p.Definition.ParameterGroup))
+                            return p;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /***************************************************/
+
         public static double LookupParameterDouble(this Element element, string parameterName, bool convertUnits = true)
         {
             double value = double.NaN;
@@ -57,11 +79,27 @@ namespace BH.Revit.Engine.Core
         public static double LookupParameterDouble(this Element element, IEnumerable<string> parameterNames, bool convertUnits = true)
         {
             double value = double.NaN;
-            foreach(string name in parameterNames)
+            foreach (string name in parameterNames)
             {
                 value = element.LookupParameterDouble(name, convertUnits);
                 if (!double.IsNaN(value))
                     return value;
+            }
+
+            return value;
+        }
+
+        /***************************************************/
+
+        public static double LookupParameterDouble(this Element element, IEnumerable<string> parameterNames, IEnumerable<BuiltInParameterGroup> parameterGroups, bool convertUnits = true)
+        {
+            double value = double.NaN;
+            Parameter p = element.LookupParameter(parameterNames, parameterGroups);
+            if (p != null && p.HasValue)
+            {
+                value = p.AsDouble();
+                if (convertUnits)
+                    value = value.ToSI(p.Definition.UnitType);
             }
 
             return value;

--- a/Revit_Core_Engine/Query/SectionShape.cs
+++ b/Revit_Core_Engine/Query/SectionShape.cs
@@ -103,18 +103,18 @@ namespace BH.Revit.Engine.Core
             {
                 StructuralSectionShape.IParallelFlange, new string[]
                 {
-                    "_RSJ-RolledSteelJoists-Column",
-                    "_RSJ-RolledSteelJoists",
+                    //"_RSJ-RolledSteelJoists-Column",
+                    //"_RSJ-RolledSteelJoists",
                     "_HP-BearingPile-Column",
                     "_IPE-Column",
                     "_IPE-Beams",
-                    "_IPN-Column",
-                    "_IPN-Beams",
+                    //"_IPN-Column",
+                    //"_IPN-Beams",
                     "_UKBP-UKBearingPiles-Column",
                     "_UKBP-UKBearingPiles",
                     "_UKB-UKBeams-Column",
                     "_UKB-UKBeams",
-                    "_ASB-Beams",
+                    //"_ASB-Beams",
                     "_UBP-UniversalBearingPile-Column",
                     "_UBP-UniversalBearingPile",
                     "_UB-UniversalBeams-Column",
@@ -162,7 +162,7 @@ namespace BH.Revit.Engine.Core
                 StructuralSectionShape.CProfile, new string[]
                 {
                     "_U-Channels",
-                    "_C-Channels"
+                    //"_C-Channels"
                 }
             },
             {
@@ -178,13 +178,13 @@ namespace BH.Revit.Engine.Core
             {
                 StructuralSectionShape.ConcreteT, new string[]
                 {
-                    "_Precast-SingleTee"
+                    //"_Precast-SingleTee"
                 }
             },
             {
                 StructuralSectionShape.StructuralTees, new string[]
                 {
-                    "_T-Tees"
+                    //"_T-Tees"
                 }
             },
             {

--- a/Revit_Core_Engine/Query/SectionShape.cs
+++ b/Revit_Core_Engine/Query/SectionShape.cs
@@ -161,7 +161,7 @@ namespace BH.Revit.Engine.Core
             {
                 StructuralSectionShape.CProfile, new string[]
                 {
-                    "_U-Channels",
+                    //"_U-Channels",
                     //"_C-Channels"
                 }
             },


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #848
Closes #849

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
#848 on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/Installers/Forms/AllItems.aspx?RootFolder=%2fsites%2fBHoM%2fInstallers%2fScripts%2fBuroHappold%5fBHoM%5fv3%2e3%2f0001%5fRevit%5fToolkit%2fPull&FolderCTID=0x012000181C071E8B6D1E438B59C87DA36B9302):
- _BuroHappold_BHoM_v3.3.beta_PullColumnProfiles_ for columns
- _BuroHappold_BHoM_v3.3.beta_PullFramingProfiles_ for framing

**Important:** to make the GH script work fine, Rhino document tolerance should be set to 1e-6 (usually 1e-3 by default).

To select top row of supported types, one can use a predefined selection set named _1st row_:
![image](https://user-images.githubusercontent.com/26874773/93625145-bfdb4e80-f9e1-11ea-99c4-c9e922d8dda4.png)


#849 can be tested using the 2nd file from the above, taking one of the light gauge profiles, e.g. the one under ID 1388030.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Name matching of profile dimensions improved
- Pull of freeform framing profile fixed to return the profile in correct orientation


### Additional comments
<!-- As required -->
There is still a few bugs here and there, but as discussed with @IsakNaslundBh, it looks like we may not be able to fix all of them with the current approach - possible adjustments (cross checks or determination of profile shape from its outline) to be discussed on the Structures planning for 4.0. Following that, I am happy to merge the PR in its current state regardless the bugs.