### PR TITLE
Removal of FilterTypesOfFamily reverted

### DIFF
--- a/Revit_Engine/Create/Requests/FilterTypesOfFamily.cs
+++ b/Revit_Engine/Create/Requests/FilterTypesOfFamily.cs
@@ -1,0 +1,54 @@
+﻿/*	
+ * This file is part of the Buildings and Habitats object Model (BHoM)	
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.	
+ *	
+ * Each contributor holds copyright over their respective contributions.	
+ * The project versioning (Git) records all such contribution source information.	
+ *                                           	
+ *                                                                              	
+ * The BHoM is free software: you can redistribute it and/or modify         	
+ * it under the terms of the GNU Lesser General Public License as published by  	
+ * the Free Software Foundation, either version 3.0 of the License, or          	
+ * (at your option) any later version.                                          	
+ *                                                                              	
+ * The BHoM is distributed in the hope that it will be useful,              	
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               	
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 	
+ * GNU Lesser General Public License for more details.                          	
+ *                                                                            	
+ * You should have received a copy of the GNU Lesser General Public License     	
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      	
+ */
+
+using BH.oM.Adapters.Revit.Requests;
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.ComponentModel;
+
+namespace BH.Engine.Adapters.Revit
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Creates IRequest that filters Revit Family Types of input Family.")]
+        [Input("bHoMObject", "BHoMObject that contains ElementId of a correspondent Revit element in RevitIdentifiers fragment attached to it - usually previously pulled from Revit.")]
+        [Output("request", "Created request.")]
+        public static FilterTypesOfFamily FilterTypesOfFamily(IBHoMObject bHoMObject)
+        {
+            int elementId = bHoMObject.ElementId();
+            if (elementId == -1)
+            {
+                BH.Engine.Reflection.Compute.RecordError(String.Format("Valid ElementId has not been found. BHoM Guid: {0}", bHoMObject.BHoM_Guid));
+                return null;
+            }
+            else
+                return new FilterTypesOfFamily { FamilyId = elementId };
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Create\Requests\FilterRequest.cs" />
     <Compile Include="Create\Requests\FilterByElementIds.cs" />
     <Compile Include="Create\Requests\FilterByParameterElementId.cs" />
+    <Compile Include="Create\Requests\FilterTypesOfFamily.cs" />
     <Compile Include="Create\Requests\FilterViewByName.cs" />
     <Compile Include="Create\Requests\FilterViewsByType.cs" />
     <Compile Include="Create\Requests\FilterViewTemplateByName.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #969

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FRevit%5FToolkit%2F%23969%2DFilterTypesOfFamily&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- removal of FilterTypesOfFamily reverted

### Additional comments
<!-- As required -->
The code should work fine as it got copy-pasted from the [last moment when it was present in the code base](https://github.com/BHoM/Revit_Toolkit/commit/7c1d77c385eed89205526ec13a0dd017c0ff7a47).