### PR TITLE
Added mechanism to ensure the family type is activated before being used

### DIFF
--- a/Revit_Core_Engine/Compute/Activate.cs
+++ b/Revit_Core_Engine/Compute/Activate.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static void Activate(this ElementType elementType)
+        {
+            FamilySymbol familySymbol = elementType as FamilySymbol;
+            if (familySymbol != null && !familySymbol.IsActive)
+                familySymbol.Activate();
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -95,7 +95,10 @@ namespace BH.Revit.Engine.Core
 
             ElementType elementType = document.ElementType<ElementType>(familyName, familyTypeName, builtInCategories);
             if (elementType != null)
+            {
+                elementType.Activate();
                 return elementType;
+            }
 
             //Find ElementType in FamilyLibrary
             if (settings.FamilyLoadSettings?.FamilyLibrary?.Files != null)

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -290,6 +290,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\Activate.cs" />
     <Compile Include="Compute\Errors.cs" />
     <Compile Include="Convert\Architecture\FromRevit\Room.cs" />
     <Compile Include="Convert\MEP\FromRevit\CableTray.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #957

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FRevit%5FToolkit%2F%23957%2DActivateFamilySymbol&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added mechanism to ensure the family type is activated before being used


### Additional comments
<!-- As required -->