### PR TITLE
Adding rebar ToRevit convert method

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Rebar.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Rebar.cs
@@ -50,7 +50,6 @@ namespace BH.Revit.Engine.Core
         public static Rebar ToRevitRebar(this PrimaryReinforcingBar bar, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
         {
             return ToRevitRebar((IReinforcingBar)bar, document, settings, refObjects);
-
         }
 
         /***************************************************/
@@ -113,7 +112,7 @@ namespace BH.Revit.Engine.Core
                 iListCurves.Add(list);                                                              //
 
             rebar = Rebar.CreateFreeForm(document, barType, host, iListCurves, out rffvr);
-            
+
             rebar.CopyParameters(bar, settings);
 
             refObjects.AddOrReplace(bar, rebar);

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Rebar.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Rebar.cs
@@ -77,8 +77,8 @@ namespace BH.Revit.Engine.Core
 
             //getting host
             Element host = null;
-            if (bar.CustomData.ContainsKey("host"))
-                host = document.GetElement(new ElementId((int)bar.CustomData["host"]));
+            if (bar.CustomData.ContainsKey("HostId"))
+                host = document.GetElement(new ElementId((int)bar.CustomData["HostId"]));
             else
             {
                 BH.Engine.Reflection.Compute.RecordError("One or more rebars does not contain information about the host.");
@@ -95,7 +95,7 @@ namespace BH.Revit.Engine.Core
             RebarBarType barType = bar.ElementType(document, settings);
             if (barType == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Revit project does not contain rebar family containing type with matching diameter for one or more rebars.");
+                BH.Engine.Reflection.Compute.RecordError($"Revit project does not contain rebar family containing type with matching diameter for one or more rebars.\nMissing Family: \"Rebar Bar : {(int)(bar.Diameter * 1000)}\"");
                 return null;
             }
 

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Rebar.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Rebar.cs
@@ -1,0 +1,134 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Structure;
+using BH.Engine.Adapters.Revit;
+using BH.Engine.Geometry;
+using BH.Engine.Reflection;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Geometry;
+using BH.oM.Physical.Reinforcement;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****            Interface methods              ****/
+        /***************************************************/
+
+        public static FamilyInstance IToRevitRebar(this IReinforcingBar reinforcement, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
+        {
+            return ToRevitRebar(reinforcement as dynamic, document, settings, refObjects);
+        }
+
+
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static Rebar ToRevitRebar(this PrimaryReinforcingBar bar, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
+        {
+            if (bar == null || document == null)
+                return null;
+
+            Rebar rebar = refObjects.GetValue<Rebar>(document, bar.BHoM_Guid);
+            if (rebar != null)
+                return rebar;
+
+            settings = settings.DefaultIfNull();
+
+            //getting bar type
+            string barTypeName = ((int)(bar.Diameter * 1000)).ToString();
+            RebarBarType barType = new FilteredElementCollector(document).OfClass(typeof(RebarBarType)).Where(x => x.Name == barTypeName).FirstOrDefault() as RebarBarType;
+            if (barType == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Revit project does not contain adequate rebar family for one or more rebars.");
+                return null;
+            }
+
+            //getting host
+            Element host = null;
+            try
+            {
+                host = document.GetElement(new ElementId((int)bar.CustomData["host"]));
+            }
+            catch (KeyNotFoundException e)
+            {
+                BH.Engine.Reflection.Compute.RecordError("One or more rebars does not contain information about the host.");
+                return null;
+            }
+            if (host == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("One or more selected hosts does not exist in the Revit project.");
+                return null;
+            }
+
+            //creating rebar
+            RebarFreeFormValidationResult rffvr = new RebarFreeFormValidationResult();
+                        
+            List<List<Curve>> curves = new List<List<Curve>> { bar.CentreCurve.IToRevitCurves() };  //
+            IList<IList<Curve>> iListCurves = new List<IList<Curve>>();                             // Needed to convert
+            foreach (List<Curve> list in curves)                                                    // List<List<Curve>> -> IList<IList<Curve>>
+                iListCurves.Add(list);                                                              //
+
+            rebar = Rebar.CreateFreeForm(document, barType, host, iListCurves, out rffvr);
+
+
+            rebar.CopyParameters(bar, settings);
+            rebar.SetLocation(bar, settings);
+
+            refObjects.AddOrReplace(bar, rebar);
+            return rebar;
+        }
+
+        /***************************************************/
+
+        public static Rebar ToRevitRebar(this Stirrup reinforcement, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
+        {
+            if (reinforcement == null || document == null)
+                return null;
+
+            Rebar rebar = refObjects.GetValue<Rebar>(document, reinforcement.BHoM_Guid);
+            if (rebar != null)
+                return rebar;
+
+            settings = settings.DefaultIfNull();
+            
+            //     //
+            // WIP //
+            //     //
+
+            rebar.CopyParameters(reinforcement, settings);
+            rebar.SetLocation(reinforcement, settings);
+
+            refObjects.AddOrReplace(reinforcement, rebar);
+            return rebar;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Convert/ToRevit.cs
+++ b/Revit_Core_Engine/Convert/ToRevit.cs
@@ -175,7 +175,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static Element ToRevit(this oM.Physical.Reinforcement.IReinforcingBar reinforcement, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
+        public static Element ToRevit(this BH.oM.Physical.Reinforcement.IReinforcingBar reinforcement, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
         {
             return reinforcement.IToRevitRebar(document, settings, refObjects);
         }

--- a/Revit_Core_Engine/Convert/ToRevit.cs
+++ b/Revit_Core_Engine/Convert/ToRevit.cs
@@ -27,7 +27,6 @@ using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using System;
 using System.Collections.Generic;
-using BH.oM.Physical.Materials;
 
 namespace BH.Revit.Engine.Core
 {
@@ -125,7 +124,7 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
-  
+
         public static Element ToRevit(this BH.oM.Environment.Elements.Space space, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
         {
             return space.ToRevitSpace(document, settings, refObjects);
@@ -179,6 +178,7 @@ namespace BH.Revit.Engine.Core
         {
             return reinforcement.IToRevitRebar(document, settings, refObjects);
         }
+
 
         /***************************************************/
         /****             Disallowed Types              ****/

--- a/Revit_Core_Engine/Convert/ToRevit.cs
+++ b/Revit_Core_Engine/Convert/ToRevit.cs
@@ -174,6 +174,13 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        public static Element ToRevit(this oM.Physical.Reinforcement.IReinforcingBar reinforcement, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
+        {
+            return reinforcement.IToRevitRebar(document, settings, refObjects);
+        }
+
+        /***************************************************/
         /****             Disallowed Types              ****/
         /***************************************************/
 

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -21,6 +21,7 @@
  */
 
 using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Structure;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
@@ -62,6 +63,20 @@ namespace BH.Revit.Engine.Core
         public static RoofType ElementType(this BH.oM.Physical.Elements.Roof roof, Document document, RevitSettings settings = null)
         {
             return roof.ElementType<RoofType>(document);
+        }
+
+        /***************************************************/
+
+        public static RebarBarType ElementType(this oM.Physical.Reinforcement.IReinforcingBar bar, Document document, RevitSettings settings = null)
+        {
+            RebarBarType result = bar.ElementType<RebarBarType>(document);
+            if (result == null)
+            {
+                string barTypeName = ((int)(bar.Diameter * 1000)).ToString();
+                return new FilteredElementCollector(document).OfClass(typeof(RebarBarType)).Where(x => x.Name == barTypeName).FirstOrDefault() as RebarBarType;
+            }
+
+            return result;
         }
 
         /***************************************************/
@@ -118,7 +133,7 @@ namespace BH.Revit.Engine.Core
                 else
                     return settings.FamilyLoadSettings.LoadFamilySymbol(document, null, familyName, familyTypeName);
             }
-            
+
             return null;
         }
 

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -310,6 +310,7 @@
     <Compile Include="Convert\MEP\ToRevit\ElementType.cs" />
     <Compile Include="Convert\Physical\ToRevit\ElementType.cs" />
     <Compile Include="Convert\Revit\Internal\ToSolid.cs" />
+    <Compile Include="Convert\Physical\ToRevit\Rebar.cs" />
     <Compile Include="Create\FamilyInstance.cs" />
     <Compile Include="Create\ReferencePlane.cs" />
     <Compile Include="Query\CableTraySectionProfile.cs" />


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #955 

<!-- Add short description of what has been fixed -->
Adding simple `ToRevit` convert for `IReinforcementBar` physical objects and inheritors.

### Test files
<!-- Link to test files to validate the proposed changes -->
[SharePoint](https://burohappold.sharepoint.com/:f:/s/BHoM/EtVrncjlGQdPozEOFd1ff5EBdXaTDelq9rWUimR1V0uQWg?e=l4ZaaJ)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Adding `ToRevitRebar` methods for `IReinforcementBar` interface to the `Revit_Core_Engine` project.

### Additional comments
<!-- As required -->
See [comment below](https://github.com/BHoM/Revit_Toolkit/pull/956#issuecomment-777579118).