### PR TITLE
MEP element location curve query fixed

### DIFF
--- a/Revit_Core_Engine/Query/LocationCurve.cs
+++ b/Revit_Core_Engine/Query/LocationCurve.cs
@@ -393,9 +393,7 @@ namespace BH.Revit.Engine.Core
         [Output("locationCurveMEP", "BHoM lines list queried from the MEPCurve and its fitting connectors.")]
         public static List<BH.oM.Geometry.Line> LocationCurveMEP(this MEPCurve mepCurve, RevitSettings settings = null)
         {
-            bool dummyIsStartConnected = false;
-            bool dummyIsEndConnected = false;
-            return LocationCurveMEP(mepCurve, out dummyIsStartConnected, out dummyIsEndConnected, settings);
+            return new List<oM.Geometry.Line> { ((mepCurve?.Location as LocationCurve)?.Curve as Autodesk.Revit.DB.Line)?.FromRevit() };
         }
         
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #937

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
_PullPipes_, _PullRectangularDucts_ and _PullRoundDucts_ from [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPull&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
@tiagogrossi I have introduced the fix only to pipes and ducts, leaving cable trays untouched - taken you have tested them on more thoroughly.