### PR TITLE
Opening surface edge case bug fixed

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
@@ -57,9 +57,12 @@ namespace BH.Revit.Engine.Core
             if (location == null)
             {
                 if (host == null)
-                    BH.Engine.Reflection.Compute.RecordError(String.Format("Location of the door could not be retrieved from the model (possibly it has zero area or lies on a non-planar face). A door object without location has been returned. Revit ElementId: {0}", familyInstance.Id.IntegerValue));
+                    BH.Engine.Reflection.Compute.RecordWarning(String.Format("Location of the door could not be retrieved from the model (possibly it has zero area or lies on a non-planar face). A door object without location has been returned. Revit ElementId: {0}", familyInstance.Id.IntegerValue));
                 else
+                {
+                    BH.Engine.Reflection.Compute.RecordWarning(String.Format("Location of the door could not be retrieved from the model (possibly it has zero area or lies on a non-planar face), the opening has been skipped. Revit ElementId: {0}", familyInstance.Id.IntegerValue));
                     return null;
+                }
             }
 
             door = new Door { Location = location, Name = familyInstance.FamilyTypeFullName() };

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
@@ -57,9 +57,12 @@ namespace BH.Revit.Engine.Core
             if (location == null)
             {
                 if (host == null)
-                    BH.Engine.Reflection.Compute.RecordError(String.Format("Location of the window could not be retrieved from the model (possibly it has zero area or lies on a non-planar face). A window object without location has been returned. Revit ElementId: {0}", familyInstance.Id.IntegerValue));
+                    BH.Engine.Reflection.Compute.RecordWarning(String.Format("Location of the window could not be retrieved from the model (possibly it has zero area or lies on a non-planar face). A window object without location has been returned. Revit ElementId: {0}", familyInstance.Id.IntegerValue));
                 else
+                {
+                    BH.Engine.Reflection.Compute.RecordWarning(String.Format("Location of the window could not be retrieved from the model (possibly it has zero area or lies on a non-planar face), the opening has been skipped. Revit ElementId: {0}", familyInstance.Id.IntegerValue));
                     return null;
+                }
             }
 
             window = new Window { Location = location, Name = familyInstance.FamilyTypeFullName() };

--- a/Revit_Core_Engine/Query/OpeningSurface.cs
+++ b/Revit_Core_Engine/Query/OpeningSurface.cs
@@ -213,11 +213,16 @@ namespace BH.Revit.Engine.Core
             }
             catch
             {
-                BH.Engine.Reflection.Compute.RecordError(String.Format("Geometrical processing of a Revit element failed due to an internal Revit error. Converted opening might be missing one or more of its surfaces. Revit ElementId: {0}", familyInstance.Id));
+                loops = null;
             }
 
             t.RollBack(failureHandlingOptions);
-            surfaces.AddRange(loops.Select(x => new PlanarSurface(x.FromRevit(), null)));
+
+            if (loops != null)
+                surfaces.AddRange(loops.Select(x => new PlanarSurface(x.FromRevit(), null)));
+            else if (surfaces.Count != 0)
+                BH.Engine.Reflection.Compute.RecordWarning(String.Format("Geometrical processing of a Revit element failed due to an internal Revit error. Converted opening might be missing one or more of its surfaces. Revit ElementId: {0}", familyInstance.Id));
+
             return surfaces;
         }
 


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #960

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FRevit%5FToolkit%2F%23960%2DOpeningSurfaceBugVol2&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)- both pull of a wall with corrupted opening as well as the opening itself are tested in order to show how the warnings are managed.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- opening surface edge case bug fixed


### Additional comments
<!-- As required -->