### PR TITLE
PreviousInputNamesAttributes added to Sheet and ViewPlan

### DIFF
--- a/Revit_Engine/Create/Elements/Sheet.cs
+++ b/Revit_Engine/Create/Elements/Sheet.cs
@@ -32,6 +32,8 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [PreviousInputNames("sheetName", "name")]
+        [PreviousInputNames("sheetNumber", "number")]
         [Description("Creates BHoM Sheet object.")]
         [InputFromProperty("sheetName")]
         [InputFromProperty("sheetNumber")]

--- a/Revit_Engine/Create/Elements/ViewPlan.cs
+++ b/Revit_Engine/Create/Elements/ViewPlan.cs
@@ -32,6 +32,7 @@ namespace BH.Engine.Adapters.Revit
         /****              Public methods               ****/
         /***************************************************/
 
+        [PreviousInputNames("viewName", "name")]
         [Description("Creates BHoM ViewPlan object linked to a specific Revit level.")]
         [InputFromProperty("viewName")]
         [InputFromProperty("levelName")]
@@ -43,6 +44,8 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [PreviousInputNames("viewName", "name")]
+        [PreviousInputNames("templateName", "viewTemplateName")]
         [Description("Creates BHoM ViewPlan object linked to a specific level, based on specific Revit view template.")]
         [InputFromProperty("viewName")]
         [InputFromProperty("levelName")]


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #892

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Script using the methods created before input renaming are uploaded [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2Dissue892%2DAddPreviousInputNamesAttributes&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - if they open with all wires connected, the test is passed.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `PreviousInputNamesAttribute`s added to `Sheet` and `ViewPlan` to enable versioning of their input names