### PR TITLE
Level convert fixed not to overwrite parameters without notice nor create duplicate levels on Push

### DIFF
--- a/Revit_Core_Engine/Convert/Geometry/ToRevit/Grid.cs
+++ b/Revit_Core_Engine/Convert/Geometry/ToRevit/Grid.cs
@@ -99,6 +99,10 @@ namespace BH.Revit.Engine.Core
                 revitGrid = document.GetElement(gridId);
             }
 
+            revitGrid.CheckIfNullPush(grid);
+            if (revitGrid == null)
+                return null;
+
             try
             {
                 revitGrid.Name = grid.Name;
@@ -107,10 +111,6 @@ namespace BH.Revit.Engine.Core
             {
                 BH.Engine.Reflection.Compute.RecordWarning(String.Format("Grid name '{0}' was not unique, name '{1}' has been assigned instead. BHoM_Guid: {2}", grid.Name, revitGrid.Name, grid.BHoM_Guid));
             }
-
-            revitGrid.CheckIfNullPush(grid);
-            if (revitGrid == null)
-                return null;
 
             // Copy parameters from BHoM object to Revit element
             revitGrid.CopyParameters(grid, settings);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #854

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
_BuroHappold_BHoM_v3.3.beta_CreateGridsLevels.gh_ with _BuroHappold_BHoM_v3.3.beta_EmptyFile.rvt_, both available [here](https://burohappold.sharepoint.com/sites/BHoM/Installers/Forms/AllItems.aspx?RootFolder=%2fsites%2fBHoM%2fInstallers%2fScripts%2fBuroHappold%5fBHoM%5fv3%2e3%2f0001%5fRevit%5fToolkit%2fPush&FolderCTID=0x012000181C071E8B6D1E438B59C87DA36B9302) - simply push standard levels first, then try two pushes from red groups.

No test for grid convert as the only implemented change is null check moved up to avoid potential crashes (obvious and not harmful).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- BHoM => Revit level convert fixed not to overwrite parameters without notice nor create duplicate levels on Push


### Additional comments
<!-- As required -->
Sorry for last minute bugfix PR - full-on testing mode 🤣 