### PR TITLE
Calls to GetShallowClone replaced with ShallowClone and Clone to DeepClone

### DIFF
--- a/Revit_Core_Engine/Convert/Geometry/ToRevit/CurveList.cs
+++ b/Revit_Core_Engine/Convert/Geometry/ToRevit/CurveList.cs
@@ -21,10 +21,11 @@
  */
 
 using Autodesk.Revit.DB;
+using BH.Engine.Base;
 using BH.Engine.Geometry;
-using System.Linq;
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace BH.Revit.Engine.Core
 {
@@ -99,8 +100,8 @@ namespace BH.Revit.Engine.Core
             {
                 double param1 = nc.GetEndParameter(0);
                 double param2 = nc.GetEndParameter(1);
-                Curve c1 = nc.Clone();
-                Curve c2 = nc.Clone();
+                Curve c1 = nc.DeepClone();
+                Curve c2 = nc.DeepClone();
                 c1.MakeBound(param1, (param1 + param2) * 0.5);
                 c2.MakeBound((param1 + param2) * 0.5, param2);
                 return new List<Curve> { c1, c2 };

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
@@ -23,6 +23,7 @@
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
 using BH.Engine.Adapters.Revit;
+using BH.Engine.Base;
 using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
@@ -109,7 +110,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                property = property.GetShallowClone() as ISectionProperty;
+                property = property.ShallowClone() as ISectionProperty;
 
                 if (!materialFound)
                     BH.Engine.Reflection.Compute.RecordNote($"A matching section was found in the library. No valid material was defined in Revit, so the default material for this section was used. Revit ElementId: {familyInstance.Id.IntegerValue}");

--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
@@ -110,7 +110,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                property = property.ShallowClone() as ISectionProperty;
+                property = property.ShallowClone();
 
                 if (!materialFound)
                     BH.Engine.Reflection.Compute.RecordNote($"A matching section was found in the library. No valid material was defined in Revit, so the default material for this section was used. Revit ElementId: {familyInstance.Id.IntegerValue}");

--- a/Revit_Engine/Modify/AddParameterLinks.cs
+++ b/Revit_Engine/Modify/AddParameterLinks.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Adapters.Revit.Parameters;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Reflection.Attributes;
@@ -55,7 +56,7 @@ namespace BH.Engine.Adapters.Revit
             if (propertyInfos == null)
                 return parameterMap;
 
-            ParameterMap clonedMap = parameterMap.GetShallowClone() as ParameterMap;
+            ParameterMap clonedMap = parameterMap.ShallowClone() as ParameterMap;
             if (clonedMap.ParameterLinks == null)
                 clonedMap.ParameterLinks = new List<IParameterLink>();
             else
@@ -72,7 +73,7 @@ namespace BH.Engine.Adapters.Revit
                     clonedMap.ParameterLinks.Remove(existingLink);
                     if (merge)
                     {
-                        IParameterLink newLink = existingLink.GetShallowClone() as IParameterLink;
+                        IParameterLink newLink = existingLink.ShallowClone() as IParameterLink;
                         newLink.ParameterNames = new HashSet<string>(existingLink.ParameterNames);
                         newLink.ParameterNames.UnionWith(parameterLink.ParameterNames);
                         clonedMap.ParameterLinks.Add(newLink);
@@ -101,7 +102,7 @@ namespace BH.Engine.Adapters.Revit
             if (type == null || parameterLinks == null || parameterLinks.Count() == 0)
                 return parameterSettings;
 
-            ParameterSettings cloneSettings = parameterSettings.GetShallowClone() as ParameterSettings;
+            ParameterSettings cloneSettings = parameterSettings.ShallowClone() as ParameterSettings;
             cloneSettings.ParameterMaps = new List<ParameterMap>(parameterSettings.ParameterMaps);
 
             ParameterMap parameterMap = cloneSettings.ParameterMap(type);

--- a/Revit_Engine/Modify/AddParameterLinks.cs
+++ b/Revit_Engine/Modify/AddParameterLinks.cs
@@ -56,7 +56,7 @@ namespace BH.Engine.Adapters.Revit
             if (propertyInfos == null)
                 return parameterMap;
 
-            ParameterMap clonedMap = parameterMap.ShallowClone() as ParameterMap;
+            ParameterMap clonedMap = parameterMap.ShallowClone();
             if (clonedMap.ParameterLinks == null)
                 clonedMap.ParameterLinks = new List<IParameterLink>();
             else
@@ -73,7 +73,7 @@ namespace BH.Engine.Adapters.Revit
                     clonedMap.ParameterLinks.Remove(existingLink);
                     if (merge)
                     {
-                        IParameterLink newLink = existingLink.ShallowClone() as IParameterLink;
+                        IParameterLink newLink = existingLink.ShallowClone();
                         newLink.ParameterNames = new HashSet<string>(existingLink.ParameterNames);
                         newLink.ParameterNames.UnionWith(parameterLink.ParameterNames);
                         clonedMap.ParameterLinks.Add(newLink);
@@ -102,7 +102,7 @@ namespace BH.Engine.Adapters.Revit
             if (type == null || parameterLinks == null || parameterLinks.Count() == 0)
                 return parameterSettings;
 
-            ParameterSettings cloneSettings = parameterSettings.ShallowClone() as ParameterSettings;
+            ParameterSettings cloneSettings = parameterSettings.ShallowClone();
             cloneSettings.ParameterMaps = new List<ParameterMap>(parameterSettings.ParameterMaps);
 
             ParameterMap parameterMap = cloneSettings.ParameterMap(type);

--- a/Revit_Engine/Modify/AddParameterMaps.cs
+++ b/Revit_Engine/Modify/AddParameterMaps.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Adapters.Revit
             if (parameterMaps == null || parameterMaps.Count() == 0)
                 return parameterSettings;
 
-            ParameterSettings cloneSettings = parameterSettings.ShallowClone() as ParameterSettings;
+            ParameterSettings cloneSettings = parameterSettings.ShallowClone();
             if (cloneSettings.ParameterMaps == null)
                 cloneSettings.ParameterMaps = new List<ParameterMap>();
             else

--- a/Revit_Engine/Modify/AddParameterMaps.cs
+++ b/Revit_Engine/Modify/AddParameterMaps.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Adapters.Revit.Parameters;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Reflection.Attributes;
@@ -48,7 +49,7 @@ namespace BH.Engine.Adapters.Revit
             if (parameterMaps == null || parameterMaps.Count() == 0)
                 return parameterSettings;
 
-            ParameterSettings cloneSettings = parameterSettings.GetShallowClone() as ParameterSettings;
+            ParameterSettings cloneSettings = parameterSettings.ShallowClone() as ParameterSettings;
             if (cloneSettings.ParameterMaps == null)
                 cloneSettings.ParameterMaps = new List<ParameterMap>();
             else

--- a/Revit_Engine/Modify/Append.cs
+++ b/Revit_Engine/Modify/Append.cs
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
+using BH.Engine.Base;
 using BH.oM.Adapters.Revit.Generic;
 using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
@@ -46,7 +47,7 @@ namespace BH.Engine.Adapters.Revit
             if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
                 return familyLibrary;
 
-            FamilyLibrary famLibrary = familyLibrary.GetShallowClone() as FamilyLibrary;
+            FamilyLibrary famLibrary = familyLibrary.ShallowClone() as FamilyLibrary;
 
             DirectoryInfo directoryInfo = new DirectoryInfo(directory);
 
@@ -75,7 +76,7 @@ namespace BH.Engine.Adapters.Revit
             if (string.IsNullOrEmpty(path) || !File.Exists(path))
                 return familyLibrary;
 
-            FamilyLibrary famLibrary = familyLibrary.GetShallowClone() as FamilyLibrary;
+            FamilyLibrary famLibrary = familyLibrary.ShallowClone() as FamilyLibrary;
 
             if (famLibrary.Dictionary == null)
                 famLibrary.Dictionary = new Dictionary<string, Dictionary<string, Dictionary<string, string>>>();

--- a/Revit_Engine/Modify/Append.cs
+++ b/Revit_Engine/Modify/Append.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Adapters.Revit
             if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
                 return familyLibrary;
 
-            FamilyLibrary famLibrary = familyLibrary.ShallowClone() as FamilyLibrary;
+            FamilyLibrary famLibrary = familyLibrary.ShallowClone();
 
             DirectoryInfo directoryInfo = new DirectoryInfo(directory);
 
@@ -76,7 +76,7 @@ namespace BH.Engine.Adapters.Revit
             if (string.IsNullOrEmpty(path) || !File.Exists(path))
                 return familyLibrary;
 
-            FamilyLibrary famLibrary = familyLibrary.ShallowClone() as FamilyLibrary;
+            FamilyLibrary famLibrary = familyLibrary.ShallowClone();
 
             if (famLibrary.Dictionary == null)
                 famLibrary.Dictionary = new Dictionary<string, Dictionary<string, Dictionary<string, string>>>();

--- a/Revit_Engine/Modify/Move.cs
+++ b/Revit_Engine/Modify/Move.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
@@ -42,7 +43,7 @@ namespace BH.Engine.Adapters.Revit
             if (modelInstance == null)
                 return null;
 
-            ModelInstance modInstance = modelInstance.GetShallowClone() as ModelInstance;
+            ModelInstance modInstance = modelInstance.ShallowClone() as ModelInstance;
 
             modInstance.Location = Geometry.Modify.Translate(modInstance.Location as dynamic, vector);
             

--- a/Revit_Engine/Modify/Move.cs
+++ b/Revit_Engine/Modify/Move.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Adapters.Revit
             if (modelInstance == null)
                 return null;
 
-            ModelInstance modInstance = modelInstance.ShallowClone() as ModelInstance;
+            ModelInstance modInstance = modelInstance.ShallowClone();
 
             modInstance.Location = Geometry.Modify.Translate(modInstance.Location as dynamic, vector);
             

--- a/Revit_Engine/Modify/RemoveIdentifiers.cs
+++ b/Revit_Engine/Modify/RemoveIdentifiers.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Adapters.Revit.Parameters;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
@@ -47,7 +48,7 @@ namespace BH.Engine.Adapters.Revit
 
             if (bHoMObject.Fragments.Any(x => x is RevitIdentifiers))
             {
-                IBHoMObject obj = bHoMObject.GetShallowClone();
+                IBHoMObject obj = bHoMObject.ShallowClone();
                 obj.Fragments = new FragmentSet(bHoMObject.Fragments.Where(x => !(x is RevitIdentifiers)).ToList());
                 return obj;
             }

--- a/Revit_Engine/Modify/RemoveParameterLinks.cs
+++ b/Revit_Engine/Modify/RemoveParameterLinks.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Adapters.Revit.Parameters;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Reflection.Attributes;
@@ -27,7 +28,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
 
 
 namespace BH.Engine.Adapters.Revit
@@ -50,7 +50,7 @@ namespace BH.Engine.Adapters.Revit
             if (parameterMap.Type == null || parameterMap.ParameterLinks == null || propertyNames == null || propertyNames.Count() == 0)
                 return parameterMap;
 
-            ParameterMap clonedMap = parameterMap.GetShallowClone() as ParameterMap;
+            ParameterMap clonedMap = parameterMap.ShallowClone() as ParameterMap;
             clonedMap.ParameterLinks = parameterMap.ParameterLinks.Where(x => propertyNames.All(y => x.PropertyName != y)).ToList();
             return clonedMap;
         }
@@ -74,7 +74,7 @@ namespace BH.Engine.Adapters.Revit
             if (parameterMap == null)
                 return parameterSettings;
 
-            ParameterSettings cloneSettings = parameterSettings.GetShallowClone() as ParameterSettings;
+            ParameterSettings cloneSettings = parameterSettings.ShallowClone() as ParameterSettings;
             cloneSettings.ParameterMaps = new List<ParameterMap>(parameterSettings.ParameterMaps);
             cloneSettings.ParameterMaps.Remove(parameterMap);
             cloneSettings.ParameterMaps.Add(parameterMap.RemoveParameterLinks(propertyNames));

--- a/Revit_Engine/Modify/RemoveParameterLinks.cs
+++ b/Revit_Engine/Modify/RemoveParameterLinks.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.Adapters.Revit
             if (parameterMap.Type == null || parameterMap.ParameterLinks == null || propertyNames == null || propertyNames.Count() == 0)
                 return parameterMap;
 
-            ParameterMap clonedMap = parameterMap.ShallowClone() as ParameterMap;
+            ParameterMap clonedMap = parameterMap.ShallowClone();
             clonedMap.ParameterLinks = parameterMap.ParameterLinks.Where(x => propertyNames.All(y => x.PropertyName != y)).ToList();
             return clonedMap;
         }
@@ -74,7 +74,7 @@ namespace BH.Engine.Adapters.Revit
             if (parameterMap == null)
                 return parameterSettings;
 
-            ParameterSettings cloneSettings = parameterSettings.ShallowClone() as ParameterSettings;
+            ParameterSettings cloneSettings = parameterSettings.ShallowClone();
             cloneSettings.ParameterMaps = new List<ParameterMap>(parameterSettings.ParameterMaps);
             cloneSettings.ParameterMaps.Remove(parameterMap);
             cloneSettings.ParameterMaps.Add(parameterMap.RemoveParameterLinks(propertyNames));

--- a/Revit_Engine/Modify/RemoveParameterMaps.cs
+++ b/Revit_Engine/Modify/RemoveParameterMaps.cs
@@ -48,7 +48,7 @@ namespace BH.Engine.Adapters.Revit
             if (parameterSettings.ParameterMaps == null)
                 return parameterSettings;
 
-            ParameterSettings cloneSettings = parameterSettings.ShallowClone() as ParameterSettings;
+            ParameterSettings cloneSettings = parameterSettings.ShallowClone();
             cloneSettings.ParameterMaps = parameterSettings.ParameterMaps.Where(x => types.All(y=> x.Type != y)).ToList();
             return cloneSettings;
         }

--- a/Revit_Engine/Modify/RemoveParameterMaps.cs
+++ b/Revit_Engine/Modify/RemoveParameterMaps.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -47,7 +48,7 @@ namespace BH.Engine.Adapters.Revit
             if (parameterSettings.ParameterMaps == null)
                 return parameterSettings;
 
-            ParameterSettings cloneSettings = parameterSettings.GetShallowClone() as ParameterSettings;
+            ParameterSettings cloneSettings = parameterSettings.ShallowClone() as ParameterSettings;
             cloneSettings.ParameterMaps = parameterSettings.ParameterMaps.Where(x => types.All(y=> x.Type != y)).ToList();
             return cloneSettings;
         }

--- a/Revit_Engine/Modify/SetRevitParameter.cs
+++ b/Revit_Engine/Modify/SetRevitParameter.cs
@@ -20,8 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Base;
+using BH.Engine.Base;
 using BH.oM.Adapters.Revit.Parameters;
+using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -59,7 +60,7 @@ namespace BH.Engine.Adapters.Revit
             
             RevitParametersToPush fragment = new RevitParametersToPush { Parameters = parameters };
 
-            IBHoMObject obj = bHoMObject.GetShallowClone();
+            IBHoMObject obj = bHoMObject.ShallowClone();
             obj.Fragments = new FragmentSet(bHoMObject.Fragments.Where(x => !(x is RevitParametersToPush)).ToList());
             obj.Fragments.Add(fragment);
             return obj;
@@ -97,7 +98,7 @@ namespace BH.Engine.Adapters.Revit
 
             RevitParametersToPush fragment = new RevitParametersToPush { Parameters = parameters };
 
-            IBHoMObject obj = bHoMObject.GetShallowClone();
+            IBHoMObject obj = bHoMObject.ShallowClone();
             obj.Fragments = new FragmentSet(bHoMObject.Fragments.Where(x => !(x is RevitParametersToPush)).ToList());
             obj.Fragments.Add(fragment);
             return obj;

--- a/Revit_Engine/Modify/SetTag.cs
+++ b/Revit_Engine/Modify/SetTag.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
@@ -42,7 +43,7 @@ namespace BH.Engine.Adapters.Revit
             if (bHoMObject == null)
                 return null;
 
-            IBHoMObject obj = bHoMObject.GetShallowClone();
+            IBHoMObject obj = bHoMObject.ShallowClone();
 
             if (obj.Tags == null)
                 obj.Tags = new HashSet<string>();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #899

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
A few tests proving that the replaced and replacing methods work similarly is uploaded [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue899%2DReplaceGetShallowClone&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).

For the more concerned, macro tests are available [here](https://burohappold.sharepoint.com/sites/BHoM/Installers/Forms/AllItems.aspx?RootFolder=%2fsites%2fBHoM%2fInstallers%2fScripts%2fBuroHappold%5fBHoM%5fv3%2e3%2f0001%5fRevit%5fToolkit&FolderCTID=0x012000181C071E8B6D1E438B59C87DA36B9302).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- calls to `GetShallowClone` replaced with `ShallowClone`
- calls to `Clone` replaced with `DeepClone`


### Additional comments
<!-- As required -->