### PR TITLE
Querying link documents for ElementIds made more robust and errors made more informative

### DIFF
--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -114,7 +114,7 @@ namespace BH.Revit.Adapter.Core
             if (!pullConfig.IncludeClosedWorksets)
                 worksetPrefilter = document.ElementIdsByWorksets(document.OpenWorksetIds().Union(document.SystemWorksetIds()).ToList());
 
-            List<ElementId> elementIds = request.IElementIds(document, worksetPrefilter).RemoveGridSegmentIds(document).ToList<ElementId>();
+            List<ElementId> elementIds = request.IElementIds(document, worksetPrefilter).RemoveGridSegmentIds(document)?.ToList();
             if (elementIds == null)
                 return new List<IBHoMObject>();
 

--- a/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
+++ b/Revit_Core_Engine/Compute/SplitRequestTreeByLinks.cs
@@ -83,24 +83,6 @@ namespace BH.Engine.Adapters.Revit
             }
             else if (linkRequests.Count == 1)
             {
-                if (request.AllRequestsOfType(typeof(SelectionRequest)).Count != 0)
-                {
-                    BH.Engine.Reflection.Compute.RecordError("It is not allowed to combine selection requests with link requests - Revit selection does not work with links.");
-                    return false;
-                }
-
-                if (request.AllRequestsOfType(typeof(FilterByActiveWorkset)).Count != 0)
-                {
-                    BH.Engine.Reflection.Compute.RecordError("It is not allowed to combine active workset requests with link requests - Revit selection does not work with links.");
-                    return false;
-                }
-
-                if (request.AllRequestsOfType(typeof(FilterActiveView)).Count != 0)
-                {
-                    BH.Engine.Reflection.Compute.RecordError("It is not allowed to combine active view requests with link requests - Revit selection does not work with links.");
-                    return false;
-                }
-
                 FilterByLink linkRequest = (FilterByLink)linkRequests[0];
                 string linkName = linkRequest.LinkName.ToLower();
                 if (!linkName.EndsWith(".rvt"))

--- a/Revit_Core_Engine/Query/ElementIds/ElementIds.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIds.cs
@@ -91,6 +91,12 @@ namespace BH.Revit.Engine.Core
 
         public static IEnumerable<ElementId> ElementIds(this FilterByActiveWorkset request, Document document, IEnumerable<ElementId> ids = null)
         {
+            if (document.IsLinked)
+            {
+                BH.Engine.Reflection.Compute.RecordError("It is not allowed to combine active workset requests with link requests.");
+                return null;
+            }
+
             return document.ElementIdsByWorksets(new List<WorksetId> { document.ActiveWorksetId() }, ids);
         }
 
@@ -105,6 +111,12 @@ namespace BH.Revit.Engine.Core
 
         public static IEnumerable<ElementId> ElementIds(this SelectionRequest request, Document document, IEnumerable<ElementId> ids = null)
         {
+            if (document.IsLinked)
+            {
+                BH.Engine.Reflection.Compute.RecordError("It is not allowed to combine selection requests with link requests - Revit selection does not work with links.");
+                return null;
+            }
+
             return new UIDocument(document).ElementIdsBySelection(ids);
         }
 
@@ -290,6 +302,8 @@ namespace BH.Revit.Engine.Core
             foreach (IRequest subRequest in request.Requests.SortByPerformance())
             {
                 result = subRequest.IElementIds(document, result);
+                if (result == null)
+                    return null;
             }
 
             return result;
@@ -302,7 +316,11 @@ namespace BH.Revit.Engine.Core
             HashSet<ElementId> result = new HashSet<ElementId>();
             foreach (IRequest subRequest in request.Requests)
             {
-                result.UnionWith(subRequest.IElementIds(document, ids));
+                IEnumerable<ElementId> subResult = subRequest.IElementIds(document, ids);
+                if (subResult == null)
+                    return null;
+
+                result.UnionWith(subResult);
             }
 
             return result;
@@ -313,6 +331,9 @@ namespace BH.Revit.Engine.Core
         public static IEnumerable<ElementId> ElementIds(this LogicalNotRequest request, Document document, IEnumerable<ElementId> ids = null)
         {
             IEnumerable<ElementId> toExclude = request.Request.IElementIds(document);
+            if (toExclude == null)
+                return null;
+
             return document.ElementIdsByExclusion(toExclude, ids);
         }
 

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInView.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInView.cs
@@ -60,7 +60,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                BH.Engine.Reflection.Compute.RecordError(String.Format("Couldn't find a View under ElementId {0}", viewId));
+                BH.Engine.Reflection.Compute.RecordError($"Couldn't find a View under ElementId {viewId} in document {document.Title}.");
                 return new HashSet<ElementId>();
             }
         }

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsOfActiveView.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsOfActiveView.cs
@@ -43,6 +43,12 @@ namespace BH.Revit.Engine.Core
             if (document == null)
                 return null;
 
+            if (document.IsLinked)
+            {
+                BH.Engine.Reflection.Compute.RecordError("It is not allowed to combine active view requests with link requests.");
+                return null;
+            }
+
             if (ids != null && !ids.Contains(document.ActiveView.Id))
                 return new List<ElementId>();
             else


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #999

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
_Link_StandardRequests_ on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FRequests%2FLink&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - no need to go through the whole test file, only orange groups should be relevant.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Querying link documents for ElementIds made more robust and errors made more informative

### Additional comments
<!-- As required -->