### PR TITLE
Pulling nested elements implemented

### DIFF
--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -92,6 +92,23 @@ namespace BH.Revit.Adapter.Core
             if (representationConfig == null)
                 representationConfig = new PullRepresentationConfig();
 
+            if (pullConfig.IncludeNestedElements)
+            {
+                List<ElementId> elemIds = new List<ElementId>();
+                foreach (ElementId id in elementIds)
+                {
+                    elemIds.Add(id);
+                    Element element = document.GetElement(id);
+                    if (element is FamilyInstance)
+                    {
+                        FamilyInstance famInst = element as FamilyInstance;
+                        IEnumerable<ElementId> nestedElemIds = famInst.ElementIdsOfMemberElements();
+                        elemIds.AddRange(nestedElemIds);
+                    }
+                }
+                elementIds = elemIds;
+            }
+
             Options geometryOptions = BH.Revit.Engine.Core.Create.Options(ViewDetailLevel.Fine, geometryConfig.IncludeNonVisible, false);
             Options meshOptions = BH.Revit.Engine.Core.Create.Options(geometryConfig.MeshDetailLevel.ViewDetailLevel(), geometryConfig.IncludeNonVisible, false);
             Options renderMeshOptions = BH.Revit.Engine.Core.Create.Options(representationConfig.DetailLevel.ViewDetailLevel(), representationConfig.IncludeNonVisible, false);

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -97,7 +97,6 @@ namespace BH.Revit.Adapter.Core
                 List<ElementId> elemIds = new List<ElementId>();
                 foreach (ElementId id in elementIds)
                 {
-                    elemIds.Add(id);
                     Element element = document.GetElement(id);
                     if (element is FamilyInstance)
                     {
@@ -106,7 +105,7 @@ namespace BH.Revit.Adapter.Core
                         elemIds.AddRange(nestedElemIds);
                     }
                 }
-                elementIds = elemIds;
+                elementIds.ToList<ElementId>().AddRange(elemIds);
             }
 
             Options geometryOptions = BH.Revit.Engine.Core.Create.Options(ViewDetailLevel.Fine, geometryConfig.IncludeNonVisible, false);

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -74,7 +74,7 @@ namespace BH.Revit.Adapter.Core
             if (!pullConfig.IncludeClosedWorksets)
                 worksetPrefilter = document.ElementIdsByWorksets(document.OpenWorksetIds().Union(document.SystemWorksetIds()).ToList());
 
-            IEnumerable<ElementId> elementIds = request.IElementIds(uiDocument, worksetPrefilter).RemoveGridSegmentIds(document);
+            List<ElementId> elementIds = request.IElementIds(uiDocument, worksetPrefilter).RemoveGridSegmentIds(document).ToList<ElementId>();
             if (elementIds == null)
                 return new List<IBHoMObject>();
 
@@ -105,7 +105,7 @@ namespace BH.Revit.Adapter.Core
                         elemIds.AddRange(nestedElemIds);
                     }
                 }
-                elementIds.ToList<ElementId>().AddRange(elemIds);
+                elementIds.AddRange(elemIds);
             }
 
             Options geometryOptions = BH.Revit.Engine.Core.Create.Options(ViewDetailLevel.Fine, geometryConfig.IncludeNonVisible, false);

--- a/Revit_Core_Adapter/Revit_Core_Adapter.csproj
+++ b/Revit_Core_Adapter/Revit_Core_Adapter.csproj
@@ -150,6 +150,10 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Graphics_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Physical_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="Reflection_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>

--- a/Revit_Core_Adapter/Revit_Core_Adapter.csproj
+++ b/Revit_Core_Adapter/Revit_Core_Adapter.csproj
@@ -1,299 +1,360 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTarget="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-<PropertyGroup>
-  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-  <ProjectGuid>{C2BD93AF-8853-4685-8BD4-223055DE1CC6}</ProjectGuid>
-  <OutputType>Library</OutputType>
-  <AppDesignerFolder>Properties</AppDesignerFolder>
-  <RootNamespace>BH.Revit.Adapter.Core</RootNamespace>
-  <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
-  <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-  <FileAlignment>512</FileAlignment>
-  <OutputPath>..\Build\</OutputPath>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-  <DebugSymbols>true</DebugSymbols>
-  <DebugType>full</DebugType>
-  <Optimize>false</Optimize>
-  <DefineConstants>DEBUG;TRACE;REVIT2018</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  <DebugType>pdbonly</DebugType>
-  <Optimize>true</Optimize>
-  <DefineConstants>TRACE;REVIT2018</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2018|AnyCPU'">
-  <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
-  <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-  <DebugSymbols>true</DebugSymbols>
-  <DebugType>full</DebugType>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE;DEBUG;REVIT2018</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|AnyCPU'">
-  <AssemblyName>Revit_Core_Adapter_2019</AssemblyName>
-  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  <DebugSymbols>true</DebugSymbols>
-  <DebugType>full</DebugType>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE;DEBUG;REVIT2019</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2018|AnyCPU'">
-  <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
-  <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-  <DebugType>pdbonly</DebugType>
-  <Optimize>true</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE;REVIT2018</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2019|AnyCPU'">
-  <AssemblyName>Revit_Core_Adapter_2019</AssemblyName>
-  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  <DebugType>pdbonly</DebugType>
-  <Optimize>true</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE;REVIT2019</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2020|AnyCPU'">
-  <AssemblyName>Revit_Core_Adapter_2020</AssemblyName>
-  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  <DebugSymbols>true</DebugSymbols>
-  <DebugType>full</DebugType>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE;DEBUG;REVIT2020</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2020|AnyCPU'">
-  <AssemblyName>Revit_Core_Adapter_2020</AssemblyName>
-  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  <DebugType>pdbonly</DebugType>
-  <Optimize>true</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE;REVIT2020</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
-  <AssemblyName>Revit_Core_Adapter_2021</AssemblyName>
-  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-  <DebugSymbols>true</DebugSymbols>
-  <DebugType>full</DebugType>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE;DEBUG;REVIT2021</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2021|AnyCPU'">
-  <AssemblyName>Revit_Core_Adapter_2021</AssemblyName>
-  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-  <DebugType>pdbonly</DebugType>
-  <Optimize>true</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE;REVIT2021</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018'">
-  <PostBuildEvent>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C2BD93AF-8853-4685-8BD4-223055DE1CC6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <OutputPath>..\Build\</OutputPath>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.Revit.Adapter.Core</RootNamespace>
+    <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE;REVIT2018</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE;REVIT2018</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2018|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;REVIT2018</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;REVIT2019</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AssemblyName>Revit_Core_Adapter_2019</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2018|AnyCPU'">
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;REVIT2018</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2019|AnyCPU'">
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;REVIT2019</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AssemblyName>Revit_Core_Adapter_2019</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2020|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;REVIT2020</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AssemblyName>Revit_Core_Adapter_2020</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2020|AnyCPU'">
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;REVIT2020</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AssemblyName>Revit_Core_Adapter_2020</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;REVIT2021</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <AssemblyName>Revit_Core_Adapter_2021</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2021|AnyCPU'">
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE;REVIT2021</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <AssemblyName>Revit_Core_Adapter_2021</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Adapter_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Adapter_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BHoM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BHoM_Adapter">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BHoM_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Data_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Geometry_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Graphics_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Graphics_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Physical_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
+	  <Private>False</Private>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="Reflection_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Reflection_oM">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPI" Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018' Or '$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
+      <HintPath>..\libs\2018\RevitAPI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIIFC" Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018' Or '$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
+      <HintPath>..\libs\2018\RevitAPIIFC.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIUI" Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018' Or '$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
+      <HintPath>..\libs\2018\RevitAPIUI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPI" Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
+      <HintPath>..\libs\2019\RevitAPI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIIFC" Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
+      <HintPath>..\libs\2019\RevitAPIIFC.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIUI" Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
+      <HintPath>..\libs\2019\RevitAPIUI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPI" Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
+      <HintPath>..\libs\2020\RevitAPI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIIFC" Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
+      <HintPath>..\libs\2020\RevitAPIIFC.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIUI" Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
+      <HintPath>..\libs\2020\RevitAPIUI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPI" Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
+      <HintPath>..\libs\2021\RevitAPI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIIFC" Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
+      <HintPath>..\libs\2021\RevitAPIIFC.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIUI" Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
+      <HintPath>..\libs\2021\RevitAPIUI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Socket_Adapter">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Socket_Adapter.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Socket_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Socket_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AdapterActions\Pull.cs" />
+    <Compile Include="AdapterActions\Remove.cs" />
+    <Compile Include="CRUD\Create.cs" />
+    <Compile Include="CRUD\Delete.cs" />
+    <Compile Include="AdapterActions\Push.cs" />
+    <Compile Include="CRUD\Read.cs" />
+    <Compile Include="CRUD\Update.cs" />
+    <Compile Include="Listener\Buttons\Activate.cs" />
+    <Compile Include="Listener\Buttons\BHoMWebsite.cs" />
+    <Compile Include="Listener\Buttons\BHoMWiki.cs" />
+    <Compile Include="Listener\Buttons\Deactivate.cs" />
+    <Compile Include="Listener\Buttons\RevitToolkitWiki.cs" />
+    <Compile Include="Listener\Buttons\SetPorts.cs" />
+    <Compile Include="Listener\EventHandlers\PullEvent.cs" />
+    <Compile Include="Listener\EventHandlers\PushEvent.cs" />
+    <Compile Include="Listener\EventHandlers\RemoveEvent.cs" />
+    <Compile Include="FailuresProcessing.cs" />
+    <Compile Include="Listener\Forms\UpdatePortsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Listener\Forms\UpdatePortsForm.Designer.cs">
+      <DependentUpon>UpdatePortsForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Messages\Errors.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Listener\RevitListener.cs" />
+    <Compile Include="RevitListenerAdapter.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Revit_Adapter\Revit_Adapter.csproj">
+      <Project>{3eb6d37d-8720-495a-8feb-e826f0e69af8}</Project>
+      <Name>Revit_Adapter</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Revit_Core_Engine\Revit_Core_Engine.csproj">
+      <Project>{4dfaf9c8-9770-4e5a-818d-eb4dab665145}</Project>
+      <Name>Revit_Core_Engine</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Revit_Engine\Revit_Engine.csproj">
+      <Project>{75a99ac5-fe80-45a4-b456-1aa3b1c4bb74}</Project>
+      <Name>Revit_Engine</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Revit_oM\Revit_oM.csproj">
+      <Project>{b97dbf34-761d-4ab7-b122-d05408b34d0f}</Project>
+      <Name>Revit_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Listener\Files\BHoM_2018.Addin">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Listener\Files\BHoM_2019.Addin">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Listener\Files\BHoM_2020.Addin">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Listener\Files\BHoM_2021.Addin">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Listener\Forms\UpdatePortsForm.resx">
+      <DependentUpon>UpdatePortsForm.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Listener\Files\Resources\AdapterActivate16.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Listener\Files\Resources\AdapterActivate32.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Listener\Files\Resources\AdapterDeactivate16.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Listener\Files\Resources\AdapterDeactivate32.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Listener\Files\Resources\AdapterUpdate16.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Listener\Files\Resources\AdapterUpdate32.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Listener\Files\Resources\BHoMWebsite16.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Listener\Files\Resources\Info16.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Listener\Files\Resources\Info32.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018'">
+    <PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2018.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2018\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E
 	</PostBuildEvent>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
-  <PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
+    <PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2019.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2019\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E
 	</PostBuildEvent>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
-  <PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
+    <PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2020.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2020\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E
 	</PostBuildEvent>
-</PropertyGroup>
-<ItemGroup>
-  <Reference Include="Adapter_Engine">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Adapter_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="BHoM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="BHoM_Adapter">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="BHoM_Engine">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Data_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Geometry_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Graphics_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Graphics_oM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Physical_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="PresentationCore" />
-  <Reference Include="Reflection_Engine">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Reflection_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="RevitAPI">
-    <HintPath>..\libs\2018\RevitAPI.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPIIFC">
-    <HintPath>..\libs\2018\RevitAPIIFC.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPIUI">
-    <HintPath>..\libs\2018\RevitAPIUI.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPI">
-    <HintPath>..\libs\2019\RevitAPI.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPIIFC">
-    <HintPath>..\libs\2019\RevitAPIIFC.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPIUI">
-    <HintPath>..\libs\2019\RevitAPIUI.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPI">
-    <HintPath>..\libs\2020\RevitAPI.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPIIFC">
-    <HintPath>..\libs\2020\RevitAPIIFC.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPIUI">
-    <HintPath>..\libs\2020\RevitAPIUI.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPI">
-    <HintPath>..\libs\2021\RevitAPI.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPIIFC">
-    <HintPath>..\libs\2021\RevitAPIIFC.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="RevitAPIUI">
-    <HintPath>..\libs\2021\RevitAPIUI.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Socket_Adapter">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Socket_Adapter.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Socket_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Socket_oM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="System" />
-  <Reference Include="System.Core" />
-  <Reference Include="System.Drawing" />
-  <Reference Include="System.Windows.Forms" />
-  <Reference Include="System.Xml.Linq" />
-  <Reference Include="System.Data.DataSetExtensions" />
-  <Reference Include="Microsoft.CSharp" />
-  <Reference Include="System.Data" />
-  <Reference Include="System.Net.Http" />
-  <Reference Include="System.Xml" />
-</ItemGroup>
-<ItemGroup>
-  <Compile Include="AdapterActions\Pull.cs" />
-  <Compile Include="AdapterActions\Remove.cs" />
-  <Compile Include="CRUD\Create.cs" />
-  <Compile Include="CRUD\Delete.cs" />
-  <Compile Include="AdapterActions\Push.cs" />
-  <Compile Include="CRUD\Read.cs" />
-  <Compile Include="CRUD\Update.cs" />
-  <Compile Include="Listener\Buttons\Activate.cs" />
-  <Compile Include="Listener\Buttons\BHoMWebsite.cs" />
-  <Compile Include="Listener\Buttons\BHoMWiki.cs" />
-  <Compile Include="Listener\Buttons\Deactivate.cs" />
-  <Compile Include="Listener\Buttons\RevitToolkitWiki.cs" />
-  <Compile Include="Listener\Buttons\SetPorts.cs" />
-  <Compile Include="Listener\EventHandlers\PullEvent.cs" />
-  <Compile Include="Listener\EventHandlers\PushEvent.cs" />
-  <Compile Include="Listener\EventHandlers\RemoveEvent.cs" />
-  <Compile Include="FailuresProcessing.cs" />
-  <Compile Include="Listener\Forms\UpdatePortsForm.cs" />
-  <Compile Include="Listener\Forms\UpdatePortsForm.Designer.cs" />
-  <Compile Include="Messages\Errors.cs" />
-  <Compile Include="Properties\AssemblyInfo.cs" />
-  <Compile Include="Listener\RevitListener.cs" />
-  <Compile Include="RevitListenerAdapter.cs" />
-</ItemGroup>
-<ItemGroup>
-  <ProjectReference Include="..\Revit_Adapter\Revit_Adapter.csproj">
-    <Project>{3eb6d37d-8720-495a-8feb-e826f0e69af8}</Project>
-    <Name>Revit_Adapter</Name>
-  </ProjectReference>
-  <ProjectReference Include="..\Revit_Core_Engine\Revit_Core_Engine.csproj">
-    <Project>{4dfaf9c8-9770-4e5a-818d-eb4dab665145}</Project>
-    <Name>Revit_Core_Engine</Name>
-  </ProjectReference>
-  <ProjectReference Include="..\Revit_Engine\Revit_Engine.csproj">
-    <Project>{75a99ac5-fe80-45a4-b456-1aa3b1c4bb74}</Project>
-    <Name>Revit_Engine</Name>
-  </ProjectReference>
-  <ProjectReference Include="..\Revit_oM\Revit_oM.csproj">
-    <Project>{b97dbf34-761d-4ab7-b122-d05408b34d0f}</Project>
-    <Name>Revit_oM</Name>
-  </ProjectReference>
-</ItemGroup>
-<ItemGroup>
-  <None Include="Listener\Files\BHoM_2018.Addin" />
-  <None Include="Listener\Files\BHoM_2019.Addin" />
-  <None Include="Listener\Files\BHoM_2020.Addin" />
-  <None Include="Listener\Files\BHoM_2021.Addin" />
-</ItemGroup>
-<ItemGroup />
-<ItemGroup />
-<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
-<PropertyGroup Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
-  <PostBuildEvent>
+	<PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2021.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2021\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E
 	</PostBuildEvent>
-</PropertyGroup>
+  </PropertyGroup>
 </Project>

--- a/Revit_Core_Adapter/Revit_Core_Adapter.csproj
+++ b/Revit_Core_Adapter/Revit_Core_Adapter.csproj
@@ -1,369 +1,299 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C2BD93AF-8853-4685-8BD4-223055DE1CC6}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <OutputPath>..\Build\</OutputPath>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BH.Revit.Adapter.Core</RootNamespace>
-    <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE;REVIT2018</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE;REVIT2018</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2018|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;REVIT2018</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;REVIT2019</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <AssemblyName>Revit_Core_Adapter_2019</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2018|AnyCPU'">
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;REVIT2018</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2019|AnyCPU'">
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;REVIT2019</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <AssemblyName>Revit_Core_Adapter_2019</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2020|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;REVIT2020</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <AssemblyName>Revit_Core_Adapter_2020</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2020|AnyCPU'">
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;REVIT2020</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <AssemblyName>Revit_Core_Adapter_2020</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;REVIT2021</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <AssemblyName>Revit_Core_Adapter_2021</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2021|AnyCPU'">
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE;REVIT2021</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <AssemblyName>Revit_Core_Adapter_2021</AssemblyName>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Adapter_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Adapter_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="BHoM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="BHoM_Adapter">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="BHoM_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Data_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Geometry_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Graphics_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Graphics_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Physical_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
-    </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="Reflection_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Reflection_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPI" Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018' Or '$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-      <HintPath>..\libs\2018\RevitAPI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPIIFC" Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018' Or '$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-      <HintPath>..\libs\2018\RevitAPIIFC.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPIUI" Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018' Or '$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-      <HintPath>..\libs\2018\RevitAPIUI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPI" Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
-      <HintPath>..\libs\2019\RevitAPI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPIIFC" Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
-      <HintPath>..\libs\2019\RevitAPIIFC.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPIUI" Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
-      <HintPath>..\libs\2019\RevitAPIUI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPI" Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
-      <HintPath>..\libs\2020\RevitAPI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPIIFC" Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
-      <HintPath>..\libs\2020\RevitAPIIFC.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPIUI" Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
-      <HintPath>..\libs\2020\RevitAPIUI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPI" Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
-      <HintPath>..\libs\2021\RevitAPI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPIIFC" Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
-      <HintPath>..\libs\2021\RevitAPIIFC.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPIUI" Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
-      <HintPath>..\libs\2021\RevitAPIUI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Socket_Adapter">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Socket_Adapter.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Socket_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Socket_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AdapterActions\Pull.cs" />
-    <Compile Include="AdapterActions\Remove.cs" />
-    <Compile Include="CRUD\Create.cs" />
-    <Compile Include="CRUD\Delete.cs" />
-    <Compile Include="AdapterActions\Push.cs" />
-    <Compile Include="CRUD\Read.cs" />
-    <Compile Include="CRUD\Update.cs" />
-    <Compile Include="Listener\Buttons\Activate.cs" />
-    <Compile Include="Listener\Buttons\BHoMWebsite.cs" />
-    <Compile Include="Listener\Buttons\BHoMWiki.cs" />
-    <Compile Include="Listener\Buttons\Deactivate.cs" />
-    <Compile Include="Listener\Buttons\RevitToolkitWiki.cs" />
-    <Compile Include="Listener\Buttons\SetPorts.cs" />
-    <Compile Include="Listener\EventHandlers\PullEvent.cs" />
-    <Compile Include="Listener\EventHandlers\PushEvent.cs" />
-    <Compile Include="Listener\EventHandlers\RemoveEvent.cs" />
-    <Compile Include="FailuresProcessing.cs" />
-    <Compile Include="Listener\Forms\UpdatePortsForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="Listener\Forms\UpdatePortsForm.Designer.cs">
-      <DependentUpon>UpdatePortsForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="Messages\Errors.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Listener\RevitListener.cs" />
-    <Compile Include="RevitListenerAdapter.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Revit_Adapter\Revit_Adapter.csproj">
-      <Project>{3eb6d37d-8720-495a-8feb-e826f0e69af8}</Project>
-      <Name>Revit_Adapter</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Revit_Core_Engine\Revit_Core_Engine.csproj">
-      <Project>{4dfaf9c8-9770-4e5a-818d-eb4dab665145}</Project>
-      <Name>Revit_Core_Engine</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Revit_Engine\Revit_Engine.csproj">
-      <Project>{75a99ac5-fe80-45a4-b456-1aa3b1c4bb74}</Project>
-      <Name>Revit_Engine</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Revit_oM\Revit_oM.csproj">
-      <Project>{b97dbf34-761d-4ab7-b122-d05408b34d0f}</Project>
-      <Name>Revit_oM</Name>
-      <Private>False</Private>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Listener\Files\BHoM_2018.Addin">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Listener\Files\BHoM_2019.Addin">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Listener\Files\BHoM_2020.Addin">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Listener\Files\BHoM_2021.Addin">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Listener\Forms\UpdatePortsForm.resx">
-      <DependentUpon>UpdatePortsForm.cs</DependentUpon>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Listener\Files\Resources\AdapterActivate16.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Listener\Files\Resources\AdapterActivate32.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Listener\Files\Resources\AdapterDeactivate16.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Listener\Files\Resources\AdapterDeactivate32.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Listener\Files\Resources\AdapterUpdate16.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Listener\Files\Resources\AdapterUpdate32.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Listener\Files\Resources\BHoMWebsite16.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Listener\Files\Resources\Info16.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Listener\Files\Resources\Info32.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018'">
-    <PostBuildEvent>
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTarget="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<PropertyGroup>
+  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+  <ProjectGuid>{C2BD93AF-8853-4685-8BD4-223055DE1CC6}</ProjectGuid>
+  <OutputType>Library</OutputType>
+  <AppDesignerFolder>Properties</AppDesignerFolder>
+  <RootNamespace>BH.Revit.Adapter.Core</RootNamespace>
+  <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
+  <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <FileAlignment>512</FileAlignment>
+  <OutputPath>..\Build\</OutputPath>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <DebugSymbols>true</DebugSymbols>
+  <DebugType>full</DebugType>
+  <Optimize>false</Optimize>
+  <DefineConstants>DEBUG;TRACE;REVIT2018</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+  <WarningLevel>4</WarningLevel>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <DebugType>pdbonly</DebugType>
+  <Optimize>true</Optimize>
+  <DefineConstants>TRACE;REVIT2018</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+  <WarningLevel>4</WarningLevel>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2018|AnyCPU'">
+  <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
+  <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <DebugSymbols>true</DebugSymbols>
+  <DebugType>full</DebugType>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE;DEBUG;REVIT2018</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|AnyCPU'">
+  <AssemblyName>Revit_Core_Adapter_2019</AssemblyName>
+  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  <DebugSymbols>true</DebugSymbols>
+  <DebugType>full</DebugType>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE;DEBUG;REVIT2019</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2018|AnyCPU'">
+  <AssemblyName>Revit_Core_Adapter_2018</AssemblyName>
+  <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <DebugType>pdbonly</DebugType>
+  <Optimize>true</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE;REVIT2018</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2019|AnyCPU'">
+  <AssemblyName>Revit_Core_Adapter_2019</AssemblyName>
+  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  <DebugType>pdbonly</DebugType>
+  <Optimize>true</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE;REVIT2019</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2020|AnyCPU'">
+  <AssemblyName>Revit_Core_Adapter_2020</AssemblyName>
+  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  <DebugSymbols>true</DebugSymbols>
+  <DebugType>full</DebugType>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE;DEBUG;REVIT2020</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2020|AnyCPU'">
+  <AssemblyName>Revit_Core_Adapter_2020</AssemblyName>
+  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  <DebugType>pdbonly</DebugType>
+  <Optimize>true</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE;REVIT2020</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
+  <AssemblyName>Revit_Core_Adapter_2021</AssemblyName>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+  <DebugSymbols>true</DebugSymbols>
+  <DebugType>full</DebugType>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE;DEBUG;REVIT2021</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2021|AnyCPU'">
+  <AssemblyName>Revit_Core_Adapter_2021</AssemblyName>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+  <DebugType>pdbonly</DebugType>
+  <Optimize>true</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE;REVIT2021</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)'=='Debug2018' Or '$(Configuration)'=='Release2018'">
+  <PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2018.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2018\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E
 	</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
-    <PostBuildEvent>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)'=='Debug2019' Or '$(Configuration)'=='Release2019'">
+  <PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2019.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2019\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E
 	</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
-    <PostBuildEvent>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)'=='Debug2020' Or '$(Configuration)'=='Release2020'">
+  <PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2020.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2020\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E
 	</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
-    <PostBuildEvent>
+</PropertyGroup>
+<ItemGroup>
+  <Reference Include="Adapter_Engine">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Adapter_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="BHoM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="BHoM_Adapter">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="BHoM_Engine">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Data_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Geometry_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Graphics_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Graphics_oM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Physical_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="PresentationCore" />
+  <Reference Include="Reflection_Engine">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Reflection_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="RevitAPI">
+    <HintPath>..\libs\2018\RevitAPI.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPIIFC">
+    <HintPath>..\libs\2018\RevitAPIIFC.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPIUI">
+    <HintPath>..\libs\2018\RevitAPIUI.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPI">
+    <HintPath>..\libs\2019\RevitAPI.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPIIFC">
+    <HintPath>..\libs\2019\RevitAPIIFC.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPIUI">
+    <HintPath>..\libs\2019\RevitAPIUI.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPI">
+    <HintPath>..\libs\2020\RevitAPI.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPIIFC">
+    <HintPath>..\libs\2020\RevitAPIIFC.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPIUI">
+    <HintPath>..\libs\2020\RevitAPIUI.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPI">
+    <HintPath>..\libs\2021\RevitAPI.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPIIFC">
+    <HintPath>..\libs\2021\RevitAPIIFC.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="RevitAPIUI">
+    <HintPath>..\libs\2021\RevitAPIUI.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Socket_Adapter">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Socket_Adapter.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Socket_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Socket_oM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="System" />
+  <Reference Include="System.Core" />
+  <Reference Include="System.Drawing" />
+  <Reference Include="System.Windows.Forms" />
+  <Reference Include="System.Xml.Linq" />
+  <Reference Include="System.Data.DataSetExtensions" />
+  <Reference Include="Microsoft.CSharp" />
+  <Reference Include="System.Data" />
+  <Reference Include="System.Net.Http" />
+  <Reference Include="System.Xml" />
+</ItemGroup>
+<ItemGroup>
+  <Compile Include="AdapterActions\Pull.cs" />
+  <Compile Include="AdapterActions\Remove.cs" />
+  <Compile Include="CRUD\Create.cs" />
+  <Compile Include="CRUD\Delete.cs" />
+  <Compile Include="AdapterActions\Push.cs" />
+  <Compile Include="CRUD\Read.cs" />
+  <Compile Include="CRUD\Update.cs" />
+  <Compile Include="Listener\Buttons\Activate.cs" />
+  <Compile Include="Listener\Buttons\BHoMWebsite.cs" />
+  <Compile Include="Listener\Buttons\BHoMWiki.cs" />
+  <Compile Include="Listener\Buttons\Deactivate.cs" />
+  <Compile Include="Listener\Buttons\RevitToolkitWiki.cs" />
+  <Compile Include="Listener\Buttons\SetPorts.cs" />
+  <Compile Include="Listener\EventHandlers\PullEvent.cs" />
+  <Compile Include="Listener\EventHandlers\PushEvent.cs" />
+  <Compile Include="Listener\EventHandlers\RemoveEvent.cs" />
+  <Compile Include="FailuresProcessing.cs" />
+  <Compile Include="Listener\Forms\UpdatePortsForm.cs" />
+  <Compile Include="Listener\Forms\UpdatePortsForm.Designer.cs" />
+  <Compile Include="Messages\Errors.cs" />
+  <Compile Include="Properties\AssemblyInfo.cs" />
+  <Compile Include="Listener\RevitListener.cs" />
+  <Compile Include="RevitListenerAdapter.cs" />
+</ItemGroup>
+<ItemGroup>
+  <ProjectReference Include="..\Revit_Adapter\Revit_Adapter.csproj">
+    <Project>{3eb6d37d-8720-495a-8feb-e826f0e69af8}</Project>
+    <Name>Revit_Adapter</Name>
+  </ProjectReference>
+  <ProjectReference Include="..\Revit_Core_Engine\Revit_Core_Engine.csproj">
+    <Project>{4dfaf9c8-9770-4e5a-818d-eb4dab665145}</Project>
+    <Name>Revit_Core_Engine</Name>
+  </ProjectReference>
+  <ProjectReference Include="..\Revit_Engine\Revit_Engine.csproj">
+    <Project>{75a99ac5-fe80-45a4-b456-1aa3b1c4bb74}</Project>
+    <Name>Revit_Engine</Name>
+  </ProjectReference>
+  <ProjectReference Include="..\Revit_oM\Revit_oM.csproj">
+    <Project>{b97dbf34-761d-4ab7-b122-d05408b34d0f}</Project>
+    <Name>Revit_oM</Name>
+  </ProjectReference>
+</ItemGroup>
+<ItemGroup>
+  <None Include="Listener\Files\BHoM_2018.Addin" />
+  <None Include="Listener\Files\BHoM_2019.Addin" />
+  <None Include="Listener\Files\BHoM_2020.Addin" />
+  <None Include="Listener\Files\BHoM_2021.Addin" />
+</ItemGroup>
+<ItemGroup />
+<ItemGroup />
+<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
+<PropertyGroup Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
+  <PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2021.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2021\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E
 	</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+</PropertyGroup>
 </Project>

--- a/Revit_Core_Adapter/Revit_Core_Adapter.csproj
+++ b/Revit_Core_Adapter/Revit_Core_Adapter.csproj
@@ -351,6 +351,8 @@
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E
 	</PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
 	<PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2021.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2021\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y

--- a/Revit_Core_Engine/Modify/CopyParameters.cs
+++ b/Revit_Core_Engine/Modify/CopyParameters.cs
@@ -138,5 +138,37 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        public static void CopyParameters(this Element elementFrom, Element elementTo, IEnumerable<BuiltInParameter> toSkip = null)
+        {
+            List<Parameter> fromParams = elementFrom.GetOrderedParameters().ToList<Parameter>();
+            List<Parameter> toParams = elementTo.GetOrderedParameters().ToList<Parameter>();
+
+            foreach (Parameter paramFrom in fromParams)
+            {
+                Parameter paramTo = toParams.FirstOrDefault(x => x.Id.IntegerValue == paramFrom.Id.IntegerValue);
+                if (paramTo == null || paramTo.IsReadOnly || (toSkip != null && toSkip.Any(x => (int)x == paramTo.Id.IntegerValue)))
+                    continue;
+
+                switch (paramFrom.StorageType)
+                {
+                    case StorageType.Double:
+                        paramTo.Set(paramFrom.AsDouble());
+                        break;
+                    case StorageType.ElementId:
+                        paramTo.Set(paramFrom.AsElementId());
+                        break;
+                    case StorageType.Integer:
+                        paramTo.Set(paramFrom.AsInteger());
+                        break;
+                    case StorageType.String:
+                        paramTo.Set(paramFrom.AsString());
+                        break;
+                    case StorageType.None:
+                        paramTo.Set(paramFrom.AsValueString());
+                        break;
+                }
+            }
+        }
     }
 }

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsOfMemberElements.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsOfMemberElements.cs
@@ -184,5 +184,16 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        [Description("Filters ElementIds of elements being nested members of a given Revit family instance.")]
+        [Input("document", "Revit element to be queried for its member elements.")]
+        [Output("elementIds", "Collection of filtered ElementIds.")]
+        public static IEnumerable<ElementId> ElementIdsOfMemberElements(this FamilyInstance familyInstance)
+        {
+            // Note this method only returns shared nested families
+            return familyInstance.GetSubComponentIds();
+        }
+
+        /***************************************************/
     }
 }

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsOfMemberElements.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsOfMemberElements.cs
@@ -83,7 +83,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Filters ElementIds of elements being members of a given Revit group.")]
-        [Input("document", "Revit group to be queried for its member elements.")]
+        [Input("group", "Revit group to be queried for its member elements.")]
         [Output("elementIds", "Collection of filtered ElementIds.")]
         public static IEnumerable<ElementId> ElementIdsOfMemberElements(this Group group)
         {
@@ -105,7 +105,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Filters ElementIds of elements being members of a given Revit assembly.")]
-        [Input("document", "Revit assembly to be queried for its member elements.")]
+        [Input("assemblyInstance", "Revit assembly to be queried for its member elements.")]
         [Output("elementIds", "Collection of filtered ElementIds.")]
         public static IEnumerable<ElementId> ElementIdsOfMemberElements(this AssemblyInstance assemblyInstance)
         {
@@ -115,7 +115,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Filters ElementIds of elements being members of a given Revit mechanical system.")]
-        [Input("document", "Revit mechanical system to be queried for its member elements.")]
+        [Input("mechanicalSystem", "Revit mechanical system to be queried for its member elements.")]
         [Output("elementIds", "Collection of filtered ElementIds.")]
         public static IEnumerable<ElementId> ElementIdsOfMemberElements(this Autodesk.Revit.DB.Mechanical.MechanicalSystem mechanicalSystem)
         {
@@ -137,7 +137,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Filters ElementIds of elements being members of a given Revit piping system.")]
-        [Input("document", "Revit piping system to be queried for its member elements.")]
+        [Input("pipingSystem", "Revit piping system to be queried for its member elements.")]
         [Output("elementIds", "Collection of filtered ElementIds.")]
         public static IEnumerable<ElementId> ElementIdsOfMemberElements(this Autodesk.Revit.DB.Plumbing.PipingSystem pipingSystem)
         {
@@ -159,7 +159,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Filters ElementIds of elements being members of a given Revit electrical system.")]
-        [Input("document", "Revit electrical system to be queried for its member elements.")]
+        [Input("electricalSystem", "Revit electrical system to be queried for its member elements.")]
         [Output("elementIds", "Collection of filtered ElementIds.")]
         public static IEnumerable<ElementId> ElementIdsOfMemberElements(this Autodesk.Revit.DB.Electrical.ElectricalSystem electricalSystem)
         {
@@ -176,7 +176,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Filters ElementIds of elements being members of a given Revit selection set.")]
-        [Input("document", "Revit selection set to be queried for its member elements.")]
+        [Input("selectionSet", "Revit selection set to be queried for its member elements.")]
         [Output("elementIds", "Collection of filtered ElementIds.")]
         public static IEnumerable<ElementId> ElementIdsOfMemberElements(this SelectionFilterElement selectionSet)
         {
@@ -186,7 +186,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Filters ElementIds of elements being nested members of a given Revit family instance.")]
-        [Input("document", "Revit element to be queried for its member elements.")]
+        [Input("familyInstance", "Revit element to be queried for its member elements.")]
         [Output("elementIds", "Collection of filtered ElementIds.")]
         public static IEnumerable<ElementId> ElementIdsOfMemberElements(this FamilyInstance familyInstance)
         {

--- a/Revit_Core_Engine/Query/Identifiers.cs
+++ b/Revit_Core_Engine/Query/Identifiers.cs
@@ -73,6 +73,7 @@ namespace BH.Revit.Engine.Core
             string familyTypeName = "";
             int familyTypeId = -1;
             int ownerViewId = -1;
+            int parentElementId = -1;
 
             Parameter parameter = element.get_Parameter(BuiltInParameter.ELEM_CATEGORY_PARAM);
             if (parameter != null)
@@ -93,7 +94,17 @@ namespace BH.Revit.Engine.Core
             if (element.ViewSpecific)
                 ownerViewId = element.OwnerViewId.IntegerValue;
 
-            return new RevitIdentifiers(element.UniqueId, element.Id.IntegerValue, categoryName, familyName, familyTypeName, familyTypeId, ownerViewId);
+            if (element is FamilyInstance)
+            {
+                FamilyInstance famInstance = element as FamilyInstance;
+                Element parentElement = famInstance.SuperComponent;
+                if (parentElement != null)
+                {
+                    parentElementId = parentElement.Id.IntegerValue;
+                }
+            }
+
+            return new RevitIdentifiers(element.UniqueId, element.Id.IntegerValue, categoryName, familyName, familyTypeName, familyTypeId, ownerViewId, parentElementId);
         }
 
         /***************************************************/

--- a/Revit_Engine/Create/Config/RevitPullConfig.cs
+++ b/Revit_Engine/Create/Config/RevitPullConfig.cs
@@ -46,6 +46,20 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
+        [Description("Creates a pull action-specific configuration used for adapter interaction with Revit.")]
+        [InputFromProperty("discipline")]
+        [InputFromProperty("includeClosedWorksets")]
+        [InputFromProperty("geometryConfig")]
+        [InputFromProperty("representationConfig")]
+        [InputFromProperty("includeNestedElements")]
+        [Output("revitPullConfig")]
+        public static RevitPullConfig RevitPullConfig(Discipline discipline = Discipline.Undefined, bool includeClosedWorksets = false, PullGeometryConfig geometryConfig = null, PullRepresentationConfig representationConfig = null, bool includeNestedElements = true)
+        {
+            return new RevitPullConfig { Discipline = discipline, IncludeClosedWorksets = includeClosedWorksets, GeometryConfig = geometryConfig, RepresentationConfig = representationConfig, IncludeNestedElements = includeNestedElements };
+        }
+
+        /***************************************************/
+
         [ToBeRemoved("3.2", "Non-applicable due to the changes in RevitPullConfig class.")]
         [Description("Creates a pull action-specific configuration used for adapter interaction with Revit.")]
         [InputFromProperty("discipline")]

--- a/Revit_Engine/Create/Config/RevitPullConfig.cs
+++ b/Revit_Engine/Create/Config/RevitPullConfig.cs
@@ -38,24 +38,26 @@ namespace BH.Engine.Adapters.Revit
         [InputFromProperty("includeClosedWorksets")]
         [InputFromProperty("geometryConfig")]
         [InputFromProperty("representationConfig")]
-        [Output("revitPullConfig")]
-        public static RevitPullConfig RevitPullConfig(Discipline discipline = Discipline.Undefined, bool includeClosedWorksets = false, PullGeometryConfig geometryConfig = null, PullRepresentationConfig representationConfig = null)
-        {
-            return new RevitPullConfig { Discipline = discipline, IncludeClosedWorksets = includeClosedWorksets, GeometryConfig = geometryConfig, RepresentationConfig = representationConfig };
-        }
-
-        /***************************************************/
-
-        [Description("Creates a pull action-specific configuration used for adapter interaction with Revit.")]
-        [InputFromProperty("discipline")]
-        [InputFromProperty("includeClosedWorksets")]
-        [InputFromProperty("geometryConfig")]
-        [InputFromProperty("representationConfig")]
         [InputFromProperty("includeNestedElements")]
         [Output("revitPullConfig")]
         public static RevitPullConfig RevitPullConfig(Discipline discipline = Discipline.Undefined, bool includeClosedWorksets = false, PullGeometryConfig geometryConfig = null, PullRepresentationConfig representationConfig = null, bool includeNestedElements = true)
         {
             return new RevitPullConfig { Discipline = discipline, IncludeClosedWorksets = includeClosedWorksets, GeometryConfig = geometryConfig, RepresentationConfig = representationConfig, IncludeNestedElements = includeNestedElements };
+        }
+
+        /***************************************************/
+        /****            Deprecated methods             ****/
+        /***************************************************/
+
+        [Deprecated("3.3", "Inputs of this method have changed.")]
+        [InputFromProperty("discipline")]
+        [InputFromProperty("includeClosedWorksets")]
+        [InputFromProperty("geometryConfig")]
+        [InputFromProperty("representationConfig")]
+        [Output("revitPullConfig")]
+        public static RevitPullConfig RevitPullConfig(Discipline discipline = Discipline.Undefined, bool includeClosedWorksets = false, PullGeometryConfig geometryConfig = null, PullRepresentationConfig representationConfig = null)
+        {
+            return new RevitPullConfig { Discipline = discipline, IncludeClosedWorksets = includeClosedWorksets, GeometryConfig = geometryConfig, RepresentationConfig = representationConfig };
         }
 
         /***************************************************/

--- a/Revit_oM/Config/RevitPullConfig.cs
+++ b/Revit_oM/Config/RevitPullConfig.cs
@@ -47,6 +47,9 @@ namespace BH.oM.Adapters.Revit
         [Description("Configuration specifying representation to be pulled and passed to RevitRepresentation fragment.")]
         public virtual PullRepresentationConfig RepresentationConfig { get; set; } = new PullRepresentationConfig();
 
+        [Description("Elements nested within families will be processed if true.")]
+        public virtual bool IncludeNestedElements { get; set; } = true;
+
         /***************************************************/
     }
 }

--- a/Revit_oM/Parameters/RevitIdentifiers.cs
+++ b/Revit_oM/Parameters/RevitIdentifiers.cs
@@ -55,12 +55,15 @@ namespace BH.oM.Adapters.Revit.Parameters
         [Description("ElementId of view that owns the Revit element correspondent to the BHoM object that carries this fragment. -1 if the Revit element is not view-dependent.")]
         public virtual int OwnerViewId { get; } = -1;
 
+        [Description("ElementId of the parent Revit element correspondent to the BHoM object that owns this.")]
+        public virtual int ParentElementId { get; } = -1;
+
 
         /***************************************************/
         /****            Public Constructors            ****/
         /***************************************************/
 
-        public RevitIdentifiers(string uniqueId = "", int elementId = -1, string categoryName = "", string familyName = "", string familyTypeName = "", int familyTypeId = -1, int ownerViewId = -1)
+        public RevitIdentifiers(string uniqueId = "", int elementId = -1, string categoryName = "", string familyName = "", string familyTypeName = "", int familyTypeId = -1, int ownerViewId = -1, int parentElementId = -1)
         {
             UniqueId = uniqueId;
             ElementId = elementId;
@@ -69,6 +72,7 @@ namespace BH.oM.Adapters.Revit.Parameters
             FamilyTypeName = familyTypeName;
             FamilyTypeId = familyTypeId;
             OwnerViewId = ownerViewId;
+            ParentElementId = parentElementId;
         }
 
         /***************************************************/

--- a/Revit_oM/Parameters/RevitIdentifiers.cs
+++ b/Revit_oM/Parameters/RevitIdentifiers.cs
@@ -55,7 +55,7 @@ namespace BH.oM.Adapters.Revit.Parameters
         [Description("ElementId of view that owns the Revit element correspondent to the BHoM object that carries this fragment. -1 if the Revit element is not view-dependent.")]
         public virtual int OwnerViewId { get; } = -1;
 
-        [Description("ElementId of the parent Revit element correspondent to the BHoM object that owns this.")]
+        [Description("ElementId of the parent Revit element correspondent to the BHoM object that carries this fragment. -1 if the Revit element is not a nested element.")]
         public virtual int ParentElementId { get; } = -1;
 
 


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #720 

Nested elements are now pulled when pulling from Revit if the pull config option for IncludeNestedElements=True. Default behavior is currently to include nested elements; this can be changed in the future if default nested element pulls prove too heavy, although initial benchmarking indicates minimal extra overhead for most families with nested elements.


### Test files
[Revit and GH Test Files](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Revit_Toolkit/Revit_Toolkit-%23720-NestedElements?csf=1&web=1&e=kF7kkq)



### Additional comments
This PR includes implementation for nested instances in windows, which require unique methods due to how window geometry is calculated in revit. Most element types do not require this workaround, but some element types may going forward. These should be covered under separate issues on an as-needed basis.

See images below for examples of implementation, including storage of parent element id to a new revit identifier property. 

_Family with nested elems in Revit_
![image](https://user-images.githubusercontent.com/6752345/99306456-17434280-280a-11eb-9419-9a667fdadfb8.png)

_Pulled in GH showing elem geo for nested elems_
![image](https://user-images.githubusercontent.com/6752345/99306621-43f75a00-280a-11eb-8aba-0f615f1bd5d5.png)

_Props in Grasshopper per pull, including parent elem id. THis also shows the pull config with nested elements enabled._
![image](https://user-images.githubusercontent.com/6752345/99306685-5a9db100-280a-11eb-908a-57854323fd1d.png)




