### PR TITLE
OpeningSurface stopped from crashing on null

### DIFF
--- a/Revit_Core_Engine/Query/OpeningSurface.cs
+++ b/Revit_Core_Engine/Query/OpeningSurface.cs
@@ -77,7 +77,7 @@ namespace BH.Revit.Engine.Core
                 surfaces = familyInstance.OpeningSurfaces_LinkDocument(hosts, parentElem, settings);
             }
 
-            if (surfaces.Count == 0)
+            if (surfaces == null || surfaces.Count == 0)
                 return null;
             else if (surfaces.Count == 1)
                 return surfaces[0];


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #997

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Standard IInstance pull test](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPull&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - open _PullIInstances.rvt_ and _PullIInstances.gh_, try pulling the following:
- curve based no host
- curve based face hosted


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `OpeningSurface` method stopped from crashing on null `surfaces` variable

### Additional comments
<!-- As required -->