### PR TITLE
Remove reference to AdapterIdName in the constructor

### DIFF
--- a/Revit_Core_Adapter/RevitListenerAdapter.cs
+++ b/Revit_Core_Adapter/RevitListenerAdapter.cs
@@ -48,7 +48,7 @@ namespace BH.Revit.Adapter.Core
         public RevitListenerAdapter(UIControlledApplication uIControlledApplication, Document document)
             : base()
         {
-            AdapterIdName = BH.Engine.Adapters.Revit.Convert.AdapterIdName;
+
             m_AdapterSettings.UseAdapterId = false;
 
             m_Document = document;

--- a/Revit_Engine/Convert/Aliases.cs
+++ b/Revit_Engine/Convert/Aliases.cs
@@ -28,7 +28,6 @@ namespace BH.Engine.Adapters.Revit
         /****          Public Fields - General          ****/
         /***************************************************/
         
-        public const string AdapterIdName = "Revit_id";
         public const string ElementId = "Revit_elementId";
         public const string FamilyName = "Revit_familyName";
         public const string FamilyTypeName = "Revit_familyTypeName";


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #885 

<!-- Add short description of what has been fixed -->

Removing reference to AdapterNameId being removed in https://github.com/BHoM/BHoM_Adapter/pull/263

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->