### PR TITLE
BH.oM.Physical.Elements.ISurfaces stopped from failing to transform when their Location is not PlanarSurface

### DIFF
--- a/Revit_Core_Engine/Query/OpeningSurface.cs
+++ b/Revit_Core_Engine/Query/OpeningSurface.cs
@@ -179,7 +179,7 @@ namespace BH.Revit.Engine.Core
                         pc.Curves.Add(new BH.oM.Geometry.Line { Start = pc.EndPoint(), End = pc.StartPoint() });
                 }
 
-                return new List<ISurface>(outlines.Select(x => new PlanarSurface(x, null)));
+                return new List<ISurface>(outlines.Select(x => new PlanarSurface(x, new List<ICurve>())));
             }
             else
                 return familyInstance.OpeningSurfaces_Curtain();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Engine/pull/2416

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1001

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
- problem-specific files: *#1001-TransformPolySurfaceBug.gh* from [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FRevit%5FToolkit%2F%231001%2DTransformPolySurfaceBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4), to be tested with _FromLink_PullPanelLocation.rvt_ from [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPull%2FFromLink&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)
- general test files: _FromLink_PullWallFloorRoofLocation.gh_ with _FromLink_PullPanelLocation.rvt_ from [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPull%2FFromLink&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.oM.Physical.Elements.ISurfaces` stopped from failing to transform when their Location is not `PlanarSurface`

### Additional comments
<!-- As required -->
The issue mentioned in the header of this PR is 99% covered by https://github.com/BHoM/BHoM_Engine/pull/2416. This PR is building on top of it, by eliminating the edge case `NullReferenceException` that may occur, totalling with (hopefully) fairly robust behaviour.