### PR TITLE
Creation of FreeFormProfile changed from constructor to Create method

### DIFF
--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -684,7 +684,7 @@ namespace BH.Revit.Engine.Core
                 }
             }
 
-            return new FreeFormProfile(profileCurves);
+            return BHS.Create.FreeFormProfile(profileCurves);
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #903

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
_PullFramingProfiles.rvt_ and _PullFramingProfiles.gh_ from [here](https://burohappold.sharepoint.com/sites/BHoM/Installers/Forms/AllItems.aspx?RootFolder=%2fsites%2fBHoM%2fInstallers%2fScripts%2fBuroHappold%5fBHoM%5fv3%2e3%2f0001%5fRevit%5fToolkit%2fPull&FolderCTID=0x012000181C071E8B6D1E438B59C87DA36B9302) should work - try pulling one of the non-standard profiles, e.g. ASB.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- creation of FreeFormProfile changed from constructor to Create method


### Additional comments
<!-- As required -->