### PR TITLE
Removal of CableTrayMaterial to match oM changes

### DIFF
--- a/Revit_Core_Engine/Query/CableTraySectionProperty.cs
+++ b/Revit_Core_Engine/Query/CableTraySectionProperty.cs
@@ -50,7 +50,7 @@ namespace BH.Revit.Engine.Core
             SectionProfile sectionProfile = revitCableTray.CableTraySectionProfile(settings);
 
             // Cable Tray section property
-            return BH.Engine.MEP.Create.CableTraySectionProperty(new CableTrayMaterial(), sectionProfile);
+            return BH.Engine.MEP.Create.CableTraySectionProperty(new oM.Physical.Materials.Material(), sectionProfile);
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1114

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #920 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Test Files](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Revit_Toolkit/Revit_Toolkit-Issue920-CableTraySectionPropertyMaterial?csf=1&web=1&e=30e9ai)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->