### PR TITLE
Included MEPCurve ConnectionProperty Information

### DIFF
--- a/Revit_Core_Engine/Convert/Environment/FromRevit/CableTray.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/CableTray.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.ComponentModel;
@@ -32,6 +33,7 @@ using BH.oM.MEP.System.ConnectionProperties;
 using BH.oM.MEP.System;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Geometry;
+
 
 namespace BH.Revit.Engine.Core
 {
@@ -70,14 +72,14 @@ namespace BH.Revit.Engine.Core
             bool isStartConnected = false;
             bool isEndConnected = false;
             List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitCableTray, out isStartConnected, out isEndConnected, settings);
-
+            Vector revitCableTrayVector = BH.Engine.Geometry.Modify.RoundCoordinates(
+                VectorFromRevit((revitCableTray.Location as LocationCurve).Curve.GetEndPoint(0) -
+                                (revitCableTray.Location as LocationCurve).Curve.GetEndPoint(1)),4).Normalise();
             if (queried.Count > 2)
             {
                 //required to assert connector property later
                 queried = MatchRevitOrder(queried, revitCableTray);
             }
-            
-            Vector revitCableTrayVector = ((revitCableTray.Location as LocationCurve).Curve as Autodesk.Revit.DB.Line).Direction.VectorFromRevit().RoundCoordinates(4);
             
             for (int i = 0; i < queried.Count; i++)
             {
@@ -90,14 +92,13 @@ namespace BH.Revit.Engine.Core
                     ConnectionProperty = new CableTrayConnectionProperty(),
                     OrientationAngle = orientationAngle
                 };
-                
                 Vector bhomCableTrayVector = BH.Engine.Geometry.Modify.RoundCoordinates((thisSegment.StartPoint - thisSegment.EndPoint),4).Normalise();
 
                 if (queried.Count > 1)
                 {
-                    if (i == 0) //meaning it's the start segment of the revit cable tray that was split
+                    if (i == 0)
                     {
-                        if (BH.Engine.Geometry.Query.IsEqual(revitCableTrayVector, bhomCableTrayVector))
+                        if (revitCableTrayVector == bhomCableTrayVector)
                         {
                             thisSegment.ConnectionProperty.IsStartConnected = isStartConnected;
                             thisSegment.ConnectionProperty.IsEndConnected = true;
@@ -108,9 +109,9 @@ namespace BH.Revit.Engine.Core
                             thisSegment.ConnectionProperty.IsEndConnected = isStartConnected;   
                         }
                     }
-                    else if (i == queried.Count - 1) //meaning it's the end segment of the revit cable tray that was split
+                    else if (i == queried.Count - 1)
                     {
-                        if (BH.Engine.Geometry.Query.IsEqual(revitCableTrayVector, bhomCableTrayVector))
+                        if (revitCableTrayVector == bhomCableTrayVector)
                         {
                             thisSegment.ConnectionProperty.IsStartConnected = true;
                             thisSegment.ConnectionProperty.IsEndConnected = isEndConnected;
@@ -121,7 +122,7 @@ namespace BH.Revit.Engine.Core
                             thisSegment.ConnectionProperty.IsEndConnected = true;   
                         }
                     }
-                    else //meaning it's all mid segments of the revit cable tray that was split
+                    else
                     {
                         thisSegment.ConnectionProperty.IsStartConnected = true;
                         thisSegment.ConnectionProperty.IsEndConnected = true;
@@ -129,7 +130,7 @@ namespace BH.Revit.Engine.Core
                 }
                 else
                 {
-                    if (BH.Engine.Geometry.Query.IsEqual(revitCableTrayVector, bhomCableTrayVector))
+                    if (revitCableTrayVector == bhomCableTrayVector)
                     {
                         thisSegment.ConnectionProperty.IsStartConnected = isStartConnected;
                         thisSegment.ConnectionProperty.IsEndConnected = isEndConnected;
@@ -161,9 +162,11 @@ namespace BH.Revit.Engine.Core
         {
             LocationCurve locationCurve = reference.Location as LocationCurve;
             Curve curve = locationCurve.Curve;
-            BH.oM.Geometry.Point referenceStart = curve.GetEndPoint(0).PointFromRevit();
+            BH.oM.Geometry.Point referenceStart = BH.Revit.Engine.Core.Convert.PointFromRevit(curve.GetEndPoint(0));
 
-            return linesToMatch.OrderBy(x => x.Start.Distance(referenceStart)).ToList();
+            List<BH.oM.Geometry.Line> result = linesToMatch.OrderBy(x => x.Start.Distance(referenceStart)).ToList();
+
+            return result;
         }
         
         /***************************************************/

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/CableTray.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/CableTray.cs
@@ -71,13 +71,7 @@ namespace BH.Revit.Engine.Core
             bool isEndConnected = false;
             List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitCableTray, out isStartConnected, out isEndConnected, settings);
 
-            if (queried.Count > 2)
-            {
-                //required to assert connector property later
-                queried = MatchRevitOrder(queried, revitCableTray);
-            }
-            
-            Vector revitCableTrayVector = ((revitCableTray.Location as LocationCurve).Curve as Autodesk.Revit.DB.Line).Direction.VectorFromRevit().RoundCoordinates(4);
+            Vector revitCableTrayVector = BH.Engine.Geometry.Modify.RoundCoordinates(VectorFromRevit((revitCableTray.Location as LocationCurve).Curve.GetEndPoint(0) - (revitCableTray.Location as LocationCurve).Curve.GetEndPoint(1)),4).Normalise();
             
             for (int i = 0; i < queried.Count; i++)
             {
@@ -150,20 +144,6 @@ namespace BH.Revit.Engine.Core
 
             refObjects.AddOrReplace(revitCableTray.Id, bhomCableTrays);
             return bhomCableTrays;
-        }
-
-        /***************************************************/
-        /****              Private Methods              ****/
-        /***************************************************/
-        
-        [Description("Re-orders converted BHoM Line list to match the direction from the reference MEPCurve.")]
-        private static List<BH.oM.Geometry.Line> MatchRevitOrder(List<BH.oM.Geometry.Line> linesToMatch, MEPCurve reference)
-        {
-            LocationCurve locationCurve = reference.Location as LocationCurve;
-            Curve curve = locationCurve.Curve;
-            BH.oM.Geometry.Point referenceStart = curve.GetEndPoint(0).PointFromRevit();
-
-            return linesToMatch.OrderBy(x => x.Start.Distance(referenceStart)).ToList();
         }
         
         /***************************************************/

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
@@ -59,6 +59,7 @@ namespace BH.Revit.Engine.Core
             }
             
             List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitDuct, settings);
+            
             // Flow rate
             double flowRate = revitDuct.LookupParameterDouble(BuiltInParameter.RBS_DUCT_FLOW_PARAM); 
             BH.oM.MEP.System.SectionProperties.DuctSectionProperty sectionProperty = BH.Revit.Engine.Core.Query.DuctSectionProperty(revitDuct, settings);

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
@@ -57,10 +57,8 @@ namespace BH.Revit.Engine.Core
             {
                 bhomDucts = new List<BH.oM.MEP.System.Duct>();
             }
-
-            bool isStartConnected = false;
-            bool isEndConnected = false;
-            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitDuct, out isStartConnected, out isEndConnected, settings);
+            
+            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitDuct, settings);
             // Flow rate
             double flowRate = revitDuct.LookupParameterDouble(BuiltInParameter.RBS_DUCT_FLOW_PARAM); 
             BH.oM.MEP.System.SectionProperties.DuctSectionProperty sectionProperty = BH.Revit.Engine.Core.Query.DuctSectionProperty(revitDuct, settings);

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
@@ -57,8 +57,10 @@ namespace BH.Revit.Engine.Core
             {
                 bhomDucts = new List<BH.oM.MEP.System.Duct>();
             }
-            
-            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitDuct, settings);
+
+            bool isStartConnected = false;
+            bool isEndConnected = false;
+            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitDuct, out isStartConnected, out isEndConnected, settings);
             // Flow rate
             double flowRate = revitDuct.LookupParameterDouble(BuiltInParameter.RBS_DUCT_FLOW_PARAM); 
             BH.oM.MEP.System.SectionProperties.DuctSectionProperty sectionProperty = BH.Revit.Engine.Core.Query.DuctSectionProperty(revitDuct, settings);

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Duct.cs
@@ -58,7 +58,9 @@ namespace BH.Revit.Engine.Core
                 bhomDucts = new List<BH.oM.MEP.System.Duct>();
             }
 
-            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitDuct, settings);
+            bool isStartConnected = false;
+            bool isEndConnected = false;
+            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitDuct, out isStartConnected, out isEndConnected, settings);
             // Flow rate
             double flowRate = revitDuct.LookupParameterDouble(BuiltInParameter.RBS_DUCT_FLOW_PARAM); 
             BH.oM.MEP.System.SectionProperties.DuctSectionProperty sectionProperty = BH.Revit.Engine.Core.Query.DuctSectionProperty(revitDuct, settings);

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
@@ -58,7 +58,9 @@ namespace BH.Revit.Engine.Core
                 bhomPipes = new List<BH.oM.MEP.System.Pipe>();
             }
 
-            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitPipe, settings);
+            bool isStartConnected = false;
+            bool isEndConnected = false;
+            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitPipe,out isStartConnected, out isEndConnected, settings);
             // Flow rate
             double flowRate = revitPipe.LookupParameterDouble(BuiltInParameter.RBS_PIPE_FLOW_PARAM); // Flow rate 
             // Pipe section property

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
@@ -57,10 +57,8 @@ namespace BH.Revit.Engine.Core
             {
                 bhomPipes = new List<BH.oM.MEP.System.Pipe>();
             }
-
-            bool isStartConnected = false;
-            bool isEndConnected = false;
-            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitPipe,out isStartConnected, out isEndConnected, settings);
+            
+            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitPipe, settings);
             // Flow rate
             double flowRate = revitPipe.LookupParameterDouble(BuiltInParameter.RBS_PIPE_FLOW_PARAM); // Flow rate 
             // Pipe section property

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Pipe.cs
@@ -57,8 +57,10 @@ namespace BH.Revit.Engine.Core
             {
                 bhomPipes = new List<BH.oM.MEP.System.Pipe>();
             }
-            
-            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitPipe, settings);
+
+            bool isStartConnected = false;
+            bool isEndConnected = false;
+            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitPipe,out isStartConnected, out isEndConnected, settings);
             // Flow rate
             double flowRate = revitPipe.LookupParameterDouble(BuiltInParameter.RBS_PIPE_FLOW_PARAM); // Flow rate 
             // Pipe section property

--- a/Revit_Core_Engine/Query/LocationCurve.cs
+++ b/Revit_Core_Engine/Query/LocationCurve.cs
@@ -380,6 +380,14 @@ namespace BH.Revit.Engine.Core
         }
         
         /***************************************************/
+        public static List<BH.oM.Geometry.Line> LocationCurveMEP(this MEPCurve mepCurve, RevitSettings settings = null)
+        {
+            bool dummyIsStartConnected = false;
+            bool dummyIsEndConnected = false;
+            return LocationCurveMEP(mepCurve, out dummyIsStartConnected, out dummyIsEndConnected, settings);
+        }
+        
+        /***************************************************/
     }
 }
 

--- a/Revit_Core_Engine/Query/LocationCurve.cs
+++ b/Revit_Core_Engine/Query/LocationCurve.cs
@@ -380,14 +380,6 @@ namespace BH.Revit.Engine.Core
         }
         
         /***************************************************/
-        public static List<BH.oM.Geometry.Line> LocationCurveMEP(this MEPCurve mepCurve, RevitSettings settings = null)
-        {
-            bool dummyIsStartConnected = false;
-            bool dummyIsEndConnected = false;
-            return LocationCurveMEP(mepCurve, out dummyIsStartConnected, out dummyIsEndConnected, settings);
-        }
-        
-        /***************************************************/
     }
 }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR

Closes #911 

Adds the proper information to the `ConnectionProperty` to the `MEPCurve` converts. At the moment only `CableTray` is using the feature due to the lack of the property in `Duct` and `Pipe` objects.
Only the properties `IsStartConnected` and `IsEndConnected` have been assigned, the properties about the connection point have been ignored as they are irrelevant in this object and overall redundant.

### Test files
Link [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Revit_Toolkit/Revit_Toolkit-Issue911-IncludedMEPCurveConnectorInformation?csf=1&web=1&e=5Bjkit). Check is visual, in the GH script I've separated a few cases to check and the values expected.


### Changelog
Modified `BH.Revit.Engine.Core.Convert.CableTrayFromRevit`
Modified `BH.Revit.Engine.Core.Convert.DuctFromRevit`
Modified `BH.Revit.Engine.Core.Convert.PipeFromRevit`
Modified `BH.Revit.Engine.Core.Query.LocationCurve`