### PR TITLE
Update namespaces for MEP converts and align to oM changes

### DIFF
--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
@@ -54,8 +54,8 @@ namespace BH.Revit.Engine.Core
             // Start and end points
             LocationCurve locationCurve = revitDuct.Location as LocationCurve;
             Curve curve = locationCurve.Curve;
-            BH.oM.Geometry.Point startPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(0).X, Y = curve.GetEndPoint(0).Y, Z = curve.GetEndPoint(0).Z };
-            BH.oM.Geometry.Point endPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(1).X, Y = curve.GetEndPoint(1).Y, Z = curve.GetEndPoint(1).Z };
+            BH.oM.Geometry.Point startPoint = curve.GetEndPoint(0).PointFromRevit();
+            BH.oM.Geometry.Point endPoint = curve.GetEndPoint(1).PointFromRevit();
             BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startPoint, endPoint); // BHoM line
             double flowRate = revitDuct.LookupParameterDouble(BuiltInParameter.RBS_DUCT_FLOW_PARAM); // Flow rate
 

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
@@ -27,6 +27,7 @@ using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
+using BH.oM.Geometry;
 
 namespace BH.Revit.Engine.Core
 {
@@ -41,26 +42,24 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("duct", "BHoM duct object converted from a Revit duct element.")]
-        public static BH.oM.MEP.Elements.Duct DuctFromRevit(this Autodesk.Revit.DB.Mechanical.Duct revitDuct, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static BH.oM.MEP.System.Duct DuctFromRevit(this Autodesk.Revit.DB.Mechanical.Duct revitDuct, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
 
             // Reuse a BHoM duct from refObjects it it has been converted before
-            BH.oM.MEP.Elements.Duct bhomDuct = refObjects.GetValue<BH.oM.MEP.Elements.Duct>(revitDuct.Id);
+            BH.oM.MEP.System.Duct bhomDuct = refObjects.GetValue<BH.oM.MEP.System.Duct>(revitDuct.Id);
             if (bhomDuct != null)
                 return bhomDuct;
             
             // Start and end points
             LocationCurve locationCurve = revitDuct.Location as LocationCurve;
             Curve curve = locationCurve.Curve;
-            BH.oM.MEP.Elements.Node startNode = new BH.oM.MEP.Elements.Node { Position = curve.GetEndPoint(0).PointFromRevit() }; // Start point
-            BH.oM.MEP.Elements.Node endNode = new BH.oM.MEP.Elements.Node { Position = curve.GetEndPoint(1).PointFromRevit() }; // End point
-            
-            BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startNode.Position, endNode.Position); // BHoM line
-
+            BH.oM.Geometry.Point startPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(0).X, Y = curve.GetEndPoint(0).Y, Z = curve.GetEndPoint(0).Z };
+            BH.oM.Geometry.Point endPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(1).X, Y = curve.GetEndPoint(1).Y, Z = curve.GetEndPoint(1).Z };
+            BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startPoint, endPoint); // BHoM line
             double flowRate = revitDuct.LookupParameterDouble(BuiltInParameter.RBS_DUCT_FLOW_PARAM); // Flow rate
 
-            BH.oM.MEP.SectionProperties.DuctSectionProperty sectionProperty = BH.Revit.Engine.Core.Query.DuctSectionProperty(revitDuct, settings);
+            BH.oM.MEP.System.SectionProperties.DuctSectionProperty sectionProperty = BH.Revit.Engine.Core.Query.DuctSectionProperty(revitDuct, settings);
 
             // Orientation angle
             double orientationAngle = revitDuct.OrientationAngle(settings); //ToDo - resolve in next issue, specific issue being raised

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
@@ -41,25 +41,25 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("pipe", "BHoM pipe converted from a Revit pipe.")]
-        public static BH.oM.MEP.Elements.Pipe PipeFromRevit(this Autodesk.Revit.DB.Plumbing.Pipe revitPipe, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static BH.oM.MEP.System.Pipe PipeFromRevit(this Autodesk.Revit.DB.Plumbing.Pipe revitPipe, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
 
             // Reuse a BHoM duct from refObjects it it has been converted before
-            BH.oM.MEP.Elements.Pipe bhomPipe = refObjects.GetValue<BH.oM.MEP.Elements.Pipe>(revitPipe.Id);
+            BH.oM.MEP.System.Pipe bhomPipe = refObjects.GetValue<BH.oM.MEP.System.Pipe>(revitPipe.Id);
             if (bhomPipe != null)
                 return bhomPipe;
 
             // Start and end points
             LocationCurve locationCurve = revitPipe.Location as LocationCurve;
             Curve curve = locationCurve.Curve;
-            BH.oM.MEP.Elements.Node startNode = new BH.oM.MEP.Elements.Node { Position = curve.GetEndPoint(0).PointFromRevit() }; // Start point
-            BH.oM.MEP.Elements.Node endNode = new BH.oM.MEP.Elements.Node { Position = curve.GetEndPoint(1).PointFromRevit() }; // End point
-            BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startNode.Position, endNode.Position); // BHoM line
+            BH.oM.Geometry.Point startPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(0).X, Y = curve.GetEndPoint(0).Y, Z = curve.GetEndPoint(0).Z };
+            BH.oM.Geometry.Point endPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(1).X, Y = curve.GetEndPoint(1).Y, Z = curve.GetEndPoint(1).Z };
+            BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startPoint, endPoint); // BHoM line
             double flowRate = revitPipe.LookupParameterDouble(BuiltInParameter.RBS_PIPE_FLOW_PARAM); // Flow rate
 
             // Pipe section property
-            BH.oM.MEP.SectionProperties.PipeSectionProperty sectionProperty = revitPipe.PipeSectionProperty(settings);
+            BH.oM.MEP.System.SectionProperties.PipeSectionProperty sectionProperty = revitPipe.PipeSectionProperty(settings);
 
             // BHoM pipe
             bhomPipe = BH.Engine.MEP.Create.Pipe(line, flowRate, sectionProperty);

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
@@ -53,8 +53,8 @@ namespace BH.Revit.Engine.Core
             // Start and end points
             LocationCurve locationCurve = revitPipe.Location as LocationCurve;
             Curve curve = locationCurve.Curve;
-            BH.oM.Geometry.Point startPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(0).X, Y = curve.GetEndPoint(0).Y, Z = curve.GetEndPoint(0).Z };
-            BH.oM.Geometry.Point endPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(1).X, Y = curve.GetEndPoint(1).Y, Z = curve.GetEndPoint(1).Z };
+            BH.oM.Geometry.Point startPoint = curve.GetEndPoint(0).PointFromRevit();
+            BH.oM.Geometry.Point endPoint = curve.GetEndPoint(1).PointFromRevit();
             BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startPoint, endPoint); // BHoM line
             double flowRate = revitPipe.LookupParameterDouble(BuiltInParameter.RBS_PIPE_FLOW_PARAM); // Flow rate
 

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Wire.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Wire.cs
@@ -53,8 +53,8 @@ namespace BH.Revit.Engine.Core
             
             LocationCurve locationCurve = revitWire.Location as LocationCurve;
             Curve curve = locationCurve.Curve;
-            BH.oM.Geometry.Point startPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(0).X, Y = curve.GetEndPoint(0).Y, Z = curve.GetEndPoint(0).Z };
-            BH.oM.Geometry.Point endPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(1).X, Y = curve.GetEndPoint(1).Y, Z = curve.GetEndPoint(1).Z };
+            BH.oM.Geometry.Point startPoint = curve.GetEndPoint(0).PointFromRevit();
+            BH.oM.Geometry.Point endPoint = curve.GetEndPoint(1).PointFromRevit();
             BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startPoint, endPoint); // BHoM line
 
             // Wire

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Wire.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Wire.cs
@@ -24,7 +24,7 @@ using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
-using BH.oM.MEP.Elements;
+using BH.oM.MEP.System;
 using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -42,23 +42,23 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("wire", "BHoM wire converted from a Revit wire.")]
-        public static BH.oM.MEP.Elements.Wire WireFromRevit(this Autodesk.Revit.DB.Electrical.Wire revitWire, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static BH.oM.MEP.System.Wire WireFromRevit(this Autodesk.Revit.DB.Electrical.Wire revitWire, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
 
             // Reuse a BHoM duct from refObjects it it has been converted before
-            BH.oM.MEP.Elements.Wire bhomWire = refObjects.GetValue<BH.oM.MEP.Elements.Wire>(revitWire.Id);
+            BH.oM.MEP.System.Wire bhomWire = refObjects.GetValue<BH.oM.MEP.System.Wire>(revitWire.Id);
             if (bhomWire != null)
                 return bhomWire;
             
             LocationCurve locationCurve = revitWire.Location as LocationCurve;
             Curve curve = locationCurve.Curve;
-            BH.oM.MEP.Elements.Node startNode = new BH.oM.MEP.Elements.Node { Position = curve.GetEndPoint(0).PointFromRevit() }; // Start point
-            BH.oM.MEP.Elements.Node endNode = new BH.oM.MEP.Elements.Node { Position = curve.GetEndPoint(1).PointFromRevit() }; // End point
-            BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startNode.Position, endNode.Position); // BHoM line
+            BH.oM.Geometry.Point startPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(0).X, Y = curve.GetEndPoint(0).Y, Z = curve.GetEndPoint(0).Z };
+            BH.oM.Geometry.Point endPoint = new BH.oM.Geometry.Point { X = curve.GetEndPoint(1).X, Y = curve.GetEndPoint(1).Y, Z = curve.GetEndPoint(1).Z };
+            BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startPoint, endPoint); // BHoM line
 
             // Wire
-            bhomWire = new BH.oM.MEP.Elements.Wire();
+            bhomWire = new BH.oM.MEP.System.Wire();
 
             // Wire segment
             WireSegment wireSegment = BH.Engine.MEP.Create.Wire(line);

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Wire.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Wire.cs
@@ -61,7 +61,7 @@ namespace BH.Revit.Engine.Core
             bhomWire = new BH.oM.MEP.System.Wire();
 
             // Wire segment
-            WireSegment wireSegment = BH.Engine.MEP.Create.Wire(line);
+            WireSegment wireSegment = BH.Engine.MEP.Create.WireSegment(line);
 
             bhomWire.WireSegments.Add(wireSegment);
 

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Wire.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Wire.cs
@@ -37,17 +37,17 @@ namespace BH.Revit.Engine.Core
         /****               Public Methods              ****/
         /***************************************************/
 
-        [Description("Convert a Revit wire into a BHoM wire.")]
+        [Description("Convert a Revit wire into a BHoM wire segment.")]
         [Input("revitWire", "Revit wire to be converted.")]
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        [Output("wire", "BHoM wire converted from a Revit wire.")]
-        public static BH.oM.MEP.System.Wire WireFromRevit(this Autodesk.Revit.DB.Electrical.Wire revitWire, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        [Output("wireSegment", "BHoM wire segment converted from a Revit wire.")]
+        public static BH.oM.MEP.System.WireSegment WireFromRevit(this Autodesk.Revit.DB.Electrical.Wire revitWire, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
 
             // Reuse a BHoM duct from refObjects it it has been converted before
-            BH.oM.MEP.System.Wire bhomWire = refObjects.GetValue<BH.oM.MEP.System.Wire>(revitWire.Id);
+            BH.oM.MEP.System.WireSegment bhomWire = refObjects.GetValue<BH.oM.MEP.System.WireSegment>(revitWire.Id);
             if (bhomWire != null)
                 return bhomWire;
             
@@ -58,12 +58,7 @@ namespace BH.Revit.Engine.Core
             BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startPoint, endPoint); // BHoM line
 
             // Wire
-            bhomWire = new BH.oM.MEP.System.Wire();
-
-            // Wire segment
-            WireSegment wireSegment = BH.Engine.MEP.Create.WireSegment(line);
-
-            bhomWire.WireSegments.Add(wireSegment);
+            bhomWire = BH.Engine.MEP.Create.WireSegment(line);
 
             //Set identifiers, parameters & custom data
             bhomWire.SetIdentifiers(revitWire);

--- a/Revit_Core_Engine/Query/DuctSectionProfile.cs
+++ b/Revit_Core_Engine/Query/DuctSectionProfile.cs
@@ -41,7 +41,7 @@ namespace BH.Revit.Engine.Core
         [Input("revitDuct", "Revit duct to be queried for information needed for a BHoM section profile.")]
         [Input("settings", "Revit adapter settings.")]
         [Output("profile", "BHoM section profile for a duct extracted from a Revit duct.")]
-        public static BH.oM.MEP.SectionProperties.SectionProfile DuctSectionProfile(this Autodesk.Revit.DB.Mechanical.Duct revitDuct, RevitSettings settings = null)
+        public static BH.oM.MEP.System.SectionProperties.SectionProfile DuctSectionProfile(this Autodesk.Revit.DB.Mechanical.Duct revitDuct, RevitSettings settings = null)
         {
             settings = settings.DefaultIfNull();
 

--- a/Revit_Core_Engine/Query/DuctSectionProperty.cs
+++ b/Revit_Core_Engine/Query/DuctSectionProperty.cs
@@ -23,7 +23,7 @@
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
-using BH.oM.MEP.SectionProperties;
+using BH.oM.MEP.System.SectionProperties;
 using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -41,7 +41,7 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("sectionProperty", "BHoM duct section property extracted from a Revit duct.")]
-        public static BH.oM.MEP.SectionProperties.DuctSectionProperty DuctSectionProperty(this Autodesk.Revit.DB.Mechanical.Duct revitDuct, RevitSettings settings = null)
+        public static BH.oM.MEP.System.SectionProperties.DuctSectionProperty DuctSectionProperty(this Autodesk.Revit.DB.Mechanical.Duct revitDuct, RevitSettings settings = null)
         {
             settings = settings.DefaultIfNull();
 

--- a/Revit_Core_Engine/Query/PipeSectionProperty.cs
+++ b/Revit_Core_Engine/Query/PipeSectionProperty.cs
@@ -25,7 +25,7 @@ using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Spatial.ShapeProfiles;
-using BH.oM.MEP.SectionProperties;
+using BH.oM.MEP.System.SectionProperties;
 using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -42,7 +42,7 @@ namespace BH.Revit.Engine.Core
         [Input("pipe", "Revit pipe to be queried for information required for a BHoM section property.")]
         [Input("settings", "Revit adapter settings.")]
         [Output("sectionProperty", "BHoM pipe section property extracted from a Revit pipe.")]
-        public static BH.oM.MEP.SectionProperties.PipeSectionProperty PipeSectionProperty(this Autodesk.Revit.DB.Plumbing.Pipe pipe, RevitSettings settings = null)
+        public static BH.oM.MEP.System.SectionProperties.PipeSectionProperty PipeSectionProperty(this Autodesk.Revit.DB.Plumbing.Pipe pipe, RevitSettings settings = null)
         {
             settings = settings.DefaultIfNull();
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1069
https://github.com/BHoM/BHoM_Engine/pull/2133
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #897 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Revit_Toolkit/Revit_Toolkit-Issue897-MEP%20Converts%20Update%20Namespaces?csf=1&web=1&e=HrqIEn)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Removing MEP.Node dependency within the convert code as this object class has been removed. Current solution requires `BH.oM.Geometry.Point`
- Sync all namespace changes
- Fix Wire convert

### Additional comments
<!-- As required -->