### PR TITLE
Port naming unified across Revit and UI and descriptions updated

### DIFF
--- a/Revit_Core_Adapter/Listener/Forms/UpdatePortsForm.Designer.cs
+++ b/Revit_Core_Adapter/Listener/Forms/UpdatePortsForm.Designer.cs
@@ -62,6 +62,8 @@ namespace BH.Revit.Adapter.Core.Forms
             // 
             // InputPort
             // 
+            this.InputPort.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.InputPort.Location = new System.Drawing.Point(16, 55);
             this.InputPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.InputPort.Maximum = new decimal(new int[] {
@@ -75,7 +77,7 @@ namespace BH.Revit.Adapter.Core.Forms
             0,
             0});
             this.InputPort.Name = "InputPort";
-            this.InputPort.Size = new System.Drawing.Size(193, 22);
+            this.InputPort.Size = new System.Drawing.Size(208, 22);
             this.InputPort.TabIndex = 0;
             this.InputPort.Value = new decimal(new int[] {
             14128,
@@ -85,6 +87,8 @@ namespace BH.Revit.Adapter.Core.Forms
             // 
             // OutputPort
             // 
+            this.OutputPort.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.OutputPort.Location = new System.Drawing.Point(16, 131);
             this.OutputPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.OutputPort.Maximum = new decimal(new int[] {
@@ -98,7 +102,7 @@ namespace BH.Revit.Adapter.Core.Forms
             0,
             0});
             this.OutputPort.Name = "OutputPort";
-            this.OutputPort.Size = new System.Drawing.Size(193, 22);
+            this.OutputPort.Size = new System.Drawing.Size(208, 22);
             this.OutputPort.TabIndex = 1;
             this.OutputPort.Value = new decimal(new int[] {
             14129,
@@ -108,15 +112,18 @@ namespace BH.Revit.Adapter.Core.Forms
             // 
             // label1
             // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.label1.Location = new System.Drawing.Point(13, 12);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(196, 41);
+            this.label1.Size = new System.Drawing.Size(211, 41);
             this.label1.TabIndex = 2;
             this.label1.Text = "Push port (must be equal to ConnectorSettings.PushPort):";
             // 
             // OkBtn
             // 
-            this.OkBtn.Location = new System.Drawing.Point(129, 166);
+            this.OkBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.OkBtn.Location = new System.Drawing.Point(144, 166);
             this.OkBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.OkBtn.Name = "OkBtn";
             this.OkBtn.Size = new System.Drawing.Size(80, 27);
@@ -127,8 +134,9 @@ namespace BH.Revit.Adapter.Core.Forms
             // 
             // CancelBtn
             // 
+            this.CancelBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.CancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelBtn.Location = new System.Drawing.Point(43, 166);
+            this.CancelBtn.Location = new System.Drawing.Point(58, 166);
             this.CancelBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.CancelBtn.Name = "CancelBtn";
             this.CancelBtn.Size = new System.Drawing.Size(80, 27);
@@ -139,9 +147,11 @@ namespace BH.Revit.Adapter.Core.Forms
             // 
             // label2
             // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.label2.Location = new System.Drawing.Point(13, 88);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(196, 41);
+            this.label2.Size = new System.Drawing.Size(211, 41);
             this.label2.TabIndex = 6;
             this.label2.Text = "Pull port (must be equal to ConnectorSettings.PullPort):";
             // 
@@ -151,7 +161,7 @@ namespace BH.Revit.Adapter.Core.Forms
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.CancelBtn;
-            this.ClientSize = new System.Drawing.Size(216, 206);
+            this.ClientSize = new System.Drawing.Size(236, 206);
             this.ControlBox = false;
             this.Controls.Add(this.label2);
             this.Controls.Add(this.CancelBtn);

--- a/Revit_Core_Adapter/Listener/Forms/UpdatePortsForm.Designer.cs
+++ b/Revit_Core_Adapter/Listener/Forms/UpdatePortsForm.Designer.cs
@@ -53,16 +53,16 @@ namespace BH.Revit.Adapter.Core.Forms
             this.InputPort = new System.Windows.Forms.NumericUpDown();
             this.OutputPort = new System.Windows.Forms.NumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
             this.OkBtn = new System.Windows.Forms.Button();
             this.CancelBtn = new System.Windows.Forms.Button();
+            this.label2 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.InputPort)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.OutputPort)).BeginInit();
             this.SuspendLayout();
             // 
             // InputPort
             // 
-            this.InputPort.Location = new System.Drawing.Point(12, 37);
+            this.InputPort.Location = new System.Drawing.Point(16, 55);
             this.InputPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.InputPort.Maximum = new decimal(new int[] {
             65000,
@@ -75,7 +75,7 @@ namespace BH.Revit.Adapter.Core.Forms
             0,
             0});
             this.InputPort.Name = "InputPort";
-            this.InputPort.Size = new System.Drawing.Size(175, 22);
+            this.InputPort.Size = new System.Drawing.Size(193, 22);
             this.InputPort.TabIndex = 0;
             this.InputPort.Value = new decimal(new int[] {
             14128,
@@ -85,7 +85,7 @@ namespace BH.Revit.Adapter.Core.Forms
             // 
             // OutputPort
             // 
-            this.OutputPort.Location = new System.Drawing.Point(12, 92);
+            this.OutputPort.Location = new System.Drawing.Point(16, 131);
             this.OutputPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.OutputPort.Maximum = new decimal(new int[] {
             65000,
@@ -98,7 +98,7 @@ namespace BH.Revit.Adapter.Core.Forms
             0,
             0});
             this.OutputPort.Name = "OutputPort";
-            this.OutputPort.Size = new System.Drawing.Size(175, 22);
+            this.OutputPort.Size = new System.Drawing.Size(193, 22);
             this.OutputPort.TabIndex = 1;
             this.OutputPort.Value = new decimal(new int[] {
             14129,
@@ -108,25 +108,15 @@ namespace BH.Revit.Adapter.Core.Forms
             // 
             // label1
             // 
-            this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(13, 12);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(73, 17);
+            this.label1.Size = new System.Drawing.Size(196, 41);
             this.label1.TabIndex = 2;
-            this.label1.Text = "Push port:";
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(13, 71);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(64, 17);
-            this.label2.TabIndex = 3;
-            this.label2.Text = "Pull port:";
+            this.label1.Text = "Push port (must be equal to ConnectorSettings.PushPort):";
             // 
             // OkBtn
             // 
-            this.OkBtn.Location = new System.Drawing.Point(107, 127);
+            this.OkBtn.Location = new System.Drawing.Point(129, 166);
             this.OkBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.OkBtn.Name = "OkBtn";
             this.OkBtn.Size = new System.Drawing.Size(80, 27);
@@ -138,7 +128,7 @@ namespace BH.Revit.Adapter.Core.Forms
             // CancelBtn
             // 
             this.CancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelBtn.Location = new System.Drawing.Point(12, 127);
+            this.CancelBtn.Location = new System.Drawing.Point(43, 166);
             this.CancelBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.CancelBtn.Name = "CancelBtn";
             this.CancelBtn.Size = new System.Drawing.Size(80, 27);
@@ -147,17 +137,25 @@ namespace BH.Revit.Adapter.Core.Forms
             this.CancelBtn.UseVisualStyleBackColor = true;
             this.CancelBtn.Click += new System.EventHandler(this.CancelBtn_Click);
             // 
+            // label2
+            // 
+            this.label2.Location = new System.Drawing.Point(13, 88);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(196, 41);
+            this.label2.TabIndex = 6;
+            this.label2.Text = "Pull port (must be equal to ConnectorSettings.PullPort):";
+            // 
             // UpdatePortsForm
             // 
             this.AcceptButton = this.OkBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.CancelBtn;
-            this.ClientSize = new System.Drawing.Size(198, 166);
+            this.ClientSize = new System.Drawing.Size(216, 206);
             this.ControlBox = false;
+            this.Controls.Add(this.label2);
             this.Controls.Add(this.CancelBtn);
             this.Controls.Add(this.OkBtn);
-            this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.OutputPort);
             this.Controls.Add(this.InputPort);
@@ -167,7 +165,6 @@ namespace BH.Revit.Adapter.Core.Forms
             ((System.ComponentModel.ISupportInitialize)(this.InputPort)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.OutputPort)).EndInit();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -176,8 +173,8 @@ namespace BH.Revit.Adapter.Core.Forms
         private System.Windows.Forms.NumericUpDown InputPort;
         private System.Windows.Forms.NumericUpDown OutputPort;
         private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Button OkBtn;
         private System.Windows.Forms.Button CancelBtn;
+        private System.Windows.Forms.Label label2;
     }
 }

--- a/Revit_Core_Adapter/Listener/Forms/UpdatePortsForm.Designer.cs
+++ b/Revit_Core_Adapter/Listener/Forms/UpdatePortsForm.Designer.cs
@@ -62,8 +62,8 @@ namespace BH.Revit.Adapter.Core.Forms
             // 
             // InputPort
             // 
-            this.InputPort.Location = new System.Drawing.Point(9, 30);
-            this.InputPort.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.InputPort.Location = new System.Drawing.Point(12, 37);
+            this.InputPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.InputPort.Maximum = new decimal(new int[] {
             65000,
             0,
@@ -75,7 +75,7 @@ namespace BH.Revit.Adapter.Core.Forms
             0,
             0});
             this.InputPort.Name = "InputPort";
-            this.InputPort.Size = new System.Drawing.Size(131, 20);
+            this.InputPort.Size = new System.Drawing.Size(175, 22);
             this.InputPort.TabIndex = 0;
             this.InputPort.Value = new decimal(new int[] {
             14128,
@@ -85,8 +85,8 @@ namespace BH.Revit.Adapter.Core.Forms
             // 
             // OutputPort
             // 
-            this.OutputPort.Location = new System.Drawing.Point(9, 75);
-            this.OutputPort.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.OutputPort.Location = new System.Drawing.Point(12, 92);
+            this.OutputPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.OutputPort.Maximum = new decimal(new int[] {
             65000,
             0,
@@ -98,7 +98,7 @@ namespace BH.Revit.Adapter.Core.Forms
             0,
             0});
             this.OutputPort.Name = "OutputPort";
-            this.OutputPort.Size = new System.Drawing.Size(131, 20);
+            this.OutputPort.Size = new System.Drawing.Size(175, 22);
             this.OutputPort.TabIndex = 1;
             this.OutputPort.Value = new decimal(new int[] {
             14129,
@@ -109,29 +109,27 @@ namespace BH.Revit.Adapter.Core.Forms
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(10, 10);
-            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label1.Location = new System.Drawing.Point(13, 12);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(93, 13);
+            this.label1.Size = new System.Drawing.Size(73, 17);
             this.label1.TabIndex = 2;
-            this.label1.Text = "Input port number:";
+            this.label1.Text = "Push port:";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 58);
-            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label2.Location = new System.Drawing.Point(13, 71);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(101, 13);
+            this.label2.Size = new System.Drawing.Size(64, 17);
             this.label2.TabIndex = 3;
-            this.label2.Text = "Output port number:";
+            this.label2.Text = "Pull port:";
             // 
             // OkBtn
             // 
-            this.OkBtn.Location = new System.Drawing.Point(80, 105);
-            this.OkBtn.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.OkBtn.Location = new System.Drawing.Point(107, 127);
+            this.OkBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.OkBtn.Name = "OkBtn";
-            this.OkBtn.Size = new System.Drawing.Size(60, 35);
+            this.OkBtn.Size = new System.Drawing.Size(80, 27);
             this.OkBtn.TabIndex = 4;
             this.OkBtn.Text = "OK";
             this.OkBtn.UseVisualStyleBackColor = true;
@@ -140,10 +138,10 @@ namespace BH.Revit.Adapter.Core.Forms
             // CancelBtn
             // 
             this.CancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelBtn.Location = new System.Drawing.Point(9, 105);
-            this.CancelBtn.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.CancelBtn.Location = new System.Drawing.Point(12, 127);
+            this.CancelBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.CancelBtn.Name = "CancelBtn";
-            this.CancelBtn.Size = new System.Drawing.Size(60, 35);
+            this.CancelBtn.Size = new System.Drawing.Size(80, 27);
             this.CancelBtn.TabIndex = 5;
             this.CancelBtn.Text = "Cancel";
             this.CancelBtn.UseVisualStyleBackColor = true;
@@ -152,10 +150,10 @@ namespace BH.Revit.Adapter.Core.Forms
             // UpdatePortsForm
             // 
             this.AcceptButton = this.OkBtn;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.CancelBtn;
-            this.ClientSize = new System.Drawing.Size(171, 161);
+            this.ClientSize = new System.Drawing.Size(198, 166);
             this.ControlBox = false;
             this.Controls.Add(this.CancelBtn);
             this.Controls.Add(this.OkBtn);
@@ -163,7 +161,7 @@ namespace BH.Revit.Adapter.Core.Forms
             this.Controls.Add(this.label1);
             this.Controls.Add(this.OutputPort);
             this.Controls.Add(this.InputPort);
-            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "UpdatePortsForm";
             this.Text = "Set Ports";
             ((System.ComponentModel.ISupportInitialize)(this.InputPort)).EndInit();

--- a/Revit_oM/Elements/Sheet.cs
+++ b/Revit_oM/Elements/Sheet.cs
@@ -36,10 +36,10 @@ namespace BH.oM.Adapters.Revit.Elements
         [Description("An entity storing the information about Revit sheet type.")]
         public virtual InstanceProperties InstanceProperties { get; set; } = new InstanceProperties();
 
-        [Description("Name of the Sheet correspondent with Revit sheet name.")]
+        [Description("Name of the Revit sheet.")]
         public virtual string SheetName { get; set; } = null;
 
-        [Description("Number of the Sheet correspondent with Revit sheet number.")]
+        [Description("Number of the Revit sheet.")]
         public virtual string SheetNumber { get; set; } = null;
 
         /***************************************************/

--- a/Revit_oM/Elements/ViewPlan.cs
+++ b/Revit_oM/Elements/ViewPlan.cs
@@ -36,13 +36,13 @@ namespace BH.oM.Adapters.Revit.Elements
         [Description("An entity storing the information about Revit view type.")]
         public virtual InstanceProperties InstanceProperties { get; set; } = new InstanceProperties();
 
-        [Description("Name of Revit level to which the view belongs (Associated Level).")]
+        [Description("Name of Revit level to which the Revit view belongs (Associated Level parameter).")]
         public virtual string LevelName { get; set; } = string.Empty;
 
-        [Description("Name of the ViewPlan correspondent with Revit view name.")]
+        [Description("Name of the Revit view.")]
         public virtual string ViewName { get; set; } = string.Empty;
 
-        [Description("Name of the ViewPlan correspondent with Revit view name.")]
+        [Description("Name of the view template applied to the Revit view.")]
         public virtual string TemplateName { get; set; } = string.Empty;
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #930
Closes #934

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed:
- #930: run Revit, click Activate => Update Ports and compare the labels with `ConnectionSettings` property names
- #934: look up the code changes


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- port naming unified across Revit and UI
- descriptions updated to `Sheet` and `ViewPlan` types

### Additional comments
<!-- As required -->