### PR TITLE
Pull ceiling patterns from links fixed

### DIFF
--- a/Revit_Core_Engine/Compute/PrepareForLinkDimensioning.cs
+++ b/Revit_Core_Engine/Compute/PrepareForLinkDimensioning.cs
@@ -21,19 +21,44 @@
  */
 
 using Autodesk.Revit.DB;
-using System.Linq;
 
 namespace BH.Revit.Engine.Core
 {
-    public static partial class Query
+    public static partial class Compute
     {
         /***************************************************/
-        /****              Public methods               ****/
+        /****               Internal methods            ****/
         /***************************************************/
 
-        public static Transform LinkTransform(this Document linkDocument)
+        public static Reference PrepareForLinkDimensioning(this Reference reference, Document hostDocument)
         {
-            return linkDocument.LinkInstance()?.GetTotalTransform();
+            if (reference.LinkedElementId.IntegerValue == -1)
+                return null;
+
+            string[] ss = reference.ConvertToStableRepresentation(hostDocument).Split(':');
+            string res = string.Empty;
+            bool first = true;
+            foreach (string s in ss)
+            {
+                string t = s;
+                if (s.Contains("RVTLINK"))
+                {
+                    if (res.EndsWith(":0"))
+                        t = "RVTLINK";
+                    else
+                        t = "0:RVTLINK";
+                }
+
+                if (!first)
+                    res = string.Concat(res, ":", t);
+                else
+                {
+                    res = t;
+                    first = false;
+                }
+            }
+
+            return Reference.ParseFromStableRepresentation(hostDocument, res);
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/CeilingPattern.cs
+++ b/Revit_Core_Engine/Query/CeilingPattern.cs
@@ -271,6 +271,10 @@ namespace BH.Revit.Engine.Core
                         
                         using (Transaction t = new Transaction(hostDoc, "temp dim"))
                         {
+
+                            Transform wtf = linkInstance.GetTotalTransform();
+
+
                             t.Start();
                             Dimension horDim = hostDoc.Create.NewDimension(hostDoc.ActiveView, Autodesk.Revit.DB.Line.CreateBound(XYZ.Zero, pf.XVector), horR);
                             Dimension verDim = hostDoc.Create.NewDimension(hostDoc.ActiveView, Autodesk.Revit.DB.Line.CreateBound(XYZ.Zero, pf.YVector), verR);
@@ -278,9 +282,18 @@ namespace BH.Revit.Engine.Core
                             ElementTransformUtils.MoveElement(hostDoc, verDim.Id, XYZ.BasisX);
 
                             rotation = -(horDim.Curve as Autodesk.Revit.DB.Line).Direction.AngleOnPlaneTo(XYZ.BasisX, XYZ.BasisZ);
+
+                            if (linkInstance != null)
+                            {
+                                rotation += wtf.BasisX.AngleOnPlaneTo(XYZ.BasisX, XYZ.BasisZ);
+                            }
+
                             Transform tr = Transform.CreateRotation(XYZ.BasisZ, rotation);
-                            double x = tr.Inverse.OfPoint(horDim.Origin).X;
-                            double y = tr.Inverse.OfPoint(verDim.Origin).Y;
+
+
+
+                            double x = tr.Inverse.OfPoint(wtf.Inverse.OfPoint(horDim.Origin)).X;
+                            double y = tr.Inverse.OfPoint(wtf.Inverse.OfPoint(verDim.Origin)).Y;
                             t.RollBack();
 
                             foreach (FillGrid fg in fp.GetFillGrids())
@@ -291,10 +304,11 @@ namespace BH.Revit.Engine.Core
                                     x += fg.Offset * 0.5;
                             }
 
-                            if (linkInstance != null)
-                                tr = tr.Multiply(linkInstance.GetTotalTransform());
-
                             result = tr.OfPoint(new XYZ(x, y, 0));
+
+
+
+
                             break;
                         }
                     }

--- a/Revit_Core_Engine/Query/CeilingPattern.cs
+++ b/Revit_Core_Engine/Query/CeilingPattern.cs
@@ -39,12 +39,6 @@ namespace BH.Revit.Engine.Core
 
         public static List<BH.oM.Geometry.Line> CeilingPattern(this Ceiling ceiling, RevitSettings settings, PlanarSurface surface = null)
         {
-            if (ceiling.Document.IsLinked)
-            {
-                BH.Engine.Reflection.Compute.RecordWarning($"It is not allowed to pull the ceiling patterns from linked models - please open the document {ceiling.Document.PathName} and pull directly from it instead.");
-                return new List<oM.Geometry.Line>();
-            }
-
             CeilingType ceilingType = ceiling.Document.GetElement(ceiling.GetTypeId()) as CeilingType;
             CompoundStructure comStruct = ceilingType.GetCompoundStructure();
 
@@ -245,6 +239,9 @@ namespace BH.Revit.Engine.Core
 
             Options o = new Options();
             o.ComputeReferences = true;
+            Document hostDoc = doc.IsLinked ? doc.HostDocument() : doc;
+            RevitLinkInstance linkInstance = doc.IsLinked ? doc.LinkInstance() : null;
+
             foreach (GeometryObject go in ceiling.get_Geometry(o))
             {
                 if (go is Solid)
@@ -257,32 +254,28 @@ namespace BH.Revit.Engine.Core
 
                         if (1 + pf.FaceNormal.DotProduct(XYZ.BasisZ) > settings.AngleTolerance)
                             continue;
-                        
+
+                        Reference faceRef = f.Reference;
+                        if (doc.IsLinked)
+                            faceRef = faceRef.CreateLinkReference(linkInstance).PrepareForLinkDimensioning(hostDoc);
+
+                        string stableRef = faceRef.ConvertToStableRepresentation(hostDoc);
+
                         ReferenceArray horR = new ReferenceArray();
-                        string stable = f.Reference.ConvertToStableRepresentation(doc) + "/2";
-                        Reference href = Reference.ParseFromStableRepresentation(doc, stable);
-                        horR.Append(href);
-
-                        stable = f.Reference.ConvertToStableRepresentation(doc) + "/" + (2 + fp.GridCount * 2).ToString();
-                        href = Reference.ParseFromStableRepresentation(doc, stable);
-                        horR.Append(href);
-
-                        ReferenceArray verR = new ReferenceArray();
-                        stable = f.Reference.ConvertToStableRepresentation(doc) + "/1";
-                        href = Reference.ParseFromStableRepresentation(doc, stable);
-                        verR.Append(href);
-
-                        stable = f.Reference.ConvertToStableRepresentation(doc) + "/" + (1 + fp.GridCount * 2).ToString();
-                        href = Reference.ParseFromStableRepresentation(doc, stable);
-                        verR.Append(href);
+                        horR.Append(Reference.ParseFromStableRepresentation(hostDoc, stableRef + "/2"));
+                        horR.Append(Reference.ParseFromStableRepresentation(hostDoc, stableRef + "/" + (2 + fp.GridCount * 2).ToString()));
                         
-                        using (Transaction t = new Transaction(doc, "temp dim"))
+                        ReferenceArray verR = new ReferenceArray();
+                        verR.Append(Reference.ParseFromStableRepresentation(hostDoc, stableRef + "/1"));
+                        verR.Append(Reference.ParseFromStableRepresentation(hostDoc, stableRef + "/" + (1 + fp.GridCount * 2).ToString()));
+                        
+                        using (Transaction t = new Transaction(hostDoc, "temp dim"))
                         {
                             t.Start();
-                            Dimension horDim = doc.Create.NewDimension(doc.ActiveView, Autodesk.Revit.DB.Line.CreateBound(XYZ.Zero, pf.XVector), horR);
-                            Dimension verDim = doc.Create.NewDimension(doc.ActiveView, Autodesk.Revit.DB.Line.CreateBound(XYZ.Zero, pf.YVector), verR);
-                            ElementTransformUtils.MoveElement(doc, horDim.Id, XYZ.BasisX);
-                            ElementTransformUtils.MoveElement(doc, verDim.Id, XYZ.BasisX);
+                            Dimension horDim = hostDoc.Create.NewDimension(hostDoc.ActiveView, Autodesk.Revit.DB.Line.CreateBound(XYZ.Zero, pf.XVector), horR);
+                            Dimension verDim = hostDoc.Create.NewDimension(hostDoc.ActiveView, Autodesk.Revit.DB.Line.CreateBound(XYZ.Zero, pf.YVector), verR);
+                            ElementTransformUtils.MoveElement(hostDoc, horDim.Id, XYZ.BasisX);
+                            ElementTransformUtils.MoveElement(hostDoc, verDim.Id, XYZ.BasisX);
 
                             rotation = -(horDim.Curve as Autodesk.Revit.DB.Line).Direction.AngleOnPlaneTo(XYZ.BasisX, XYZ.BasisZ);
                             Transform tr = Transform.CreateRotation(XYZ.BasisZ, rotation);
@@ -297,6 +290,9 @@ namespace BH.Revit.Engine.Core
                                 else
                                     x += fg.Offset * 0.5;
                             }
+
+                            if (linkInstance != null)
+                                tr = tr.Multiply(linkInstance.GetTotalTransform());
 
                             result = tr.OfPoint(new XYZ(x, y, 0));
                             break;

--- a/Revit_Core_Engine/Query/LinkInstance.cs
+++ b/Revit_Core_Engine/Query/LinkInstance.cs
@@ -31,9 +31,20 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        public static Transform LinkTransform(this Document linkDocument)
+        public static RevitLinkInstance LinkInstance(this Document linkDocument)
         {
-            return linkDocument.LinkInstance()?.GetTotalTransform();
+            Document mainDoc = linkDocument.HostDocument();
+            if (linkDocument == mainDoc)
+            {
+                BH.Engine.Reflection.Compute.RecordWarning($"The document under path {linkDocument.PathName} is a host document.");
+                return null;
+            }
+
+            RevitLinkInstance linkInstance = new FilteredElementCollector(mainDoc).OfClass(typeof(RevitLinkInstance)).Cast<RevitLinkInstance>().FirstOrDefault(x => x.GetLinkDocument().PathName == linkDocument.PathName);
+            if (linkInstance == null)
+                BH.Engine.Reflection.Compute.RecordError($"The link pointing to path {linkDocument.PathName} could not be found in active Revit document.");
+
+            return linkInstance;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -296,6 +296,7 @@
   <ItemGroup>
     <Compile Include="Compute\Activate.cs" />
     <Compile Include="Compute\Errors.cs" />
+    <Compile Include="Compute\PrepareForLinkDimensioning.cs" />
     <Compile Include="Compute\SplitRequestTreeByLinks.cs" />
     <Compile Include="Convert\Architecture\FromRevit\Room.cs" />
     <Compile Include="Convert\MEP\FromRevit\CableTray.cs" />
@@ -321,6 +322,7 @@
     <Compile Include="Query\HostDocument.cs" />
     <Compile Include="Query\IsInside.cs" />
     <Compile Include="Query\IsOnFace.cs" />
+    <Compile Include="Query\LinkInstance.cs" />
     <Compile Include="Query\LinkPanelFaces.cs" />
     <Compile Include="Query\LinkTransform.cs" />
     <Compile Include="Query\Shape.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

Not a direct dependency, but https://github.com/BHoM/BHoM_Engine/pull/2407 is required to avoid stack overflow on pull of the ceiling patterns.

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #974

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%23996%2DPullCeilingPatternFromLink&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - run *FromLink_#974-PullCeilingPatternFromLink.rvt* in combination with *#974-PullCeilingPatternFromLink.gh* and visually inspect the outputs.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Pull ceiling patterns from links fixed


### Additional comments
<!-- As required -->
Please do not even bother to review `PrepareForLinkDimensioning` - it is yet another chapter of [reference and dimensioning voodoo](https://thebuildingcoder.typepad.com/blog/2017/06/hatch-line-dimensioning-voodoo.html), the only important thing about it is that it works.