### PR TITLE
Logging of events coming from Revit fixed

### DIFF
--- a/Revit_Adapter/RevitAdapter.cs
+++ b/Revit_Adapter/RevitAdapter.cs
@@ -144,10 +144,8 @@ namespace BH.Adapter.Revit
             if (m_ReturnEvents == null)
                 return;
 
-            Engine.Reflection.Query.CurrentEvents().AddRange(m_ReturnEvents);
-            Engine.Reflection.Query.AllEvents().AddRange(m_ReturnEvents);
-
-            m_ReturnEvents = new List<Event>();
+            m_ReturnEvents.ForEach(x => Engine.Reflection.Compute.RecordEvent(x));
+            m_ReturnEvents.Clear();
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #979

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FRevit%5FToolkit%2F%23979%2DRevitEvents&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - the content of the warnings on Pull does not matter, it is all about recording them at all.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- logging of events coming from Revit fixed

### Additional comments
<!-- As required -->