### PR TITLE
Pull of panels from links fixed to possible extent

### DIFF
--- a/Revit_Core_Engine/Query/LinkPanelFaces.cs
+++ b/Revit_Core_Engine/Query/LinkPanelFaces.cs
@@ -1,0 +1,141 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.oM.Adapters.Revit.Settings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public static List<Face> ILinkPanelFaces(this HostObject hostObject, RevitSettings settings)
+        {
+            return LinkPanelFaces(hostObject as dynamic, settings);
+        }
+
+        /***************************************************/
+
+        public static List<Face> LinkPanelFaces(this Wall wall, RevitSettings settings)
+        {
+            Line line = (wall?.Location as LocationCurve)?.Curve as Line;
+            if (line == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Querying panel surfaces from links for Revit curved walls is currently not supported.");
+                return null;
+            }
+
+            XYZ normal = line.Direction.CrossProduct(XYZ.BasisZ);
+            Plane p = Plane.CreateByNormalAndOrigin(normal, line.Origin);
+
+            List<Solid> solids = wall.Solids(new Options());
+            List<Solid> halfSolids = solids.Select(x => BooleanOperationsUtils.CutWithHalfSpace(x, p)).ToList();
+
+            List<Face> result = new List<Face>();
+            foreach (Solid s in halfSolids)
+            {
+                foreach (Face f in s.Faces)
+                {
+                    PlanarFace pf = f as PlanarFace;
+                    if (pf == null)
+                        continue;
+
+                    if (1 - Math.Abs(pf.FaceNormal.DotProduct(normal)) > settings.AngleTolerance)
+                        continue;
+
+                    if (Math.Abs(normal.DotProduct(pf.Origin - p.Origin)) > settings.DistanceTolerance)
+                        continue;
+
+                    result.Add(pf);
+                }
+            }
+
+            return result;
+        }
+
+        /***************************************************/
+
+        public static List<Face> LinkPanelFaces(this Floor floor, RevitSettings settings)
+        {
+            List<Face> result = new List<Face>();
+            foreach (Reference reference in HostObjectUtils.GetTopFaces(floor))
+            {
+                PlanarFace pf = floor.GetGeometryObjectFromReference(reference) as PlanarFace;
+                if (pf != null)
+                    result.Add(pf);
+            }
+
+            return result;
+        }
+
+        /***************************************************/
+
+        public static List<Face> LinkPanelFaces(this RoofBase roof, RevitSettings settings)
+        {
+            List<Face> result = new List<Face>();
+            foreach (Reference reference in HostObjectUtils.GetTopFaces(roof))
+            {
+                PlanarFace pf = roof.GetGeometryObjectFromReference(reference) as PlanarFace;
+                if (pf != null)
+                    result.Add(pf);
+            }
+
+            return result;
+        }
+
+        /***************************************************/
+
+        public static List<Face> LinkPanelFaces(this Ceiling ceiling, RevitSettings settings)
+        {
+            List<Face> result = new List<Face>();
+            foreach (Reference reference in HostObjectUtils.GetBottomFaces(ceiling))
+            {
+                PlanarFace pf = ceiling.GetGeometryObjectFromReference(reference) as PlanarFace;
+                if (pf != null)
+                    result.Add(pf);
+            }
+
+            return result;
+        }
+
+
+        /***************************************************/
+        /****             Fallback methods              ****/
+        /***************************************************/
+
+        private static List<Face> LinkPanelFaces(this HostObject hostObject, RevitSettings settings)
+        {
+            BH.Engine.Reflection.Compute.RecordError($"Querying panel surfaces from links for Revit elements of type {hostObject.GetType().Name} is currently not supported.");
+            return new List<Face>();
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/Revit_Core_Engine/Query/OpeningSurface.cs
+++ b/Revit_Core_Engine/Query/OpeningSurface.cs
@@ -70,8 +70,12 @@ namespace BH.Revit.Engine.Core
             if (!familyInstance.Document.IsLinked)
                 surfaces = familyInstance.OpeningSurfaces_HostDocument(hosts, parentElem, settings);
             else
-                //TODO: record warning if host == null?
+            {
+                BH.Engine.Reflection.Compute.RecordWarning("Pulling panels and openings from Revit link documents is simplified compared to pulling directly from the host document, therefore it may result in degraded output.\n" +
+                                                           "In case of requirement for best possible outcome, it is recommended to open the link document in Revit and pull the elements directly from there.");
+
                 surfaces = familyInstance.OpeningSurfaces_LinkDocument(hosts, parentElem, settings);
+            }
 
             if (surfaces.Count == 0)
                 return null;

--- a/Revit_Core_Engine/Query/OpeningSurface.cs
+++ b/Revit_Core_Engine/Query/OpeningSurface.cs
@@ -21,7 +21,6 @@
  */
 
 using Autodesk.Revit.DB;
-using Autodesk.Revit.DB.IFC;
 using BH.Engine.Adapters.Revit;
 using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Parameters;
@@ -44,9 +43,7 @@ namespace BH.Revit.Engine.Core
             if (familyInstance == null)
                 return null;
 
-            BoundingBoxXYZ bbox = familyInstance.get_BoundingBox(null);
-            if (bbox == null)
-                return null;
+            settings = settings.DefaultIfNull();
 
             // Get parent element if this family instance is a nested instance
             Element parentElem = familyInstance.SuperComponent;
@@ -54,21 +51,46 @@ namespace BH.Revit.Engine.Core
             if (parentElem != null)
                 parentId = familyInstance.SuperComponent.Id.IntegerValue;
 
-            settings = settings.DefaultIfNull();
             List<HostObject> hosts;
 
             if (host != null)
                 hosts = new List<HostObject> { host };
             else
             {
+                BoundingBoxXYZ bbox = familyInstance.get_BoundingBox(null);
+                if (bbox == null)
+                    return null;
+
                 BoundingBoxIntersectsFilter bbif = new BoundingBoxIntersectsFilter(new Outline(bbox.Min, bbox.Max));
                 hosts = new FilteredElementCollector(familyInstance.Document).OfClass(typeof(HostObject)).WherePasses(bbif).Cast<HostObject>().ToList();
                 hosts = hosts.Where(x => x.FindInserts(true, true, true, true).Any(y => (y.IntegerValue == familyInstance.Id.IntegerValue) || (y.IntegerValue == parentId))).ToList();
             }
 
+            List<ISurface> surfaces;
+            if (!familyInstance.Document.IsLinked)
+                surfaces = familyInstance.OpeningSurfaces_HostDocument(hosts, parentElem, settings);
+            else
+                //TODO: record warning if host == null?
+                surfaces = familyInstance.OpeningSurfaces_LinkDocument(hosts, parentElem, settings);
+
+            if (surfaces.Count == 0)
+                return null;
+            else if (surfaces.Count == 1)
+                return surfaces[0];
+            else
+                return new PolySurface { Surfaces = surfaces };
+        }
+
+
+        /***************************************************/
+        /****              Private Methods              ****/
+        /***************************************************/
+
+        private static List<ISurface> OpeningSurfaces_HostDocument(this FamilyInstance familyInstance, List<HostObject> hosts, Element parentElement, RevitSettings settings = null)
+        {
             List<ISurface> surfaces = new List<ISurface>();
 
-            if (parentElem != null) // Indicates element is a nested instance and needs different approach to extract location
+            if (parentElement != null) // Indicates element is a nested instance and needs different approach to extract location
             {
                 Document doc = familyInstance.Document;
                 Transaction t = new Transaction(doc);
@@ -79,49 +101,15 @@ namespace BH.Revit.Engine.Core
                 // Create dummy instance of nested element with matching parameters
                 LocationPoint locPt = familyInstance.Location as LocationPoint;
                 Element dummyInstance = doc.Create.NewFamilyInstance(locPt.Point, familyInstance.Symbol, hosts.First() as Element, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
-                IEnumerable <BuiltInParameter> paramsToSkip= new List<BuiltInParameter> { BuiltInParameter.INSTANCE_HEAD_HEIGHT_PARAM, BuiltInParameter.INSTANCE_SILL_HEIGHT_PARAM };
+                IEnumerable<BuiltInParameter> paramsToSkip = new List<BuiltInParameter> { BuiltInParameter.INSTANCE_HEAD_HEIGHT_PARAM, BuiltInParameter.INSTANCE_SILL_HEIGHT_PARAM };
                 familyInstance.CopyParameters(dummyInstance, paramsToSkip);
 
                 doc.Delete(inserts);
                 doc.Regenerate();
 
-                surfaces = GetOpeningGeometry(t, doc, hosts, inserts, familyInstance, settings);
+                return GetOpeningGeometry(t, doc, hosts, inserts, familyInstance, settings);
             }
-
-            else if (hosts.Count == 0)
-            {
-                HostObject curtainHost = familyInstance.Host as HostObject;
-                if (curtainHost == null)
-                    return null;
-
-                List<CurtainGrid> curtainGrids = curtainHost.ICurtainGrids();
-                if (curtainGrids.Count != 0)
-                {
-                    foreach (CurtainGrid cg in curtainGrids)
-                    {
-                        List<ElementId> ids = cg.GetPanelIds().ToList();
-                        List<CurtainCell> cells = cg.GetCurtainCells().ToList();
-                        if (ids.Count != cells.Count)
-                            return null;
-
-                        for (int i = 0; i < ids.Count; i++)
-                        {
-                            if (ids[i].IntegerValue == familyInstance.Id.IntegerValue)
-                            {
-                                foreach (PolyCurve curve in cells[i].CurveLoops.FromRevit())
-                                {
-                                    PlanarSurface surface = new PlanarSurface(curve, null);
-                                    if (surface == null)
-                                        return null;
-
-                                    surfaces.Add(surface);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            else
+            else if (hosts.Count != 0)
             {
                 Document doc = familyInstance.Document;
                 Transaction t = new Transaction(doc);
@@ -141,20 +129,97 @@ namespace BH.Revit.Engine.Core
 
                 }
 
-                surfaces = GetOpeningGeometry(t, doc, hosts, inserts, familyInstance, settings);
+                return GetOpeningGeometry(t, doc, hosts, inserts, familyInstance, settings);
             }
-
-            if (surfaces.Count == 0)
-                return null;
-            else if (surfaces.Count == 1)
-                return surfaces[0];
             else
-                return new PolySurface { Surfaces = surfaces };
+                return familyInstance.OpeningSurfaces_Curtain();
         }
 
+        /***************************************************/
+
+        private static List<ISurface> OpeningSurfaces_LinkDocument(this FamilyInstance familyInstance, List<HostObject> hosts, Element parentElement, RevitSettings settings = null)
+        {
+            if (parentElement != null)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Pull of nested families from link documents is currently not implemented. Please consider opening the document {familyInstance.Document.PathName} and pulling directly from it.");
+                return new List<ISurface>();
+            }
+            else if (hosts.Count != 0)
+            {
+                List<PolyCurve> outlines = new List<PolyCurve>();
+                foreach (HostObject host in hosts)
+                {
+                    List<Autodesk.Revit.DB.Face> panelFaces = host.ILinkPanelFaces(settings);
+                    List<Autodesk.Revit.DB.Face> edgeFaces = host.Faces(new Options(), settings).Where(x => host.GetGeneratingElementIds(x).Any(y => y.IntegerValue == familyInstance.Id.IntegerValue)).ToList();
+                    List<Curve> edgeCurves = new List<Curve>();
+                    foreach (Autodesk.Revit.DB.Face face in panelFaces)
+                    {
+                        foreach (EdgeArray ea in face.EdgeLoops)
+                        {
+                            foreach (Edge e in ea)
+                            {
+                                Curve crv = e.AsCurve();
+                                if (crv.IsEdge(edgeFaces, settings))
+                                    edgeCurves.Add(crv);
+                            }
+                        }
+                    }
+
+                    List<ICurve> bHoMCurves = edgeCurves.Select(x => x.IFromRevit()).ToList();
+                    outlines.AddRange(bHoMCurves.IJoin(settings.DistanceTolerance));
+                }
+
+                foreach (PolyCurve pc in outlines)
+                {
+                    if (!pc.IsClosed(settings.DistanceTolerance))
+                        pc.Curves.Add(new BH.oM.Geometry.Line { Start = pc.EndPoint(), End = pc.StartPoint() });
+                }
+
+                return new List<ISurface>(outlines.Select(x => new PlanarSurface(x, null)));
+            }
+            else
+                return familyInstance.OpeningSurfaces_Curtain();
+        }
 
         /***************************************************/
-        /****              Private Methods              ****/
+
+        private static List<ISurface> OpeningSurfaces_Curtain(this FamilyInstance familyInstance)
+        {
+            List<ISurface> surfaces = new List<ISurface>();
+            HostObject curtainHost = familyInstance.Host as HostObject;
+            if (curtainHost == null)
+                return null;
+
+            List<CurtainGrid> curtainGrids = curtainHost.ICurtainGrids();
+            if (curtainGrids.Count != 0)
+            {
+                foreach (CurtainGrid cg in curtainGrids)
+                {
+                    List<ElementId> ids = cg.GetPanelIds().ToList();
+                    List<CurtainCell> cells = cg.GetCurtainCells().ToList();
+                    if (ids.Count != cells.Count)
+                        return null;
+
+                    for (int i = 0; i < ids.Count; i++)
+                    {
+                        if (ids[i].IntegerValue == familyInstance.Id.IntegerValue)
+                        {
+                            foreach (PolyCurve curve in cells[i].CurveLoops.FromRevit())
+                            {
+                                PlanarSurface surface = new PlanarSurface(curve, null);
+                                if (surface == null)
+                                    return null;
+
+                                surfaces.Add(surface);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return surfaces;
+        }
+
         /***************************************************/
 
         private static List<ISurface> GetOpeningGeometry(Transaction t, Document doc, List<HostObject> hosts, List<ElementId> inserts, FamilyInstance familyInstance, RevitSettings settings = null)
@@ -224,6 +289,21 @@ namespace BH.Revit.Engine.Core
                 BH.Engine.Reflection.Compute.RecordWarning(String.Format("Geometrical processing of a Revit element failed due to an internal Revit error. Converted opening might be missing one or more of its surfaces. Revit ElementId: {0}", familyInstance.Id));
 
             return surfaces;
+        }
+
+        /***************************************************/
+
+        private static bool IsEdge(this Curve crv, List<Autodesk.Revit.DB.Face> edgeFaces, RevitSettings settings)
+        {
+            XYZ mid = crv.Evaluate(0.5, true);
+            foreach (Autodesk.Revit.DB.Face f in edgeFaces)
+            {
+                IntersectionResult ir = f.Project(mid);
+                if (ir != null && ir.Distance <= settings.DistanceTolerance)
+                    return true;
+            }
+
+            return false;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/PanelSurfaces.cs
+++ b/Revit_Core_Engine/Query/PanelSurfaces.cs
@@ -210,7 +210,7 @@ namespace BH.Revit.Engine.Core
                         List<ICurve> edges = new List<ICurve>();
                         foreach (Edge e in ea)
                         {
-                            Curve crv = e.AsCurve();
+                            Curve crv = e.AsCurveFollowingFace(pf);
                             if (!crv.IsEdge(edgeFaces, settings))
                                 edges.Add(crv.IFromRevit());
                         }
@@ -237,7 +237,7 @@ namespace BH.Revit.Engine.Core
                     {
                         foreach(Edge e in ea)
                         {
-                            loop.Curves.Add(e.AsCurve().IFromRevit());
+                            loop.Curves.Add(e.AsCurveFollowingFace(pf).IFromRevit());
                         }
                     }
 

--- a/Revit_Core_Engine/Query/PanelSurfaces.cs
+++ b/Revit_Core_Engine/Query/PanelSurfaces.cs
@@ -45,7 +45,9 @@ namespace BH.Revit.Engine.Core
                 return hostObject.PanelSurfaces_HostDocument(insertsToIgnore, settings);
             else
             {
-                //TODO: warning?
+                BH.Engine.Reflection.Compute.RecordWarning("Pulling panels and openings from Revit link documents is simplified compared to pulling directly from the host document, therefore it may result in degraded output.\n" +
+                                                           "In case of requirement for best possible outcome, it is recommended to open the link document in Revit and pull the elements directly from there.");
+
                 return hostObject.PanelSurfaces_LinkDocument(insertsToIgnore, settings);
             }
         }

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -321,6 +321,7 @@
     <Compile Include="Query\HostDocument.cs" />
     <Compile Include="Query\IsInside.cs" />
     <Compile Include="Query\IsOnFace.cs" />
+    <Compile Include="Query\LinkPanelFaces.cs" />
     <Compile Include="Query\LinkTransform.cs" />
     <Compile Include="Query\Shape.cs" />
     <Compile Include="Query\MaterialTakeOff.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM_Engine/pull/2398

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #975

<!-- Add short description of what has been fixed -->

### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPull%2FFromLink&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4), both scripts mentioned below to be run with _FromLink_PullPanelLocation.rvt_.

**PULL PHYSICAL**
_FromLink_PullWallFloorRoofLocation.gh_
- elements marked as 1 in the snip below fail because the panel is entirely split by the openings - that is something that I could not make any better without opening a transaction (which is not allowed on links 🙄)
- elements marked as 2 get converted to Physical objects with location as `PolySurface`, which fails on transform due to [requirement for PlanarSurface](https://github.com/BHoM/BHoM_Engine/blob/1210c894accd9b6e9539ca8a7fd3b91302b33356/Physical_Engine/Query/OutlineElements1D.cs#L44-L54) (https://github.com/BHoM/BHoM/issues/1223 raised for that)
- elements marked as 3 do not work even on pull from host document, so out of scope

![image](https://user-images.githubusercontent.com/26874773/111347654-b3c60600-867f-11eb-8ba4-187dd3f34ecb.png)

**PULL STRUCTURAL**
_FromLink_PullPanelLocation.gh_
- elements marked as 1 do not work due to lack of handling of nurbs, fails on pull from host document as well - out of scope
- elements marked as 2 do not work even on pull from host document, so out of scope

![image](https://user-images.githubusercontent.com/26874773/111357193-6189e280-8689-11eb-8eb4-f6a6b69a72c9.png)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- pull of panels from links fixed to possible extent

### Additional comments
<!-- As required -->
The solution for the issue is not perfect (quite far away from it actually), but I could not make it any better - the inability to open temporary transactions in link documents spoils everything. Therefore, I would opt for leaving it as is with appropriate warnings (as added in the PR). Happy to discuss if others disagree.