### PR TITLE
Update of IInstances improved to handle orientation and hosts

### DIFF
--- a/Revit_Core_Engine/Compute/Errors.cs
+++ b/Revit_Core_Engine/Compute/Errors.cs
@@ -96,7 +96,7 @@ namespace BH.Revit.Engine.Core
         
         internal static void InvalidTwoLevelLocationError(this FamilySymbol familySymbol)
         {
-            BH.Engine.Reflection.Compute.RecordWarning($"Location line of the two-level based element is upside-down, which is not allowed for given family placement type. ElementId: {familySymbol.Id.IntegerValue}");
+            BH.Engine.Reflection.Compute.RecordError($"Location line of the two-level based element is upside-down, which is not allowed for given family placement type. ElementId: {familySymbol.Id.IntegerValue}");
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Compute/Warnings.cs
+++ b/Revit_Core_Engine/Compute/Warnings.cs
@@ -474,7 +474,14 @@ namespace BH.Revit.Engine.Core
 
         internal static void CurveBasedNonHostedWarning(this FamilyInstance familyInstance)
         {
-            BH.Engine.Reflection.Compute.RecordWarning($"A curve-based non-structural element has been created without a host. There is a high chance it got created in a wrong location due to a Revit bug, therefore it is recommended to inspect the element. ElementId: {familyInstance.Id.IntegerValue}");
+            BH.Engine.Reflection.Compute.RecordWarning($"A curve-based non-structural element has been created without a host. There is a high chance it got created in a wrong location due to Revit limitations, therefore it is recommended to inspect the element. ElementId: {familyInstance.Id.IntegerValue}");
+        }
+
+        /***************************************************/
+
+        internal static void TwoLevelBasedByPointWarning(this FamilyInstance familyInstance)
+        {
+            BH.Engine.Reflection.Compute.RecordWarning($"A point-based, two level based element has been created. There is a high chance it got created in a wrong location due to Revit limitations, therefore it is recommended to inspect the element. ElementId: {familyInstance.Id.IntegerValue}");
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Create/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance.cs
@@ -181,9 +181,13 @@ namespace BH.Revit.Engine.Core
                     BH.Engine.Reflection.Compute.RecordWarning($"The orientation used to create the family instance was not perpendicular to the face on which the instance was placed. The orientation out of plane has been ignored. ElementId: {familyInstance.Id.IntegerValue}");
             }
 
-            List<Solid> hostSolids = host.Solids(new Options());
-            if (hostSolids != null && hostSolids.All(x => !origin.IsInside(x, settings.DistanceTolerance)))
-                BH.Engine.Reflection.Compute.RecordWarning($"The input location point for creation of a family instance was outside of the host solid, the point has been snapped to the host. ElementId: {familyInstance.Id.IntegerValue}");
+            XYZ location = (familyInstance.Location as LocationPoint)?.Point;
+            if (location != null && location.DistanceTo(origin) > settings.DistanceTolerance)
+            {
+                List<Solid> hostSolids = host.Solids(new Options());
+                if (hostSolids == null && hostSolids.All(x => !origin.IsInside(x, settings.DistanceTolerance)))
+                    BH.Engine.Reflection.Compute.RecordWarning($"The input location point for creation of a family instance was outside of the host solid, the point has been snapped to the host. ElementId: {familyInstance.Id.IntegerValue}");
+            }
 
             return familyInstance;
         }
@@ -401,7 +405,7 @@ namespace BH.Revit.Engine.Core
                 if (location != null && reference != null)
                     familyInstance = document.Create.NewFamilyInstance(reference, location, familySymbol);
 
-                if (location.GetEndPoint(0).DistanceTo(line.GetEndPoint(0)) > settings.DistanceTolerance || location.GetEndPoint(1).DistanceTo(line.GetEndPoint(1)) > settings.DistanceTolerance)
+                if (familyInstance != null && location.GetEndPoint(0).DistanceTo(line.GetEndPoint(0)) > settings.DistanceTolerance || location.GetEndPoint(1).DistanceTo(line.GetEndPoint(1)) > settings.DistanceTolerance)
                     BH.Engine.Reflection.Compute.RecordWarning($"The location line of the created family instance has been snapped to the closest face of the host element. ElementId: {familyInstance.Id.IntegerValue}");
             }
 

--- a/Revit_Core_Engine/Create/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance.cs
@@ -159,7 +159,10 @@ namespace BH.Revit.Engine.Core
             else
             {
                 FamilyInstance familyInstance = document.Create.NewFamilyInstance(origin, familySymbol, orientation.BasisX, host, StructuralType.NonStructural);
-                familyInstance.CheckIfSameNormal(orientation.BasisZ, settings);
+
+                if (1 - Math.Abs(familyInstance.GetTotalTransform().BasisY.DotProduct(orientation.BasisY.Normalize())) > settings.AngleTolerance)
+                    BH.Engine.Reflection.Compute.RecordWarning($"The orientation used to create the family instance was not perpendicular to the face on which the instance was placed. The orientation out of plane has been ignored. ElementId: {familyInstance.Id.IntegerValue}");
+                
                 return familyInstance;
             }
         }
@@ -219,7 +222,10 @@ namespace BH.Revit.Engine.Core
                 }
 
                 FamilyInstance familyInstance = document.Create.NewFamilyInstance(reference, location, refDir, familySymbol);
-                familyInstance.CheckIfSameNormal(orientation?.BasisZ, settings);
+
+                if (orientation?.BasisZ != null && 1 - Math.Abs(familyInstance.GetTotalTransform().BasisZ.DotProduct(orientation.BasisZ.Normalize())) > settings.AngleTolerance)
+                    BH.Engine.Reflection.Compute.RecordWarning($"The orientation used to create the family instance was not perpendicular to the face on which the instance was placed. The orientation out of plane has been ignored. ElementId: {familyInstance.Id.IntegerValue}");
+                
                 return familyInstance;
             }
             else
@@ -535,14 +541,6 @@ namespace BH.Revit.Engine.Core
                 result = basis.BasisY.CrossProduct(basis.BasisZ);
 
             return result;
-        }
-
-        /***************************************************/
-
-        private static void CheckIfSameNormal(this FamilyInstance familyInstance, XYZ normal, RevitSettings settings)
-        {
-            if (normal != null && 1 - Math.Abs(familyInstance.GetTotalTransform().BasisZ.DotProduct(normal.Normalize())) > settings.AngleTolerance)
-                BH.Engine.Reflection.Compute.RecordWarning($"The orientation used to create the family instance was not perpendicular to the face on which the instance was placed. The orientation out of plane has been ignored. ElementId: {familyInstance.Id.IntegerValue}");
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Modify/Update.cs
+++ b/Revit_Core_Engine/Modify/Update.cs
@@ -104,7 +104,7 @@ namespace BH.Revit.Engine.Core
             if (!string.IsNullOrWhiteSpace(bHoMObject.Properties?.CategoryName) && element.Category?.Name != bHoMObject.Properties.CategoryName)
                 BH.Engine.Reflection.Compute.RecordWarning($"Updating the category of an existing Revit element is not allowed. Revit ElementId: {element.Id} BHoM_Guid: {bHoMObject.BHoM_Guid}");
 
-            if ((element.Host == null && bHoMObject.HostId != -1) || (element.Host != null && element.Host.Id.IntegerValue != bHoMObject.HostId))
+            if (((element.Host == null || element.Host is ReferencePlane) && bHoMObject.HostId != -1) || (element.Host != null && !(element.Host is ReferencePlane) && element.Host.Id.IntegerValue != bHoMObject.HostId))
                 BH.Engine.Reflection.Compute.RecordWarning($"Updating the host of an existing hosted element is not allowed. Revit ElementId: {element.Id} BHoM_Guid: {bHoMObject.BHoM_Guid}");
 
             return ((Element)element).Update(bHoMObject, settings, setLocationOnUpdate);

--- a/Revit_Core_Engine/Modify/Update.cs
+++ b/Revit_Core_Engine/Modify/Update.cs
@@ -102,7 +102,7 @@ namespace BH.Revit.Engine.Core
             }
 
             if (!string.IsNullOrWhiteSpace(bHoMObject.Properties?.CategoryName) && element.Category?.Name != bHoMObject.Properties.CategoryName)
-                BH.Engine.Reflection.Compute.RecordWarning($"Updating the category of an existing Revit element is not allowed. Revit ElementId: {element.Id} BHoM_Guid: {bHoMObject.BHoM_Guid}");
+                BH.Engine.Reflection.Compute.RecordWarning($"Updating the category of an existing element is not allowed. Revit ElementId: {element.Id} BHoM_Guid: {bHoMObject.BHoM_Guid}");
 
             if (((element.Host == null || element.Host is ReferencePlane) && bHoMObject.HostId != -1) || (element.Host != null && !(element.Host is ReferencePlane) && element.Host.Id.IntegerValue != bHoMObject.HostId))
                 BH.Engine.Reflection.Compute.RecordWarning($"Updating the host of an existing hosted element is not allowed. Revit ElementId: {element.Id} BHoM_Guid: {bHoMObject.BHoM_Guid}");

--- a/Revit_Core_Engine/Query/IsInside.cs
+++ b/Revit_Core_Engine/Query/IsInside.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using System;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static bool IsInside(this XYZ point, Solid solid, double tolerance)
+        {
+            SolidCurveIntersectionOptions sco = new SolidCurveIntersectionOptions();
+            sco.ResultType = SolidCurveIntersectionMode.CurveSegmentsInside;
+
+            XYZ[] vectors = { XYZ.BasisX, XYZ.BasisY, XYZ.BasisZ };
+            foreach (XYZ vector in vectors)
+            {
+                Line l = Line.CreateBound(point - vector, point + vector);
+                SolidCurveIntersection sci = solid.IntersectWithCurve(l, sco);
+                if (sci == null)
+                    continue;
+
+                for (int i = 0; i < sci.SegmentCount; i++)
+                {
+                    Curve c = sci.GetCurveSegment(i);
+                    IntersectionResult ir = c.Project(point);
+                    if (ir != null && ir.Distance <= tolerance)
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Query/IsInside.cs
+++ b/Revit_Core_Engine/Query/IsInside.cs
@@ -33,6 +33,9 @@ namespace BH.Revit.Engine.Core
 
         public static bool IsInside(this XYZ point, Solid solid, double tolerance)
         {
+            if (solid == null || solid.Volume < tolerance)
+                return false;
+
             SolidCurveIntersectionOptions sco = new SolidCurveIntersectionOptions();
             sco.ResultType = SolidCurveIntersectionMode.CurveSegmentsInside;
 

--- a/Revit_Core_Engine/Query/IsOnFace.cs
+++ b/Revit_Core_Engine/Query/IsOnFace.cs
@@ -33,7 +33,7 @@ namespace BH.Revit.Engine.Core
 
         public static bool IsOnFace(this XYZ point, Face face, double tolerance)
         {
-            IntersectionResult ir = face.Project(point);
+            IntersectionResult ir = face?.Project(point);
             return ir != null && ir.Distance <= tolerance;
         }
 

--- a/Revit_Core_Engine/Query/IsOnFace.cs
+++ b/Revit_Core_Engine/Query/IsOnFace.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using System;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static bool IsOnFace(this XYZ point, Face face, double tolerance)
+        {
+            IntersectionResult ir = face.Project(point);
+            return ir != null && ir.Distance <= tolerance;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -309,6 +309,8 @@
     <Compile Include="Query\CableTraySectionProperty.cs" />
     <Compile Include="Query\DuctSectionProfile.cs" />
     <Compile Include="Query\DuctSectionProperty.cs" />
+    <Compile Include="Query\IsInside.cs" />
+    <Compile Include="Query\IsOnFace.cs" />
     <Compile Include="Query\Shape.cs" />
     <Compile Include="Query\MaterialTakeOff.cs" />
     <Compile Include="Query\PipeSectionProperty.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #931

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
_PushInstances.rvt_ and _PushInstances.gh_ from [this folder](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPush&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - I did my best to set up the tests in a granular, understandable way.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- update of IInstances improved to handle orientation and hosts
- minor refinements made to `Create.FamilyInstance` methods to fix the bugs caught when preparing the test scripts


### Additional comments
<!-- As required -->
@michaelhoehn @enarhi @tiagogrossi @AndreBalasian I believe it might be worth for you to have a look at `Create.FamilyInstance` methods, which is my attempt to tame one of the prime evils of Revit, family instance creation - I tried to structure the methods in a problem-agnostic manner, so that they could be reused by others to avoid the lottery related to the application of [`NewFamilyInstance`](https://www.revitapidocs.com/2020/4f835512-a922-c7da-d389-3bdcb41a5660.htm?section=methodTableToggle) method.