### PR TITLE
Revit_Toolkit: FreeFormProfiles stopped from being flipped and account made for mirroring of framing

### DIFF
--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Profile.cs
@@ -678,7 +678,7 @@ namespace BH.Revit.Engine.Core
                 if (familySymbol.Family.FamilyPlacementType == FamilyPlacementType.CurveDrivenStructural)
                 {
                     // First rotate the profile to align its local plane with global XY, then rotate to align its local Z with global Y.
-                    double angle = Math.PI * 0.5;
+                    double angle = -Math.PI * 0.5;
                     profileCurves = profileCurves.Select(x => x.IRotate(oM.Geometry.Point.Origin, Vector.YAxis, angle)).ToList();
                     profileCurves = profileCurves.Select(x => x.IRotate(oM.Geometry.Point.Origin, Vector.ZAxis, angle)).ToList();
                 }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #972

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%23985%2DProfilesComeOutFlipped&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `FreeFormProfiles` from framing stopped from coming out flipped on Pull
- account made for mirroring of framing on Pull


### Additional comments
<!-- As required -->
This closes #972, but #984 has been raised as a follow-up to cover the tricky bits that could not be resolved using any conventional approach.