### PR TITLE
Added convert FromRevit for CableTray object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ bld/
 *.suo
 *.user
 .vs/
+.idea/

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -199,39 +199,62 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Convert a Revit cable tray into a BHoM cable tray.")]
+        [Input("cableTray", "Revit cable tray to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("settings", "Revit adapter settings.")]
+        [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("cableTrays", "Resulted list of BHoM cable trays converted from a Revit cable trays.")]
+        public static List<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Electrical.CableTray cableTray, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            switch (discipline)
+            {
+                case Discipline.Architecture:
+                case Discipline.Physical:
+                case Discipline.Environmental: 
+                    return new List<IBHoMObject>(cableTray.CableTrayFromRevit(settings, refObjects));
+                default:
+                    return null;
+            }
+        }
+        
+        /***************************************************/
+
         [Description("Convert a Revit duct into a BHoM duct.")]
         [Input("duct", "Revit duct to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        [Output("duct", "BHoM duct converted from a Revit duct.")]
-        public static IBHoMObject FromRevit(this Autodesk.Revit.DB.Mechanical.Duct duct, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        [Output("ducts", "Resulted list of BHoM ducts converted from a Revit ducts.")]
+        public static List<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Mechanical.Duct duct, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
                 case Discipline.Architecture:
                 case Discipline.Physical:
                 case Discipline.Environmental:
-                    return duct.DuctFromRevit(settings, refObjects);
+                    return new List<IBHoMObject>(duct.DuctFromRevit(settings, refObjects));
                 default:
                     return null;
             }
         }
 
+        /***************************************************/
+        
         [Description("Convert a Revit pipe into a BHoM pipe.")]
         [Input("pipe", "Revit pipe to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        [Output("pipe", "BHoM pipe converted from a Revit pipe.")]
-        public static IBHoMObject FromRevit(this Autodesk.Revit.DB.Plumbing.Pipe pipe, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        [Output("pipes", "Resulted list of BHoM MEP pipes converted from a Revit pipes.")]
+        public static List<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Plumbing.Pipe pipe, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
                 case Discipline.Architecture:
                 case Discipline.Physical:
                 case Discipline.Environmental:
-                    return pipe.PipeFromRevit(settings, refObjects);
+                    return new List<IBHoMObject>(pipe.PipeFromRevit(settings, refObjects));pipe.PipeFromRevit(settings, refObjects);
                 default:
                     return null;
             }

--- a/Revit_Core_Engine/Query/CableTraySectionProfile.cs
+++ b/Revit_Core_Engine/Query/CableTraySectionProfile.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Spatial.ShapeProfiles;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+        
+        [Description("Query a Revit cable tray to extract a BHoM cable tray section profile.")]
+        [Input("revitCableTray", "Revit cable tray to be queried for information needed for a BHoM section profile.")]
+        [Input("settings", "Revit adapter settings.")]
+        [Output("profile", "BHoM section profile for a cable tray extracted from a Revit cable tray.")]
+        public static BH.oM.MEP.System.SectionProperties.SectionProfile CableTraySectionProfile(this Autodesk.Revit.DB.Electrical.CableTray revitCableTray, RevitSettings settings = null)
+        {
+            settings = settings.DefaultIfNull();
+
+            IProfile profile = revitCableTray.Profile(settings);
+            
+            // Create a section profile
+            if (profile != null)
+            {
+                return BH.Engine.MEP.Create.SectionProfile(profile as dynamic, 0, 0);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Query/CableTraySectionProperty.cs
+++ b/Revit_Core_Engine/Query/CableTraySectionProperty.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.MEP.System.SectionProperties;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.MEP.System.MaterialFragments;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        [Description("Query a Revit cable tray to extract a BHoM cable tray section property.")]
+        [Input("revitCableTray", "Revit cable tray to be queried for information required for a BHoM section property.")]
+        [Input("settings", "Revit adapter settings.")]
+        [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("sectionProperty", "BHoM cable tray section property extracted from a Revit cable tray.")]
+        public static BH.oM.MEP.System.SectionProperties.CableTraySectionProperty CableTraySectionProperty(this Autodesk.Revit.DB.Electrical.CableTray revitCableTray, RevitSettings settings = null)
+        {
+            settings = settings.DefaultIfNull();
+
+            // Cable Tray section profile
+            SectionProfile sectionProfile = revitCableTray.CableTraySectionProfile(settings);
+
+            // Cable Tray section property
+            return BH.Engine.MEP.Create.CableTraySectionProperty(new CableTrayMaterial(), sectionProfile);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Query/LocationCurve.cs
+++ b/Revit_Core_Engine/Query/LocationCurve.cs
@@ -28,6 +28,7 @@ using BH.oM.Geometry;
 using BH.oM.Physical.Elements;
 using BH.oM.Reflection;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BH.Revit.Engine.Core
@@ -139,6 +140,205 @@ namespace BH.Revit.Engine.Core
             return curve;
         }
 
+        /***************************************************/
+        
+        public static List<BH.oM.Geometry.Line> LocationCurveMEP(this MEPCurve mepCurve, RevitSettings settings = null)
+        {            
+            settings = settings.DefaultIfNull();
+            
+            // Determine start and end points, which if the MEP linear object is connected to
+            // a fitting then uses the fitting origin as either start/end
+            List<BH.oM.Geometry.Point> allPoints = new List<BH.oM.Geometry.Point>();
+            
+            var tolerance = BH.oM.Adapters.Revit.Tolerance.Vertex.FromSI(UnitType.UT_Length);
+            
+            //add placeholder for extra lines required to snap multi-connected fittings
+            BH.oM.Geometry.Line extraLine1 = null;
+            BH.oM.Geometry.Line extraLine2 = null;
+
+            //save points to recreate line later
+            List<BH.oM.Geometry.Point> endPoints = new List<BH.oM.Geometry.Point>();
+            List<BH.oM.Geometry.Point> midPoints = new List<BH.oM.Geometry.Point>();
+
+            // Get connectors
+            ConnectorManager connectorManager = mepCurve.ConnectorManager;
+            ConnectorSet connectorSet = connectorManager.Connectors;
+            List<Connector> c1Connectors = connectorSet.Cast<Connector>().ToList();
+            
+            // the following logic is applied below
+            // we must get both END connectors of mepcurve SELF 
+            // for each END connector c1 check if it's connected
+            // if connected check its references (every object that refers to it)
+            // and grab c2 that is not from SELF (meaning the fitting connected to it)
+            // grab c2 object owner, if it's a fitting then get all connectors
+            // grab c3 from fitting 1 that is not c2 (retrieves the other end of fitting 1)
+            // if c3 is connected then get its references
+            // and grab c4 that is not c3
+            // grab c4 object owner, if it's a fitting then get all connectors
+            // grab c5 from fitting 2 that is not c4 (retrieves the other end of fitting 1)
+            
+            // depending on the conditions above it'll try to recreate the linear object
+            // either by a simple straight line from connector to connector
+            //     - MEP curve without fittings
+            //     - or MEP curve that connects with/without fitting
+            // or adds extra lines if MEP curve is connected by a chain (up to 2 devices) of fittings
+            //     - if this is the case then it performs the aforementioned loop to find all possible connections
+            // also any connectors that are not END in the beginning must be accounted
+            //     - mid connectors means mep curves connected without fittings (in particular cable trays)
+            
+            for (int i = 0; i < c1Connectors.Count; i++)
+            {
+                BH.oM.Geometry.Point locationToSnap = null;
+                BH.oM.Geometry.Point locationFromSnap = null;
+                
+                Connector c1 = c1Connectors[i];
+                if (c1.ConnectorType == ConnectorType.End)
+                {
+                    locationFromSnap = BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4);
+                    if (c1.IsConnected)
+                    {
+                        List<Connector> c2Connectors = (c1.AllRefs).Cast<Connector>().ToList();
+                        for (int j = 0; j < c2Connectors.Count; j++)
+                        {
+                            Connector c2 = c2Connectors[j];
+                            if (c2.Owner.Id != c1.Owner.Id)
+                            {
+                                if (!(c2.Owner is MEPCurve))
+                                {
+                                    FamilyInstance familyInstance1 = c2.Owner as FamilyInstance;
+                                    ConnectorManager connectorManager1 = familyInstance1.MEPModel.ConnectorManager;
+                                    List<Connector> c3Connectors = (connectorManager1.Connectors).Cast<Connector>().ToList();
+                                    if (c3Connectors.Count == 2)
+                                    {
+                                        for (int k = 0; k < c3Connectors.Count; k++)
+                                        {
+                                            Connector c3 = c3Connectors[k];
+                                            if (c3.Origin.DistanceTo(c1.Origin) > tolerance)
+                                            {
+                                                if (c3.IsConnected)
+                                                {
+                                                    List<Connector> c4Connectors = (c3.AllRefs).Cast<Connector>().ToList();
+                                                    for (int l = 0; l < c4Connectors.Count; l++)
+                                                    {
+                                                        Connector c4 = c4Connectors[l];
+                                                        if (c4.Owner.Id != c2.Owner.Id && c4.Owner.Id != c1.Owner.Id)
+                                                        {
+                                                            if (!(c4.Owner is MEPCurve))
+                                                            {
+                                                                FamilyInstance familyInstance2 = c4.Owner as FamilyInstance;
+                                                                ConnectorManager connectorManager2 = familyInstance2.MEPModel.ConnectorManager;
+                                                                List<Connector> c5Connectors = (connectorManager2.Connectors).Cast<Connector>().ToList();
+                                                                if (c5Connectors.Count == 2)
+                                                                {
+                                                                    for (int m = 0; m < c5Connectors.Count; m++)
+                                                                    {
+                                                                        Connector c5 = c5Connectors[m];
+                                                                        if (c5.Origin.DistanceTo(c4.Origin) > tolerance)
+                                                                        {
+                                                                            locationToSnap = BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c5.Origin),4);
+                                                                            BH.oM.Geometry.Line longLine = BH.Engine.Geometry.Create.Line(locationToSnap, locationFromSnap);
+                                                                            locationToSnap = BH.Engine.Geometry.Modify.RoundCoordinates(longLine.PointAtParameter(0.5),4);
+                                                                            
+                                                                            endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
+                                                                            BH.oM.Geometry.Line shortLine = BH.Engine.Geometry.Create.Line(locationToSnap, locationFromSnap);
+                                                                            
+                                                                            if (c1.Id == 0)
+                                                                                extraLine1 = shortLine;
+                                                                            else 
+                                                                                extraLine2 = shortLine;
+                                                                            
+                                                                        }
+                                                                    }
+                                                                }
+                                                                else
+                                                                {
+                                                                    locationToSnap = BH.Engine.Geometry.Modify.RoundCoordinates(Convert.FromRevit((familyInstance2.Location) as LocationPoint),4);
+                                                                    BH.oM.Geometry.Line shortLine = BH.Engine.Geometry.Create.Line(locationToSnap, locationFromSnap);
+                                                                    endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
+                                                                    
+                                                                    if (c1.Id == 0)
+                                                                        extraLine1 = shortLine;
+                                                                    else 
+                                                                        extraLine2 = shortLine;
+                                                                    
+                                                                }
+                                                            }
+                                                            else
+                                                            {
+                                                                endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.FromRevit((c3.Owner.Location) as LocationPoint),4));
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                                else
+                                                {
+                                                    endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin), 4));
+                                                    locationToSnap = BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c3.Origin), 4);
+                                                    BH.oM.Geometry.Line shortLine = BH.Engine.Geometry.Create.Line(locationToSnap, locationFromSnap);
+
+                                                    if (c1.Id == 0)
+                                                    {
+                                                        extraLine1 = shortLine;
+                                                    }
+                                                    else
+                                                    {
+                                                        extraLine2 = shortLine;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    else
+                                    {
+                                        endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.FromRevit((familyInstance1.Location)as LocationPoint),4));
+                                    }
+                                }
+                                else
+                                {
+                                    endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
+                    }
+                }
+                else
+                {
+                    //if MEP linear object has connections that don't take fitting,
+                    //then we need to store the point to later split the curve
+                    midPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
+                }
+            }
+
+            //split MEP linear object if there was any other MEP linear object connected to it without fitting
+            BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(endPoints[1], endPoints[0]);
+            List<BH.oM.Geometry.Line> result = new List<BH.oM.Geometry.Line>();
+            
+            if (extraLine1 != null) 
+            {
+                result.Add(extraLine1);
+            }
+            
+            if (midPoints.Any())
+            {
+                result.AddRange(line.SplitAtPoints(midPoints));
+            }
+            else
+            {
+                result.Add(line);
+            }
+            
+            if (extraLine2 != null) 
+            {
+                result.Add(extraLine2);
+            }
+
+            return result;
+        }
+        
         /***************************************************/
     }
 }

--- a/Revit_Core_Engine/Query/OrientationAngle.cs
+++ b/Revit_Core_Engine/Query/OrientationAngle.cs
@@ -54,26 +54,26 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Query a Revit duct to extract its orientation angle.")]
-        [Input("duct", "Revit duct to be queried.")]
+        [Description("Query a Revit MEPCurve to extract its orientation angle.")]
+        [Input("mepCurve", "Revit MEPCurve (cable trays, ducts and pipes) to be queried.")]
         [Input("settings", "Revit adapter settings.")]
-        [Output("double", "Orientation angle of a duct in radians extracted from a Revit duct.")]
-        public static double OrientationAngle(this Duct duct, RevitSettings settings = null)
+        [Output("double", "Orientation angle of a MEPCurve in radians extracted from a Revit MEPCurve.")]
+        public static double OrientationAngle(this MEPCurve mepCurve, RevitSettings settings = null)
         {
             settings = settings.DefaultIfNull();
 
             double rotation;
 
-            Location location = duct.Location;
+            Location location = mepCurve.Location;
 
             LocationCurve locationCurve = location as LocationCurve;
             Curve curve = locationCurve.Curve;
 
             BH.oM.Geometry.ICurve bhomCurve = curve.IFromRevit(); // Convert to a BHoM curve
 
-            // Get the duct connector
+            // Get the connector
             Connector connector = null;
-            foreach (Connector conn in duct.ConnectorManager.Connectors)
+            foreach (Connector conn in mepCurve.ConnectorManager.Connectors)
             {
                 // Get the End connector for this duct
                 if (conn.ConnectorType == ConnectorType.End)
@@ -83,7 +83,7 @@ namespace BH.Revit.Engine.Core
                 }
             }
 
-            // Coordinate system of the duct connector
+            // Coordinate system of the connector
             Transform transform = connector.CoordinateSystem;
 
             // Get the rotation

--- a/Revit_Core_Engine/Query/Profile.cs
+++ b/Revit_Core_Engine/Query/Profile.cs
@@ -39,7 +39,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Extract a BHoM duct profile from a Revit duct.")]
-        [Input("duct", "Revit duct to extract relevant profie information from.")]
+        [Input("duct", "Revit duct to extract relevant profile information from.")]
         [Input("settings", "Revit adapter settings.")]
         [Output("profile", "BHoM duct profile extracted from a Revit duct.")]
         public static IProfile Profile(this Autodesk.Revit.DB.Mechanical.Duct duct, RevitSettings settings = null)
@@ -78,11 +78,29 @@ namespace BH.Revit.Engine.Core
                     return null;
             }
         }
+        
+        [Description("Extract a BHoM cable tray profile from a Revit cable tray.")]
+        [Input("cableTray", "Revit cable tray to extract relevant profile information from.")]
+        [Input("settings", "Revit adapter settings.")]
+        [Output("profile", "BHoM cable tray profile extracted from a Revit cable tray.")]
+        public static IProfile Profile(this Autodesk.Revit.DB.Electrical.CableTray cableTray, RevitSettings settings = null)
+        {
+            settings = settings.DefaultIfNull();
+
+            // Cable Trays are always rectangular
+            double boxHeight = cableTray.Height.ToSI(UnitType.UT_Electrical_CableTraySize);
+            double boxWidth = cableTray.Width.ToSI(UnitType.UT_Electrical_CableTraySize);
+            double boxThickness = 0.001519;
+            double outerRadius = 0;
+            double innerRadius = 0;
+
+            return BH.Engine.Spatial.Create.BoxProfile(boxHeight, boxWidth, boxThickness, outerRadius, innerRadius);
+        }
 
         /***************************************************/
 
         [Description("Extract a BHoM pipe profile from a Revit pipe.")]
-        [Input("pipe", "Revit pipe to extract relevant profie information from.")]
+        [Input("pipe", "Revit pipe to extract relevant profile information from.")]
         [Input("settings", "Revit adapter settings.")]
         [Output("profile", "BHoM pipe profile extracted from a Revit pipe.")]
         public static IProfile Profile(this Autodesk.Revit.DB.Plumbing.Pipe pipe, RevitSettings settings = null)
@@ -104,7 +122,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Extract a BHoM tube profile from a Revit wire. A tube profile is used in this case to facilitate the extraction of the wire diameter because a dedicated BHoM profile for a wire is not available.")]
-        [Input("wire", "Revit wire to extract relevant profie information from.")]
+        [Input("wire", "Revit wire to extract relevant profile information from.")]
         [Input("settings", "Revit adapter settings.")]
         [Output("profile", "BHoM tube profile extracted from a Revit wire.")]
         public static IProfile Profile(this Autodesk.Revit.DB.Electrical.Wire wire, RevitSettings settings = null)

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -295,6 +295,8 @@
     <Compile Include="Convert\Environment\FromRevit\CableTray.cs" />
     <Compile Include="Convert\Environment\FromRevit\Duct.cs" />
     <Compile Include="Convert\Environment\FromRevit\Pipe.cs" />
+    <Compile Include="Query\CableTraySectionProfile.cs" />
+    <Compile Include="Query\CableTraySectionProperty.cs" />
     <Compile Include="Query\DuctSectionProfile.cs" />
     <Compile Include="Query\DuctSectionProperty.cs" />
     <Compile Include="Query\DuctShape.cs" />

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -292,14 +292,15 @@
   <ItemGroup>
     <Compile Include="Compute\Errors.cs" />
     <Compile Include="Convert\Architecture\FromRevit\Room.cs" />
+    <Compile Include="Convert\Environment\FromRevit\CableTray.cs" />
+    <Compile Include="Convert\Environment\FromRevit\Duct.cs" />
+    <Compile Include="Convert\Environment\FromRevit\Pipe.cs" />
     <Compile Include="Query\DuctSectionProfile.cs" />
     <Compile Include="Query\DuctSectionProperty.cs" />
     <Compile Include="Query\DuctShape.cs" />
     <Compile Include="Query\PipeSectionProperty.cs" />
     <Compile Include="Query\Profile.cs" />
     <Compile Include="Convert\Environment\FromRevit\Wire.cs" />
-    <Compile Include="Convert\Environment\FromRevit\Pipe.cs" />
-    <Compile Include="Convert\Environment\FromRevit\Duct.cs" />
     <Compile Include="Convert\Environment\FromRevit\EnergyAnalysisModel.cs" />
     <Compile Include="Convert\Environment\ToRevit\Space.cs" />
     <Compile Include="Convert\Geometry\FromRevit\Mesh.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### This is a copy of #880, opened to avoid branch rebase and conflicts.

   
### Issues addressed by this PR
Closes #859

Ignores BHoM/MEP_oM#1034

Initial convert FromRevit created for `CableTray` objects, that bypasses fittings to query its connectors to allow its line creation without gaps at fittings. This behavior has been replicated for `Duct` and `Pipe`.
An important observation is that pulling these objects may not result into a single element anymore, but a list of elements(e.g. if a cable tray has cable trays connected to it without fittings, or when there is a chain of fittings connected)


### Test files
Test files [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Revit_Toolkit/Revit_Toolkit-Issue859-AddedConvertFromRevitForCableTrays?csf=1&web=1&e=Z4MkTp).


### Changelog
Added `Revit_Core_Engine.Convert.Environment.FromRevit.CableTray`
Added `Revit_Core_Engine.Query.CableTraySectionProfile`
Added `Revit_Core_Engine.Query.CableTraySectionProperty`
Modified `Revit_Core_Engine.Convert.Environment.FromRevit.Duct`
Modified `Revit_Core_Engine.Convert.Environment.FromRevit.Pipe`
Modified `Revit_Core_Engine.Convert.FromRevit`
Modified `Revit_Core_Engine.Query.OrientationAngle`
Modified `Revit_Core_Engine.Query.Profile`
Modified `Revit_Core_Engine.Query.LocationCurve`

### Additional comments
Due to recent changes in MEP namespaces `CableTray` will be pulled without a proper line geometry, but it's being pulled nevertheless. This will be addressed in the core BHoM repo at the object level.