### PR TITLE
Floor, wall and roof offset issues fixed

### DIFF
--- a/Revit_Core_Engine/Convert/Geometry/ToRevit/Curve.cs
+++ b/Revit_Core_Engine/Convert/Geometry/ToRevit/Curve.cs
@@ -88,7 +88,7 @@ namespace BH.Revit.Engine.Core
                 }
                 catch
                 {
-                    BH.Engine.Reflection.Compute.RecordWarning("Revit does not support nurbs curves of degree 2. A simplified (possibly distorted) hermite spline has been created.");
+                    BH.Engine.Reflection.Compute.RecordWarning("Conversion of a nurbs curve from BHoM to Revit failed. A simplified (possibly distorted) hermite spline has been created instead.");
 
                     List<XYZ> cps = new List<XYZ>();
                     for (int i = 0; i < controlPoints.Count; i++)

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
@@ -114,9 +114,12 @@ namespace BH.Revit.Engine.Core
 
             document.Regenerate();
 
-            foreach (ICurve hole in planarSurface.InternalBoundaries)
+            if (planarSurface.InternalBoundaries != null)
             {
-                document.Create.NewOpening(revitFloor, Create.CurveArray(hole.IToRevitCurves()), true);
+                foreach (ICurve hole in planarSurface.InternalBoundaries)
+                {
+                    document.Create.NewOpening(revitFloor, Create.CurveArray(hole.IProject(slabPlane).IToRevitCurves()), true);
+                }
             }
 
             foreach (BH.oM.Physical.Elements.IOpening opening in floor.Openings)
@@ -134,6 +137,8 @@ namespace BH.Revit.Engine.Core
                     BH.Engine.Reflection.Compute.RecordWarning(String.Format("Revit allows only void openings in floors, therefore the BHoM opening of type {0} has been converted to a void opening. Floor BHoM_Guid: {1}, Opening BHoM_Guid: {2}", opening.GetType().Name, floor.BHoM_Guid, opening.BHoM_Guid));
             }
 
+            double offset = revitFloor.LookupParameterDouble(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM);
+
             // Copy parameters from BHoM object to Revit element
             revitFloor.CopyParameters(floor, settings);
 
@@ -141,10 +146,10 @@ namespace BH.Revit.Engine.Core
             if (revitFloor.LevelId.IntegerValue != level.Id.IntegerValue)
             {
                 Level newLevel = document.GetElement(revitFloor.LevelId) as Level;
-                double offset = revitFloor.LookupParameterDouble(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM);
                 offset += (level.ProjectElevation - newLevel.ProjectElevation).ToSI(UnitType.UT_Length);
-                revitFloor.SetParameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM, offset);
             }
+
+            revitFloor.SetParameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM, offset);
 
             refObjects.AddOrReplace(floor, revitFloor);
             return revitFloor;

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/RoofBase.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/RoofBase.cs
@@ -91,30 +91,28 @@ namespace BH.Revit.Engine.Core
             
             oM.Geometry.Plane plane = BH.Engine.Geometry.Create.Plane(BH.Engine.Geometry.Create.Point(0, 0, elevation), BH.Engine.Geometry.Create.Vector(0, 0, 1));
 
-            ICurve curve = BH.Engine.Geometry.Modify.Project(planarSurface.ExternalBoundary as dynamic, plane) as ICurve;
+            ICurve curve = planarSurface.ExternalBoundary.IProject(plane);
             CurveArray curveArray = Create.CurveArray(curve.IToRevitCurves());
 
             ModelCurveArray modelCurveArray = new ModelCurveArray();
             roofBase = document.Create.NewFootPrintRoof(curveArray, level, roofType, out modelCurveArray);
+            
             if (roofBase != null)
             {
                 Parameter parameter = roofBase.get_Parameter(BuiltInParameter.ROOF_UPTO_LEVEL_PARAM);
                 if (parameter != null)
                     parameter.Set(ElementId.InvalidElementId);
 
-                List<ICurve> curveList = planarSurface.ExternalBoundary.ISubParts().ToList();
+                List<oM.Geometry.Point> controlPoints = planarSurface.ExternalBoundary.IControlPoints();
 
-                if (curveList != null && curveList.Count > 2)
+                if (controlPoints != null && controlPoints.Count > 2)
                 {
                     SlabShapeEditor slabShapeEditor = roofBase.SlabShapeEditor;
                     slabShapeEditor.ResetSlabShape();
 
-                    foreach (ICurve tempCurve in curveList)
+                    foreach (oM.Geometry.Point point in controlPoints)
                     {
-                        oM.Geometry.Point point = tempCurve.IStartPoint();
-
-                        //TODO: remove hardcoded tolerance
-                        if (System.Math.Abs(point.Z - plane.Origin.Z) > Tolerance.MicroDistance)
+                        if (System.Math.Abs(point.Z - plane.Origin.Z) > Tolerance.Distance)
                         {
                             XYZ xyz = point.ToRevit();
                             slabShapeEditor.DrawPoint(xyz);
@@ -130,6 +128,16 @@ namespace BH.Revit.Engine.Core
 
             // Copy parameters from BHoM object to Revit element
             roofBase.CopyParameters(roof, settings);
+
+            // Update the offset in case the level had been overwritten.
+            double offset = 0;
+            if (roofBase.LevelId.IntegerValue != level.Id.IntegerValue)
+            {
+                Level newLevel = document.GetElement(roofBase.LevelId) as Level;
+                offset += (level.ProjectElevation - newLevel.ProjectElevation).ToSI(UnitType.UT_Length);
+            }
+
+            roofBase.SetParameter(BuiltInParameter.ROOF_LEVEL_OFFSET_PARAM, offset);
 
             refObjects.AddOrReplace(roof, roofBase);
             return roofBase;


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #852

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Check if the existing Revit elements overlap with the pushed ones.
- issue-specific test file [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue852%2DPanelOffsetBugs&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - select an element, pull it and push back, getting rid of the red GH group should be possible after fix (see description inside script)
- macro tests: best to run _BuroHappold_BHoM_v3.3.beta_CreatePanelLocation.gh_ script from [here](https://burohappold.sharepoint.com/sites/BHoM/Installers/Forms/AllItems.aspx?RootFolder=%2fsites%2fBHoM%2fInstallers%2fScripts%2fBuroHappold%5fBHoM%5fv3%2e3%2f0001%5fRevit%5fToolkit%2fPush&FolderCTID=0x012000181C071E8B6D1E438B59C87DA36B9302) on _BuroHappold_BHoM_v3.3.beta_PullPanelLocation.rvt_ file from [here](https://burohappold.sharepoint.com/sites/BHoM/Installers/Forms/AllItems.aspx?RootFolder=%2fsites%2fBHoM%2fInstallers%2fScripts%2fBuroHappold%5fBHoM%5fv3%2e3%2f0001%5fRevit%5fToolkit%2fPull&FolderCTID=0x012000181C071E8B6D1E438B59C87DA36B9302) switch `PushType` to `CreateOnly` and check if the newly added elements overlap with the existing ones - important to know that wall and roof openings do not get pushed, which is an expected behaviour for now, to be further investigated in 4.0 Milestone



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- null check added on floor push to increase robustness
- sloped floor offset bug on push fixed
- sloped roof offset bug on push fixed
- cut wall offset bug on push fixed
- BHoM => Revit nurbs curve conversion wrapped in a `try/catch` to increase robustness as it turned out that not only degree 2 curves fail in Revit, but also higher degrees combined with certain knot multiplicities cause issues


### Additional comments
<!-- As required -->
Looking forward to including it in the 3.3 Beta, therefore I would be thankful for prompt review @LMarkowski @IsakNaslundBh. Thanks!