### PR TITLE
Pull framing issues fixed

### DIFF
--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
@@ -112,7 +112,7 @@ namespace BH.Revit.Engine.Core
                 property = property.GetShallowClone() as ISectionProperty;
 
                 if (!materialFound)
-                    BH.Engine.Reflection.Compute.RecordWarning($"Section property of a bar has been loaded from the library, but the material could not be converted. Default material of the section property has been used. Revit ElementId: {familyInstance.Id.IntegerValue}");
+                    BH.Engine.Reflection.Compute.RecordNote($"A matching section was found in the library. No valid material was defined in Revit, so the default material for this section was used. Revit ElementId: {familyInstance.Id.IntegerValue}");
                 else
                     property.Material = materialFragment;
 

--- a/Revit_Core_Engine/Query/FramingElementProperty.cs
+++ b/Revit_Core_Engine/Query/FramingElementProperty.cs
@@ -59,7 +59,10 @@ namespace BH.Revit.Engine.Core
 
             // If Revit material is null, rename the BHoM material based on material type of framing family.
             if (material != null && revitMaterial == null)
+            {
                 material.Name = String.Format("Unknown {0} Material", familyInstance.StructuralMaterialType);
+                material.Properties.Add(familyInstance.StructuralMaterialType.EmptyMaterialFragment(materialGrade));
+            }
 
             IProfile profile = familyInstance.Symbol.ProfileFromRevit(settings, refObjects);
             if (profile == null)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #882
Closes #883

<!-- Add short description of what has been fixed -->

### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue882%2C883%2DPullFramingIssues&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- pull of material-specific sections without material assigned fixed to return material-specific BHoM `ISectionProperty`
- pull of bars fixed to keep the default material of `SectionProperty` loaded from library in case of failed material convert

### Additional comments
<!-- As required -->
This PR should not overlap with any of the currently open PRs.