### PR TITLE
BHoM method loading made more eager

### DIFF
--- a/Revit_Core_Adapter/Listener/RevitListener.cs
+++ b/Revit_Core_Adapter/Listener/RevitListener.cs
@@ -162,7 +162,7 @@ namespace BH.Revit.Adapter.Core
             UIControlledApplication = uIControlledApplication;
 
             //Make sure all BHoM assemblies are loaded
-            BH.Engine.Reflection.Compute.LoadAllAssemblies();
+            BH.Engine.Reflection.Query.BHoMMethodList();
 
             //Add buttons to manage the adapter
             AddAdapterButtons(uIControlledApplication);

--- a/Revit_Core_Adapter/Listener/RevitListener.cs
+++ b/Revit_Core_Adapter/Listener/RevitListener.cs
@@ -161,7 +161,7 @@ namespace BH.Revit.Adapter.Core
         {
             UIControlledApplication = uIControlledApplication;
 
-            //Make sure all BHoM assemblies are loaded
+            //Make sure all BHoM assemblies and methods are loaded
             BH.Engine.Reflection.Query.BHoMMethodList();
 
             //Add buttons to manage the adapter


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #908

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue908%2DMethodLoadWarnings&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - activate the adapter, then activate Pull in GH and check the warnings - there should be none.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- loading of BHoM methods forced to happen on startup to avoid warnings pop up on the 1st call of `RunExtensionMethod`


### Additional comments
<!-- As required -->