### PR TITLE
Pull from links partially enabled

### DIFF
--- a/Revit_Core_Adapter/CRUD/Delete.cs
+++ b/Revit_Core_Adapter/CRUD/Delete.cs
@@ -23,8 +23,10 @@
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using BH.Engine.Adapters.Revit;
+using BH.Engine.Data;
 using BH.oM.Adapter;
 using BH.oM.Adapters.Revit;
+using BH.oM.Adapters.Revit.Requests;
 using BH.oM.Base;
 using BH.oM.Data.Requests;
 using BH.Revit.Engine.Core;
@@ -44,10 +46,16 @@ namespace BH.Revit.Adapter.Core
         {
             if (request == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("BHoM objects could not be read because provided IRequest is null.");
+                BH.Engine.Reflection.Compute.RecordError("Deletion could not be executed because provided IRequest is null.");
                 return 0;
             }
-            
+
+            if (request.AllRequestsOfType(typeof(FilterByLink)).Count != 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"It is not allowed to remove objects from Revit links - please remove the requests of type {nameof(FilterByLink)} from the request.");
+                return 0;
+            }
+
             Document document = this.Document;
             RevitRemoveConfig removeConfig = actionConfig as RevitRemoveConfig;
 

--- a/Revit_Core_Adapter/CRUD/Delete.cs
+++ b/Revit_Core_Adapter/CRUD/Delete.cs
@@ -47,8 +47,7 @@ namespace BH.Revit.Adapter.Core
                 BH.Engine.Reflection.Compute.RecordError("BHoM objects could not be read because provided IRequest is null.");
                 return 0;
             }
-
-            UIDocument uiDocument = this.UIDocument;
+            
             Document document = this.Document;
             RevitRemoveConfig removeConfig = actionConfig as RevitRemoveConfig;
 
@@ -56,7 +55,7 @@ namespace BH.Revit.Adapter.Core
             if (!removeConfig.IncludeClosedWorksets)
                 worksetPrefilter = document.ElementIdsByWorksets(document.OpenWorksetIds().Union(document.SystemWorksetIds()).ToList());
 
-            IEnumerable<ElementId> elementIds = request.IElementIds(uiDocument, worksetPrefilter).RemoveGridSegmentIds(document);
+            IEnumerable<ElementId> elementIds = request.IElementIds(document, worksetPrefilter).RemoveGridSegmentIds(document);
 
             List<ElementId> deletedIds = Delete(elementIds, document, removeConfig.RemovePinned);
             if (deletedIds == null)

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -73,7 +73,7 @@ namespace BH.Revit.Adapter.Core
             if (discipline == Discipline.Undefined)
                 discipline = Discipline.Physical;
 
-            Dictionary<RevitLinkInstance, IRequest> requestsByLinks = request.SplitRequestTreeByLinks(this.Document);
+            Dictionary<Document, IRequest> requestsByLinks = request.SplitRequestTreeByLinks(this.Document);
             if (requestsByLinks == null)
             {
                 BH.Engine.Reflection.Compute.RecordError("Pull failed due to issues with the request tree. Please try to simplify the used Request and try again.");
@@ -95,18 +95,15 @@ namespace BH.Revit.Adapter.Core
             Options renderMeshOptions = BH.Revit.Engine.Core.Create.Options(representationConfig.DetailLevel.ViewDetailLevel(), representationConfig.IncludeNonVisible, false);
 
             List<IBHoMObject> result = new List<IBHoMObject>();
-            foreach (KeyValuePair<RevitLinkInstance, IRequest> requestByLink in requestsByLinks)
+            foreach (KeyValuePair<Document, IRequest> requestByLink in requestsByLinks)
             {
-                Document document;
+                Document document = requestByLink.Key;
                 TransformMatrix transform = null;
-                if (requestByLink.Key == null)
+
+                if (document != this.Document)
                 {
-                    document = this.Document;
-                }
-                else
-                {
-                    document = requestByLink.Key.GetLinkDocument();
-                    transform = requestByLink.Key.GetTotalTransform().FromRevit();
+                    RevitLinkInstance linkInstance = new FilteredElementCollector(this.Document).OfClass(typeof(RevitLinkInstance)).Cast<RevitLinkInstance>().FirstOrDefault(x => x.GetLinkDocument().Title == document.Title);
+                    transform = linkInstance.GetTotalTransform().FromRevit();
                 }
 
                 //TODO: WRAP THIS INTO A SEPARATE METHOD FROM HERE!

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -114,7 +114,7 @@ namespace BH.Revit.Adapter.Core
                 if (!pullConfig.IncludeClosedWorksets)
                     worksetPrefilter = document.ElementIdsByWorksets(document.OpenWorksetIds().Union(document.SystemWorksetIds()).ToList());
 
-                List<ElementId> elementIds = requestByLink.Value.IElementIds(new UIDocument(document), worksetPrefilter).RemoveGridSegmentIds(document).ToList<ElementId>();
+                List<ElementId> elementIds = requestByLink.Value.IElementIds(document, worksetPrefilter).RemoveGridSegmentIds(document).ToList<ElementId>();
                 if (elementIds == null)
                     return new List<IBHoMObject>();
 

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -76,7 +76,7 @@ namespace BH.Revit.Adapter.Core
             Dictionary<Document, IRequest> requestsByLinks = request.SplitRequestTreeByLinks(this.Document);
             if (requestsByLinks == null)
             {
-                BH.Engine.Reflection.Compute.RecordError($"Pull failed due to issues with the request containing {nameof(FilterByLink)}. Please try to simplify the used Request and try again.");
+                BH.Engine.Reflection.Compute.RecordError($"Pull failed due to issues with the request containing {nameof(FilterByLink)}. Please try to restructure the used Request and try again.");
                 return new List<IBHoMObject>();
             }
 

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -111,7 +111,7 @@ namespace BH.Revit.Adapter.Core
                 UIApplication uiApp = new UIApplication(document.Application);
                 Document mainDoc = uiApp.ActiveUIDocument.Document;
                 RevitLinkInstance linkInstance = new FilteredElementCollector(mainDoc).OfClass(typeof(RevitLinkInstance)).Cast<RevitLinkInstance>().FirstOrDefault(x => x.GetLinkDocument().Title == document.Title);
-                linkTransform = linkInstance.GetTotalTransform();
+                linkTransform = linkInstance.GetTotalTransform().Inverse;
                 bHoMTransform = linkTransform.FromRevit();
             }
 

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -76,7 +76,7 @@ namespace BH.Revit.Adapter.Core
             Dictionary<Document, IRequest> requestsByLinks = request.SplitRequestTreeByLinks(this.Document);
             if (requestsByLinks == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Pull failed due to issues with the request tree. Please try to simplify the used Request and try again.");
+                BH.Engine.Reflection.Compute.RecordError($"Pull failed due to issues with the request containing {nameof(FilterByLink)}. Please try to simplify the used Request and try again.");
                 return new List<IBHoMObject>();
             }
 

--- a/Revit_Core_Adapter/Revit_Core_Adapter.csproj
+++ b/Revit_Core_Adapter/Revit_Core_Adapter.csproj
@@ -138,6 +138,11 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Data_Engine">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Data_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
@@ -152,7 +157,7 @@
     </Reference>
     <Reference Include="Physical_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="Reflection_Engine">
@@ -353,7 +358,7 @@
 	</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug2021' Or '$(Configuration)'=='Release2021'">
-	<PostBuildEvent>
+    <PostBuildEvent>
 		C:\Windows\System32\xcopy "$(ProjectDir)Listener\Files\BHoM_2021.Addin" "C:\Users\$(Username)\AppData\Roaming\Autodesk\Revit\Addins\2021\" /Y /I /E
 		xcopy "$(TargetDir)$(TargetFileName)" "C:\\ProgramData\\BHoM\\Assemblies" /Y
 		xcopy "$(TargetDir)Listener\Files\Resources"  "C:\ProgramData\BHoM\Resources\Revit" /Y /I /E

--- a/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
+++ b/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
@@ -112,16 +112,16 @@ namespace BH.Engine.Adapters.Revit
                 bool fullPath = linkName.Contains("\\");
                 List<Document> validDocs;
                 if (fullPath)
-                    validDocs = linkDocuments.Where(x => x.PathName.ToLower() == linkRequest.LinkName).ToList();
+                    validDocs = linkDocuments.Where(x => x.PathName.ToLower() == linkName).ToList();
                 else
-                    validDocs = linkDocuments.Where(x => x.Title.ToLower() == linkRequest.LinkName).ToList();
+                    validDocs = linkDocuments.Where(x => x.Title.ToLower() == linkName).ToList();
 
                 if (validDocs.Count == 0)
                 {
                     if (fullPath)
-                        BH.Engine.Reflection.Compute.RecordError($"Active Revit document does not contain link under path {linkName}.");
+                        BH.Engine.Reflection.Compute.RecordError($"Active Revit document does not contain link under path {linkRequest.LinkName}.");
                     else
-                        BH.Engine.Reflection.Compute.RecordError($"Active Revit document does not contain link named {linkName}.");
+                        BH.Engine.Reflection.Compute.RecordError($"Active Revit document does not contain link named {linkRequest.LinkName}.");
 
                     return false;
                 }

--- a/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
+++ b/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
@@ -1,0 +1,224 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+ 
+using Autodesk.Revit.DB;
+using BH.Engine.Data;
+using BH.oM.Adapters.Revit.Requests;
+using BH.oM.Data.Requests;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Engine.Adapters.Revit
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****              Public Methods               ****/
+        /***************************************************/
+
+        //[Description("Groups and sorts IRequests by their estimated execution time in order to execute fastest first. Order from slowest to fastest: IParameterRequest, IlogicalRequests, others. ")]
+        //[Input("requests", "A collection of IRequests to be sorted.")]
+        //[Output("sortedRequests")]
+        public static Dictionary<RevitLinkInstance, IRequest> SplitRequestTreeByLinks(this IRequest request, Document document)
+        {
+            IEnumerable<RevitLinkInstance> linkInstances = new FilteredElementCollector(document).OfClass(typeof(RevitLinkInstance)).Cast<RevitLinkInstance>();
+            Dictionary<string, RevitLinkInstance> linkInstancesByNames = linkInstances.ToDictionary(x => (document.GetElement(x.GetTypeId()) as RevitLinkType)?.Name?.ToLower(), x => x);
+
+            Dictionary<RevitLinkInstance, IRequest> requestsByLinks = new Dictionary<RevitLinkInstance, IRequest>();
+            List<IRequest> splitPerDoc = request.SplitRequestTreeByType(typeof(FilterByLink));
+            foreach (IRequest splitRequest in splitPerDoc)
+            {
+                if (!splitRequest.TryOrganizeByLink(linkInstancesByNames, requestsByLinks))
+                    return null;
+            }
+
+            return requestsByLinks;
+        }
+
+
+        /***************************************************/
+        /****              Private Methods              ****/
+        /***************************************************/
+
+        private static bool TryOrganizeByLink(this IRequest request, Dictionary<string, RevitLinkInstance> linkInstancesByNames, Dictionary<RevitLinkInstance, IRequest> requestsByLinks)
+        {
+            if (request == null)
+                return false;
+
+            if (request is FilterByLink)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"It is not allowed to pull from links without any filtering (IRequest of type {nameof(FilterByLink)} needs to be wrapped into a {nameof(LogicalAndRequest)} with at least one more request).");
+                return false;
+            }
+            else if (!request.IsValidToOrganize())
+                return false;
+
+            List<IRequest> linkRequests = request.AllRequestsOfType(typeof(FilterByLink));
+            if (linkRequests.Count == 0)
+            {
+                requestsByLinks.AddRequestByLink(request, null);
+                return true;
+            }
+            else if (linkRequests.Count == 1)
+            {
+                if (request.AllRequestsOfType(typeof(SelectionRequest)).Count != 0)
+                {
+                    BH.Engine.Reflection.Compute.RecordError("It is not allowed to combine selection requests with link requests - Revit selection does not work with links.");
+                    return false;
+                }
+
+                FilterByLink linkRequest = (FilterByLink)linkRequests[0];
+                string linkName = linkRequest.LinkName.ToLower(); ;
+                if (!linkName.EndsWith(".rvt"))
+                {
+                    BH.Engine.Reflection.Compute.RecordWarning($"Link name {linkName} inside a link request does not end with .rvt - the suffix has been added.");
+                    linkName += ".rvt";
+                }
+
+                RevitLinkInstance linkInstance;
+                if (!linkInstancesByNames.ContainsKey(linkName))
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"Active Revit document does not contain link named {linkName}.");
+                    return false;
+                }
+                else
+                    linkInstance = linkInstancesByNames[linkName];
+
+                request.RemoveSubRequest(linkRequest);
+                request = request.SimplifyRequestTree();
+                requestsByLinks.AddRequestByLink(request, linkInstance);
+
+                return true;
+            }
+            else
+                return false;
+        }
+
+        /***************************************************/
+
+        private static void AddRequestByLink(this Dictionary<RevitLinkInstance, IRequest> requestsByLinks, IRequest request, RevitLinkInstance linkInstance)
+        {
+            if (requestsByLinks.ContainsKey(linkInstance))
+            {
+                IRequest requestByLink = requestsByLinks[linkInstance];
+                if (requestByLink is LogicalOrFilter)
+                    ((LogicalOrRequest)requestByLink).Requests.Add(request);
+                else
+                {
+                    LogicalOrRequest newHead = new LogicalOrRequest();
+                    newHead.Requests.Add(requestByLink);
+                    newHead.Requests.Add(request);
+                    requestsByLinks[linkInstance] = newHead;
+                }
+            }
+            else
+                requestsByLinks[linkInstance] = request;
+        }
+
+        /***************************************************/
+
+        private static bool RemoveSubRequest(this IRequest requestTree, IRequest toRemove)
+        {
+            if (requestTree is LogicalNotRequest)
+            {
+                LogicalNotRequest logical = (LogicalNotRequest)requestTree;
+                if (logical.Request == toRemove)
+                {
+                    logical.Request = null;
+                    return true;
+                }
+                else
+                    return logical.Request.RemoveSubRequest(toRemove);
+            }
+            else if (requestTree is ILogicalRequest)
+            {
+                ILogicalRequest logical = (ILogicalRequest)requestTree;
+                List<IRequest> subRequests = logical.IRequests();
+                if (subRequests.Contains(toRemove))
+                {
+                    subRequests.Remove(toRemove);
+                    return true;
+                }
+                else
+                {
+                    foreach (IRequest subRequest in subRequests)
+                    {
+                        bool removed = subRequest.RemoveSubRequest(toRemove);
+                        if (removed)
+                            return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /***************************************************/
+
+        private static bool IsValidToOrganize(this IRequest request)
+        {
+            if (request is LogicalNotRequest)
+            {
+                IRequest subRequest = ((LogicalNotRequest)request).Request;
+                if (subRequest == null)
+                    return false;
+
+                if (subRequest.GetType() == typeof(FilterByLink))
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"It is not allowed to wrap IRequests of type {nameof(FilterByLink)} into a {nameof(LogicalNotRequest)} request.");
+                    return false;
+                }
+                else if (subRequest.AllRequestsOfType(typeof(LogicalNotRequest)).Count != 0)
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"A chain of nested {nameof(LogicalNotRequest)}s has been detected, which is not allowed.");
+                    return false;
+                }
+                else if (subRequest.AllRequestsOfType(typeof(FilterByLink)).Count != 0)
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"A {nameof(FilterByLink)} nested in {nameof(LogicalNotRequest)} has been detected, which is not allowed.");
+                    return false;
+                }
+                else
+                    return subRequest.IsValidToOrganize();
+            }
+            else if (request is ILogicalRequest)
+            {
+                List<IRequest> subRequests = ((ILogicalRequest)request).IRequests();
+                if (subRequests.Any(x => x.GetType() == typeof(FilterByLink))
+                    && (request is LogicalOrRequest || (request is LogicalAndRequest && subRequests.Count == 1)))
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"It is not allowed to pull from links without any filtering (IRequest of type {nameof(FilterByLink)} needs to be wrapped into a {nameof(LogicalAndRequest)}).");
+                    return false;
+                }
+
+                return subRequests.All(x => x.IsValidToOrganize());
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
+++ b/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
@@ -112,9 +112,9 @@ namespace BH.Engine.Adapters.Revit
                 bool fullPath = linkName.Contains("\\");
                 List<Document> validDocs;
                 if (fullPath)
-                    validDocs = linkDocuments.Where(x => x.PathName.ToLower() == linkName).ToList();
+                    validDocs = linkDocuments.Where(x => x.PathName.ToLower() == linkRequest.LinkName).ToList();
                 else
-                    validDocs = linkDocuments.Where(x => x.Title.ToLower() == linkName).ToList();
+                    validDocs = linkDocuments.Where(x => x.Title.ToLower() == linkRequest.LinkName).ToList();
 
                 if (validDocs.Count == 0)
                 {

--- a/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
+++ b/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
@@ -89,6 +89,18 @@ namespace BH.Engine.Adapters.Revit
                     return false;
                 }
 
+                if (request.AllRequestsOfType(typeof(FilterByActiveWorkset)).Count != 0)
+                {
+                    BH.Engine.Reflection.Compute.RecordError("It is not allowed to combine active workset requests with link requests - Revit selection does not work with links.");
+                    return false;
+                }
+
+                if (request.AllRequestsOfType(typeof(FilterActiveView)).Count != 0)
+                {
+                    BH.Engine.Reflection.Compute.RecordError("It is not allowed to combine active view requests with link requests - Revit selection does not work with links.");
+                    return false;
+                }
+
                 FilterByLink linkRequest = (FilterByLink)linkRequests[0];
                 string linkName = linkRequest.LinkName.ToLower(); ;
                 if (!linkName.EndsWith(".rvt"))

--- a/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
+++ b/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
@@ -38,9 +38,10 @@ namespace BH.Engine.Adapters.Revit
         /****              Public Methods               ****/
         /***************************************************/
 
-        //[Description("Groups and sorts IRequests by their estimated execution time in order to execute fastest first. Order from slowest to fastest: IParameterRequest, IlogicalRequests, others. ")]
-        //[Input("requests", "A collection of IRequests to be sorted.")]
-        //[Output("sortedRequests")]
+        [Description("Decomposes a tree created by a set of nested ILogicalRequests into a dictionary of Revit documents (both host and linked) and the IRequests relevant to them, which in total represents the same request as the original IRequest.")]
+        [Input("request", "An IRequest to be split into a dictionary of Revit documents and the IRequests relevant to them.")]
+        [Input("document", "Host document to be used as the basis of the splitting routine.")]
+        [Output("splitRequests", "A dictionary of Revit documents (both host and linked) and the IRequests relevant to them, which in total represents the same request as the input IRequest.")]
         public static Dictionary<Document, IRequest> SplitRequestTreeByLinks(this IRequest request, Document document)
         {
             List<Document> linkDocs = new FilteredElementCollector(document).OfClass(typeof(RevitLinkInstance)).Cast<RevitLinkInstance>().Select(x=>x.GetLinkDocument()).ToList();

--- a/Revit_Core_Engine/Compute/Warnings.cs
+++ b/Revit_Core_Engine/Compute/Warnings.cs
@@ -499,6 +499,14 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        internal static void TransformNotImplementedWarning(this Element element)
+        {
+            BH.Engine.Reflection.Compute.RecordWarning($"Transform method has not been implemented in convert from {element.GetType()} to type BHoM.\n" +
+                                                        $"All elements of type {element.GetType()} coming from link {element.Document.Title} will be be pulled in coordinate system of the link, not the host model.");
+        }
+
+        /***************************************************/
     }
 }
 

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/EnergyAnalysisModel.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/EnergyAnalysisModel.cs
@@ -41,7 +41,7 @@ namespace BH.Revit.Engine.Core
         {
             if (energyAnalysisModel.Document.IsLinked)
             {
-                BH.Engine.Reflection.Compute.RecordError($"It is not allowed to pull the energy analysis model from link - please open the document {energyAnalysisModel.Document.PathName} and pull directly from it.");
+                BH.Engine.Reflection.Compute.RecordError($"It is not allowed to pull the energy analysis model from linked models - please open the document {energyAnalysisModel.Document.PathName} and pull directly from it instead.");
                 return null;
             }
 

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/EnergyAnalysisModel.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/EnergyAnalysisModel.cs
@@ -39,6 +39,12 @@ namespace BH.Revit.Engine.Core
 
         public static List<IBHoMObject> EnergyAnalysisModelFromRevit(this EnergyAnalysisDetailModel energyAnalysisModel, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (energyAnalysisModel.Document.IsLinked)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"It is not allowed to pull the energy analysis model from link - please open the document {energyAnalysisModel.Document.PathName} and pull directly from it.");
+                return null;
+            }
+
             settings = settings.DefaultIfNull();
 
             ElementId modelId = energyAnalysisModel.Id;

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -40,7 +40,7 @@ namespace BH.Revit.Engine.Core
         /****      Convert Revit elements to BHoM       ****/
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this ProjectInfo projectInfo, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this ProjectInfo projectInfo, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -53,7 +53,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IEnumerable<IBHoMObject> FromRevit(this EnergyAnalysisDetailModel energyAnalysisModel, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IEnumerable<IBHoMObject> FromRevit(this EnergyAnalysisDetailModel energyAnalysisModel, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -66,8 +66,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IEnumerable<IBHoMObject> FromRevit(this FamilyInstance familyInstance, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IEnumerable<IBHoMObject> FromRevit(this FamilyInstance familyInstance, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                familyInstance.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Structural:
@@ -98,7 +101,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this FamilySymbol familySymbol, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this FamilySymbol familySymbol, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -112,8 +115,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IEnumerable<IBHoMObject> FromRevit(this Wall wall, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IEnumerable<IBHoMObject> FromRevit(this Wall wall, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                wall.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Environmental:
@@ -130,8 +136,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IEnumerable<IBHoMObject> FromRevit(this Ceiling ceiling, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IEnumerable<IBHoMObject> FromRevit(this Ceiling ceiling, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                ceiling.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Environmental:
@@ -146,8 +155,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IEnumerable<IBHoMObject> FromRevit(this Floor floor, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IEnumerable<IBHoMObject> FromRevit(this Floor floor, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                floor.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Environmental:
@@ -164,8 +176,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IEnumerable<IBHoMObject> FromRevit(this RoofBase roofBase, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IEnumerable<IBHoMObject> FromRevit(this RoofBase roofBase, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                roofBase.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Environmental:
@@ -182,7 +197,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this HostObjAttributes hostObjAttributes, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this HostObjAttributes hostObjAttributes, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -205,8 +220,11 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("cableTrays", "Resulted list of BHoM cable trays converted from a Revit cable trays.")]
-        public static List<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Electrical.CableTray cableTray, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static List<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Electrical.CableTray cableTray, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                cableTray.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Architecture:
@@ -226,8 +244,11 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("ducts", "Resulted list of BHoM ducts converted from a Revit ducts.")]
-        public static List<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Mechanical.Duct duct, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static List<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Mechanical.Duct duct, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                duct.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Architecture:
@@ -247,8 +268,11 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("pipes", "Resulted list of BHoM MEP pipes converted from a Revit pipes.")]
-        public static List<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Plumbing.Pipe pipe, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static List<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Plumbing.Pipe pipe, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                pipe.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Architecture:
@@ -268,8 +292,11 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("wire", "BHoM wire converted from a Revit wire.")]
-        public static IBHoMObject FromRevit(this Autodesk.Revit.DB.Electrical.Wire wire, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this Autodesk.Revit.DB.Electrical.Wire wire, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                wire.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Architecture:
@@ -283,8 +310,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this Level level, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this Level level, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                level.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 default:
@@ -294,8 +324,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this Grid grid, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this Grid grid, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                grid.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 default:
@@ -305,8 +338,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this MultiSegmentGrid grid, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this MultiSegmentGrid grid, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                grid.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 default:
@@ -316,7 +352,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this ElementType elementType, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this ElementType elementType, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -327,7 +363,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this GraphicsStyle graphicStyle, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this GraphicsStyle graphicStyle, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -338,8 +374,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this SpatialElement spatialElement, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this SpatialElement spatialElement, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                spatialElement.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Environmental:
@@ -354,8 +393,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this EnergyAnalysisSpace energyAnalysisSpace, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this EnergyAnalysisSpace energyAnalysisSpace, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                energyAnalysisSpace.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Environmental:
@@ -369,8 +411,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this EnergyAnalysisSurface energyAnalysisSurface, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this EnergyAnalysisSurface energyAnalysisSurface, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                energyAnalysisSurface.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Environmental:
@@ -384,8 +429,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this EnergyAnalysisOpening energyAnalysisOpening, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this EnergyAnalysisOpening energyAnalysisOpening, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (transform?.IsIdentity == false)
+                energyAnalysisOpening.TransformNotImplementedWarning();
+
             switch (discipline)
             {
                 case Discipline.Environmental:
@@ -399,7 +447,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this ViewSheet viewSheet, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this ViewSheet viewSheet, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -410,7 +458,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this Viewport viewport, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this Viewport viewport, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -421,7 +469,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this ViewPlan viewPlan, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this ViewPlan viewPlan, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -432,7 +480,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this Material material, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this Material material, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -449,7 +497,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this Family family, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this Family family, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -460,8 +508,12 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this CurveElement curveElement, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this CurveElement curveElement, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
+            if (!curveElement.ViewSpecific && transform?.IsIdentity == false)
+                curveElement.TransformNotImplementedWarning();
+
+
             switch (discipline)
             {
                 default:
@@ -471,7 +523,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this FilledRegion filledRegion, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this FilledRegion filledRegion, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
             {
@@ -485,7 +537,7 @@ namespace BH.Revit.Engine.Core
         /****             Fallback Methods              ****/
         /***************************************************/
 
-        public static IBHoMObject FromRevit(this Element element, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IBHoMObject FromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             return null;
         }
@@ -502,7 +554,7 @@ namespace BH.Revit.Engine.Core
         /****             Interface Methods             ****/
         /***************************************************/
 
-        public static object IFromRevit(this Element element, Discipline discipline, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static object IFromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             if (element == null)
             {
@@ -510,7 +562,9 @@ namespace BH.Revit.Engine.Core
                 return null;
             }
 
-            var result = FromRevit(element as dynamic, discipline, settings, refObjects);
+            //material, family, elementType, view, graphicsStyle
+
+            var result = FromRevit(element as dynamic, discipline, transform, settings, refObjects);
             if (result == null || (typeof(IEnumerable<object>).IsAssignableFrom(result.GetType()) && ((IEnumerable<object>)result).Count(x => x != null) == 0))
             {
                 result = element.ObjectFromRevit(discipline, settings, refObjects);

--- a/Revit_Core_Engine/Query/CeilingPattern.cs
+++ b/Revit_Core_Engine/Query/CeilingPattern.cs
@@ -39,6 +39,12 @@ namespace BH.Revit.Engine.Core
 
         public static List<BH.oM.Geometry.Line> CeilingPattern(this Ceiling ceiling, RevitSettings settings, PlanarSurface surface = null)
         {
+            if (ceiling.Document.IsLinked)
+            {
+                BH.Engine.Reflection.Compute.RecordWarning($"It is not allowed to pull the ceiling patterns from linked models - please open the document {ceiling.Document.PathName} and pull directly from it instead.");
+                return new List<oM.Geometry.Line>();
+            }
+
             CeilingType ceilingType = ceiling.Document.GetElement(ceiling.GetTypeId()) as CeilingType;
             CompoundStructure comStruct = ceilingType.GetCompoundStructure();
 

--- a/Revit_Core_Engine/Query/Curves.cs
+++ b/Revit_Core_Engine/Query/Curves.cs
@@ -33,9 +33,9 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        public static List<Curve> Curves(this Element element, Options options, RevitSettings settings = null, bool includeEdges = false)
+        public static List<Curve> Curves(this Element element, Options options, Transform transform = null, RevitSettings settings = null, bool includeEdges = false)
         {
-            List<GeometryObject> geometryPrimitives = element.GeometryPrimitives(options, settings);
+            List<GeometryObject> geometryPrimitives = element.GeometryPrimitives(options, transform, settings);
             if (geometryPrimitives == null)
                 return null;
 

--- a/Revit_Core_Engine/Query/ElementIds/ElementIds.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIds.cs
@@ -38,7 +38,7 @@ namespace BH.Revit.Engine.Core
         /****         Public methods - Requests         ****/
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterRequest request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterRequest request, Document document, IEnumerable<ElementId> ids = null)
         {
             IEnumerable<ElementId> elementIds = ids;
 
@@ -47,11 +47,11 @@ namespace BH.Revit.Engine.Core
             {
                 IList list = idObject as IList;
                 if (list != null)
-                    elementIds = uIDocument.Document.ElementIdsByIdObjects(list, elementIds);
+                    elementIds = document.ElementIdsByIdObjects(list, elementIds);
             }
 
             if (request.Type != null)
-                elementIds = uIDocument.Document.ElementIdsByBHoMType(request.Type, elementIds);
+                elementIds = document.ElementIdsByBHoMType(request.Type, elementIds);
 
             if (!string.IsNullOrWhiteSpace(request.Tag))
                 BH.Engine.Reflection.Compute.RecordError("Filtering based on tag declared in FilterRequest is currently not supported. The tag-related filter has not been applied.");
@@ -61,218 +61,218 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByElementIds request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByElementIds request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByInts(request.ElementIds, ids);
+            return document.ElementIdsByInts(request.ElementIds, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByUniqueIds request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByUniqueIds request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByUniqueIds(request.UniqueIds, ids);
+            return document.ElementIdsByUniqueIds(request.UniqueIds, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByCategory request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByCategory request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByCategory(request.CategoryName, request.CaseSensitive, ids);
+            return document.ElementIdsByCategory(request.CategoryName, request.CaseSensitive, ids);
         }
 
         /***************************************************/
         
-        public static IEnumerable<ElementId> ElementIds(this FilterByDBTypeName request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByDBTypeName request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByDBType("RevitAPI.dll", request.TypeName, ids);
+            return document.ElementIdsByDBType("RevitAPI.dll", request.TypeName, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByActiveWorkset request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByActiveWorkset request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByWorksets(new List<WorksetId> { uIDocument.Document.ActiveWorksetId() }, ids);
+            return document.ElementIdsByWorksets(new List<WorksetId> { document.ActiveWorksetId() }, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByWorkset request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByWorkset request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByWorksets(new List<WorksetId> { uIDocument.Document.WorksetId(request.WorksetName) }, ids);
+            return document.ElementIdsByWorksets(new List<WorksetId> { document.WorksetId(request.WorksetName) }, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this SelectionRequest request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this SelectionRequest request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.ElementIdsBySelection(ids);
+            return new UIDocument(document).ElementIdsBySelection(ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterBySelectionSet request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterBySelectionSet request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsBySelectionSet(request.SelectionSetName, true, ids);
+            return document.ElementIdsBySelectionSet(request.SelectionSetName, true, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByParameterExistence request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByParameterExistence request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByParameterExistence(request.ParameterName, request.ParameterExists, ids);
+            return document.ElementIdsByParameterExistence(request.ParameterName, request.ParameterExists, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByParameterBool request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByParameterBool request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByParameter(request.ParameterName, request.Value, ids);
+            return document.ElementIdsByParameter(request.ParameterName, request.Value, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByParameterElementId request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByParameterElementId request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByParameter(request.ParameterName, request.ElementId, ids);
+            return document.ElementIdsByParameter(request.ParameterName, request.ElementId, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByParameterInteger request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByParameterInteger request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByParameter(request.ParameterName, request.NumberComparisonType, request.Value, ids);
+            return document.ElementIdsByParameter(request.ParameterName, request.NumberComparisonType, request.Value, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByParameterNumber request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByParameterNumber request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByParameter(request.ParameterName, request.NumberComparisonType, request.Value, request.Tolerance, ids);
+            return document.ElementIdsByParameter(request.ParameterName, request.NumberComparisonType, request.Value, request.Tolerance, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByParameterText request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByParameterText request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByParameter(request.ParameterName, request.TextComparisonType, request.Value, ids);
+            return document.ElementIdsByParameter(request.ParameterName, request.TextComparisonType, request.Value, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByFamilyAndTypeName request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByFamilyAndTypeName request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByFamilyAndType(request.FamilyName, request.FamilyTypeName, request.CaseSensitive, ids);
+            return document.ElementIdsByFamilyAndType(request.FamilyName, request.FamilyTypeName, request.CaseSensitive, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByFamilyType request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByFamilyType request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByElementType(request.FamilyTypeId, ids);
+            return document.ElementIdsByElementType(request.FamilyTypeId, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterFamilyTypeByName request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterFamilyTypeByName request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfFamilyTypes(request.FamilyName, request.FamilyTypeName, request.CaseSensitive, ids);
+            return document.ElementIdsOfFamilyTypes(request.FamilyName, request.FamilyTypeName, request.CaseSensitive, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterFamilyByName request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterFamilyByName request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfFamilies(request.FamilyName, request.CaseSensitive, ids);
+            return document.ElementIdsOfFamilies(request.FamilyName, request.CaseSensitive, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterTypesOfFamily request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterTypesOfFamily request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfFamilyTypes(request.FamilyId, ids);
+            return document.ElementIdsOfFamilyTypes(request.FamilyId, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterActiveView request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterActiveView request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfActiveView(ids);
+            return document.ElementIdsOfActiveView(ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByViewSpecific request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByViewSpecific request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByViewSpecific(request.ViewId, ids);
+            return document.ElementIdsByViewSpecific(request.ViewId, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByVisibleInView request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByVisibleInView request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByVisibleInView(request.ViewId, ids);
+            return document.ElementIdsByVisibleInView(request.ViewId, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterViewByName request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterViewByName request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfViews(request.ViewName, request.CaseSensitive, ids);
+            return document.ElementIdsOfViews(request.ViewName, request.CaseSensitive, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterViewsByTemplate request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterViewsByTemplate request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfViews(request.TemplateId, ids);
+            return document.ElementIdsOfViews(request.TemplateId, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterViewsByType request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterViewsByType request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfViews(request.RevitViewType.ViewType(), ids);
+            return document.ElementIdsOfViews(request.RevitViewType.ViewType(), ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterViewTemplateByName request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterViewTemplateByName request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfViewTemplates(request.TemplateName, request.CaseSensitive, ids);
+            return document.ElementIdsOfViewTemplates(request.TemplateName, request.CaseSensitive, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this EnergyAnalysisModelRequest request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this EnergyAnalysisModelRequest request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfEnergyAnalysisModel(ids);
+            return document.ElementIdsOfEnergyAnalysisModel(ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterMemberElements request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterMemberElements request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfMemberElements(request.ParentId, ids);
+            return document.ElementIdsOfMemberElements(request.ParentId, ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterModelElements request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterModelElements request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsOfModelElements(ids);
+            return document.ElementIdsOfModelElements(ids);
         }
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this FilterByUsage request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this FilterByUsage request, Document document, IEnumerable<ElementId> ids = null)
         {
-            return uIDocument.Document.ElementIdsByUsage(request.Used, ids);
+            return document.ElementIdsByUsage(request.Used, ids);
         }
 
         /***************************************************/
 
 
-        public static IEnumerable<ElementId> ElementIds(this LogicalAndRequest request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this LogicalAndRequest request, Document document, IEnumerable<ElementId> ids = null)
         {
             IEnumerable<ElementId> result;
             if (ids == null)
@@ -282,7 +282,7 @@ namespace BH.Revit.Engine.Core
 
             foreach (IRequest subRequest in request.Requests.SortByPerformance())
             {
-                result = subRequest.IElementIds(uIDocument, result);
+                result = subRequest.IElementIds(document, result);
             }
 
             return result;
@@ -290,12 +290,12 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this LogicalOrRequest request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this LogicalOrRequest request, Document document, IEnumerable<ElementId> ids = null)
         {
             HashSet<ElementId> result = new HashSet<ElementId>();
             foreach (IRequest subRequest in request.Requests)
             {
-                result.UnionWith(subRequest.IElementIds(uIDocument, ids));
+                result.UnionWith(subRequest.IElementIds(document, ids));
             }
 
             return result;
@@ -303,10 +303,10 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static IEnumerable<ElementId> ElementIds(this LogicalNotRequest request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> ElementIds(this LogicalNotRequest request, Document document, IEnumerable<ElementId> ids = null)
         {
-            IEnumerable<ElementId> toExclude = request.Request.IElementIds(uIDocument);
-            return uIDocument.Document.ElementIdsByExclusion(toExclude, ids);
+            IEnumerable<ElementId> toExclude = request.Request.IElementIds(document);
+            return document.ElementIdsByExclusion(toExclude, ids);
         }
 
 
@@ -314,12 +314,12 @@ namespace BH.Revit.Engine.Core
         /****        Interface methods - Requests       ****/
         /***************************************************/
 
-        public static IEnumerable<ElementId> IElementIds(this IRequest request, UIDocument uIDocument, IEnumerable<ElementId> ids = null)
+        public static IEnumerable<ElementId> IElementIds(this IRequest request, Document document, IEnumerable<ElementId> ids = null)
         {
-            if (uIDocument == null || request == null)
+            if (document == null || request == null)
                 return null;
 
-            return ElementIds(request as dynamic, uIDocument, ids);
+            return ElementIds(request as dynamic, document, ids);
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/Faces.cs
+++ b/Revit_Core_Engine/Query/Faces.cs
@@ -33,9 +33,9 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        public static List<Face> Faces(this Element element, Options options, RevitSettings settings = null)
+        public static List<Face> Faces(this Element element, Options options, Transform transform = null, RevitSettings settings = null)
         {
-            List<GeometryObject> geometryPrimitives = element.GeometryPrimitives(options, settings);
+            List<GeometryObject> geometryPrimitives = element.GeometryPrimitives(options, transform, settings);
             if (geometryPrimitives == null)
                 return null;
 

--- a/Revit_Core_Engine/Query/GeometryPrimitives.cs
+++ b/Revit_Core_Engine/Query/GeometryPrimitives.cs
@@ -66,7 +66,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        public static List<GeometryObject> GeometryPrimitives(this Element element, Options options, RevitSettings settings = null)
+        public static List<GeometryObject> GeometryPrimitives(this Element element, Options options, Transform transform = null, RevitSettings settings = null)
         {
             if (element == null)
                 return null;
@@ -82,10 +82,15 @@ namespace BH.Revit.Engine.Core
             GeometryElement geometryElement = element.get_Geometry(options);
             if (geometryElement == null)
                 return new List<GeometryObject>();
-
-            Transform transform = null;
+            
             if (element is FamilyInstance)
-                transform = ((FamilyInstance)element).GetTotalTransform();
+            {
+                Transform instanceTransform = ((FamilyInstance)element).GetTotalTransform();
+                if (transform == null)
+                    transform = instanceTransform;
+                else
+                    transform = transform.Multiply(instanceTransform);
+            }
 
             return geometryElement.GeometryPrimitives(transform, settings);
         }

--- a/Revit_Core_Engine/Query/MeshedGeometry.cs
+++ b/Revit_Core_Engine/Query/MeshedGeometry.cs
@@ -33,14 +33,14 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        public static List<oM.Geometry.Mesh> MeshedGeometry(this Element element, Options options, RevitSettings settings = null)
+        public static List<oM.Geometry.Mesh> MeshedGeometry(this Element element, Options options, Transform transform = null, RevitSettings settings = null)
         {
             if (element == null)
                 return null;
 
-            List<oM.Geometry.Mesh> result = element.Faces(options, settings).Select(x => x.Triangulate(options.DetailLevel.FaceTriangulationFactor()).MeshFromRevit()).ToList();
-            result.AddRange(element.GeometryPrimitives(options, settings).Where(x => x is Mesh).Cast<Mesh>().Select(x => x.MeshFromRevit()));
-            result.AddRange(element.Curves(options, settings, false).Select(x => x.MeshFromRevit()));
+            List<oM.Geometry.Mesh> result = element.Faces(options, transform, settings).Select(x => x.Triangulate(options.DetailLevel.FaceTriangulationFactor()).MeshFromRevit()).ToList();
+            result.AddRange(element.GeometryPrimitives(options, transform, settings).Where(x => x is Mesh).Cast<Mesh>().Select(x => x.MeshFromRevit()));
+            result.AddRange(element.Curves(options, transform, settings, false).Select(x => x.MeshFromRevit()));
             return result;
         }
 

--- a/Revit_Core_Engine/Query/RenderMeshes.cs
+++ b/Revit_Core_Engine/Query/RenderMeshes.cs
@@ -35,13 +35,13 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        public static List<RenderMesh> RenderMeshes(this Element element, Options options, RevitSettings settings = null)
+        public static List<RenderMesh> RenderMeshes(this Element element, Options options, Transform transform = null, RevitSettings settings = null)
         {
             if (element == null)
                 return null;
 
             List<RenderMesh> result = new List<RenderMesh>();
-            foreach (Face face in element.Faces(options, settings))
+            foreach (Face face in element.Faces(options, transform, settings))
             {
                 RenderMesh renderMesh = face.Triangulate(options.DetailLevel.FaceTriangulationFactor()).MeshFromRevit().ToRenderMesh();
                 System.Drawing.Color color = face.Color(element.Document);
@@ -54,7 +54,7 @@ namespace BH.Revit.Engine.Core
                 result.Add(renderMesh);
             }
 
-            foreach (Curve curve in element.Curves(options, settings, false))
+            foreach (Curve curve in element.Curves(options, transform, settings, false))
             {
                 RenderMesh renderMesh = curve.MeshFromRevit().ToRenderMesh();
                 System.Drawing.Color color = curve.Color(element.Document);
@@ -66,7 +66,7 @@ namespace BH.Revit.Engine.Core
                 result.Add(renderMesh);
             }
 
-            result.AddRange(element.GeometryPrimitives(options, settings).Where(x => x is Mesh).Cast<Mesh>().Select(x => x.MeshFromRevit().ToRenderMesh()));
+            result.AddRange(element.GeometryPrimitives(options, transform, settings).Where(x => x is Mesh).Cast<Mesh>().Select(x => x.MeshFromRevit().ToRenderMesh()));
             return result;
         }
 

--- a/Revit_Core_Engine/Query/Solids.cs
+++ b/Revit_Core_Engine/Query/Solids.cs
@@ -33,9 +33,9 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        public static List<Solid> Solids(this Element element, Options options, RevitSettings settings = null)
+        public static List<Solid> Solids(this Element element, Options options, Transform transform = null, RevitSettings settings = null)
         {
-            List<GeometryObject> geometryPrimitives = element.GeometryPrimitives(options, settings);
+            List<GeometryObject> geometryPrimitives = element.GeometryPrimitives(options, transform, settings);
             if (geometryPrimitives == null)
                 return null;
 

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -146,6 +146,10 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Data_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Data_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
@@ -292,6 +296,7 @@
   <ItemGroup>
     <Compile Include="Compute\Activate.cs" />
     <Compile Include="Compute\Errors.cs" />
+    <Compile Include="Compute\SplitRequestTreeByLinks.cs" />
     <Compile Include="Convert\Architecture\FromRevit\Room.cs" />
     <Compile Include="Convert\MEP\FromRevit\CableTray.cs" />
     <Compile Include="Convert\MEP\FromRevit\Duct.cs" />

--- a/Revit_oM/Requests/FilterByLink.cs
+++ b/Revit_oM/Requests/FilterByLink.cs
@@ -32,7 +32,7 @@ namespace BH.oM.Adapters.Revit.Requests
         /****                Properties                 ****/
         /***************************************************/
 
-        [Description("Name of the link file (not whole file path) to pull from, case insensitive.")]
+        [Description("Name of the link file (alternatively whole file path) to pull from, case insensitive.")]
         public virtual string LinkName { get; set; } = "";
 
         /***************************************************/

--- a/Revit_oM/Requests/FilterByLink.cs
+++ b/Revit_oM/Requests/FilterByLink.cs
@@ -25,7 +25,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Requests
 {
-    [Description("IRequest that filters all elements from a Revit link with given name.")]
+    [Description("IRequest that filters all elements from a Revit link with given name or path.")]
     public class FilterByLink : IRequest
     {
         /***************************************************/

--- a/Revit_oM/Requests/FilterByLink.cs
+++ b/Revit_oM/Requests/FilterByLink.cs
@@ -25,14 +25,14 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Requests
 {
-    [Description("IRequest that filters all elements of a Revit category.")]
+    [Description("IRequest that filters all elements from a Revit link with given name.")]
     public class FilterByLink : IRequest
     {
         /***************************************************/
         /****                Properties                 ****/
         /***************************************************/
 
-        [Description("Name of the link file to pull from, case insensitive.")]
+        [Description("Name of the link file (not whole file path) to pull from, case insensitive.")]
         public virtual string LinkName { get; set; } = "";
 
         /***************************************************/

--- a/Revit_oM/Requests/FilterByLink.cs
+++ b/Revit_oM/Requests/FilterByLink.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Data.Requests;
+using System.ComponentModel;
+
+namespace BH.oM.Adapters.Revit.Requests
+{
+    [Description("IRequest that filters all elements of a Revit category.")]
+    public class FilterByLink : IRequest
+    {
+        /***************************************************/
+        /****                Properties                 ****/
+        /***************************************************/
+
+        [Description("Name of the link file to pull from, case insensitive.")]
+        public virtual string LinkName { get; set; } = "";
+
+        /***************************************************/
+    }
+}
+

--- a/Revit_oM/Revit_oM.csproj
+++ b/Revit_oM/Revit_oM.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Parameters\RevitParameter.cs" />
     <Compile Include="Parameters\RevitParametersToPush.cs" />
     <Compile Include="Parameters\RevitPulledParameters.cs" />
+    <Compile Include="Requests\FilterByLink.cs" />
     <Compile Include="Requests\IParameterRequest.cs" />
     <Compile Include="Elements\IView.cs" />
     <Compile Include="Elements\IInstance.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #396

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
- [issue-specific test file](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FRevit%5FToolkit%2F%23396%2DPullFromLinks&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)
- [standard test files for requests extended to links](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FRequests%2FLink&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

**IMPORTANT:** Please see the additional comments for more information.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `LinkRequest` object introduced
- handling of the above object implemented, enabling pulling from links

### Additional comments
<!-- As required -->
First of all, apologies for the size of this PR - it has already been limited to the bare minimum, focusing on the framework-level changes. Large parts of code will require gradual refactoring in order to make pull from links fully functional. **The following functionality is not implemented yet:**
- pull of physical `ISurfaces` (walls, floors, roofs etc.) and `IOpenings` (windows, doors etc.)
- pull of ceiling patterns (pull of ceilings does not work on two levels: this and above 😃)
- pull from links that are transformed with regard to the host document does not handle the transformation - temporary warnings added where necessary
- link information does not get saved to `RevitIdentifiers`

**Another few limitations are permanent due to limitations of Revit:**
- selection, active view and active workset requests do not work in combination with `LinkRequest` - relevant messages added
- `Remove` does not work with `LinkRequest` - relevant message added

**A few follow-up issues to be raised once this PR gets merged:**
- add link information to `RevitIdentifiers`
- introduce pull of `ISurfaces`, `IOpenings` from links (if possible - Revit API is a monster here)
- introduce pull of ceiling patterns from links
- enable transform of elements pulled from links

Finally, @LMarkowski looks like there will be no conflict between this PR and #956 since this one is dealing mainly with `FromRevit`, while the latter with `ToRevit`.