### PR TITLE
Initial Setup for Facade Discipline Additions

### DIFF
--- a/Revit_Core_Engine/Convert/Facade/FromRevit/CurtainWall.cs
+++ b/Revit_Core_Engine/Convert/Facade/FromRevit/CurtainWall.cs
@@ -20,29 +20,34 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.Engine.Facade;
+using BH.Engine.Geometry;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Geometry;
+using BH.oM.Physical.Constructions;
+using BH.oM.Facade.Elements;
+using BH.oM.Facade.SectionProperties;
+using System;
+using System.Collections.Generic;
 
-namespace BH.oM.Adapters.Revit.Enums
+namespace BH.Revit.Engine.Core
 {
-    /***************************************************/
-
-    [Description("Enumerator allowing choosing to which discipline (and corresponding namespace) should Revit elements be converted on pull.")]
-    public enum Discipline
+    public static partial class Convert
     {
-        [Description("Default discipline to be used.")]
-        Undefined,
-        [Description("Elements to be converted to types from BH.oM.Environment. If no suitable conversion exists, default discipline to be used.")]
-        Environmental,
-        [Description("Elements to be converted to types from BH.oM.Structure. If no suitable conversion exists, default discipline to be used.")]
-        Structural,
-        [Description("Elements to be converted to types from BH.oM.Architecture. If no suitable conversion exists, default discipline to be used.")]
-        Architecture,
-        [Description("Elements to be converted to types from BH.oM.Physical. If no suitable conversion exists, default discipline to be used.")]
-        Physical,
-        [Description("Elements to be converted to types from BH.oM.Physical. If no suitable conversion exists, default discipline to be used.")]
-        Facade,
-    }
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
 
-    /***************************************************/
+        public static oM.Facade.Elements.CurtainWall FacadeCurtainWallFromRevit(this Wall wall, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            BH.Engine.Reflection.Compute.RecordError("Conversion of CurtainWalls from Revit for the Facade discipline is not yet implemented."); 
+            return null;
+        }
+
+        /***************************************************/
+    }
 }
 

--- a/Revit_Core_Engine/Convert/Facade/FromRevit/CurtainWall.cs
+++ b/Revit_Core_Engine/Convert/Facade/FromRevit/CurtainWall.cs
@@ -41,7 +41,7 @@ namespace BH.Revit.Engine.Core
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static oM.Facade.Elements.CurtainWall FacadeCurtainWallFromRevit(this Wall wall, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static oM.Facade.Elements.CurtainWall CurtainWallFromRevit(this Wall wall, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             BH.Engine.Reflection.Compute.RecordError("Conversion of CurtainWalls from Revit for the Facade discipline is not yet implemented."); 
             return null;

--- a/Revit_Core_Engine/Convert/Facade/FromRevit/FrameEdge.cs
+++ b/Revit_Core_Engine/Convert/Facade/FromRevit/FrameEdge.cs
@@ -41,7 +41,7 @@ namespace BH.Revit.Engine.Core
         /****               Public Methods              ****/
         /***************************************************/
 
-        public static oM.Facade.Elements.FrameEdge FacadeFrameEdgeFromRevit(this FamilyInstance familyInstance, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static oM.Facade.Elements.FrameEdge FrameEdgeFromRevit(this FamilyInstance familyInstance, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             BH.Engine.Reflection.Compute.RecordError("Conversion of FrameEdges from Revit for the Facade discipline is not yet implemented.");
             return null;

--- a/Revit_Core_Engine/Convert/Facade/FromRevit/FrameEdge.cs
+++ b/Revit_Core_Engine/Convert/Facade/FromRevit/FrameEdge.cs
@@ -20,29 +20,34 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.Engine.Facade;
+using BH.Engine.Geometry;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Geometry;
+using BH.oM.Physical.Constructions;
+using BH.oM.Facade.Elements;
+using BH.oM.Facade.SectionProperties;
+using System;
+using System.Collections.Generic;
 
-namespace BH.oM.Adapters.Revit.Enums
+namespace BH.Revit.Engine.Core
 {
-    /***************************************************/
-
-    [Description("Enumerator allowing choosing to which discipline (and corresponding namespace) should Revit elements be converted on pull.")]
-    public enum Discipline
+    public static partial class Convert
     {
-        [Description("Default discipline to be used.")]
-        Undefined,
-        [Description("Elements to be converted to types from BH.oM.Environment. If no suitable conversion exists, default discipline to be used.")]
-        Environmental,
-        [Description("Elements to be converted to types from BH.oM.Structure. If no suitable conversion exists, default discipline to be used.")]
-        Structural,
-        [Description("Elements to be converted to types from BH.oM.Architecture. If no suitable conversion exists, default discipline to be used.")]
-        Architecture,
-        [Description("Elements to be converted to types from BH.oM.Physical. If no suitable conversion exists, default discipline to be used.")]
-        Physical,
-        [Description("Elements to be converted to types from BH.oM.Physical. If no suitable conversion exists, default discipline to be used.")]
-        Facade,
-    }
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
 
-    /***************************************************/
+        public static oM.Facade.Elements.FrameEdge FacadeFrameEdgeFromRevit(this FamilyInstance familyInstance, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            BH.Engine.Reflection.Compute.RecordError("Conversion of FrameEdges from Revit for the Facade discipline is not yet implemented.");
+            return null;
+        }
+
+        /***************************************************/
+    }
 }
 

--- a/Revit_Core_Engine/Convert/Facade/FromRevit/Opening.cs
+++ b/Revit_Core_Engine/Convert/Facade/FromRevit/Opening.cs
@@ -20,29 +20,34 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.Engine.Facade;
+using BH.Engine.Geometry;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Geometry;
+using BH.oM.Physical.Constructions;
+using BH.oM.Facade.Elements;
+using BH.oM.Facade.SectionProperties;
+using System;
+using System.Collections.Generic;
 
-namespace BH.oM.Adapters.Revit.Enums
+namespace BH.Revit.Engine.Core
 {
-    /***************************************************/
-
-    [Description("Enumerator allowing choosing to which discipline (and corresponding namespace) should Revit elements be converted on pull.")]
-    public enum Discipline
+    public static partial class Convert
     {
-        [Description("Default discipline to be used.")]
-        Undefined,
-        [Description("Elements to be converted to types from BH.oM.Environment. If no suitable conversion exists, default discipline to be used.")]
-        Environmental,
-        [Description("Elements to be converted to types from BH.oM.Structure. If no suitable conversion exists, default discipline to be used.")]
-        Structural,
-        [Description("Elements to be converted to types from BH.oM.Architecture. If no suitable conversion exists, default discipline to be used.")]
-        Architecture,
-        [Description("Elements to be converted to types from BH.oM.Physical. If no suitable conversion exists, default discipline to be used.")]
-        Physical,
-        [Description("Elements to be converted to types from BH.oM.Physical. If no suitable conversion exists, default discipline to be used.")]
-        Facade,
-    }
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
 
-    /***************************************************/
+        public static oM.Facade.Elements.Opening FacadeOpeningFromRevit(this FamilyInstance familyInstance, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            BH.Engine.Reflection.Compute.RecordError("Conversion of Openings from Revit for the Facade discipline is not yet implemented.");
+            return null;
+        }
+
+        /***************************************************/
+    }
 }
 

--- a/Revit_Core_Engine/Convert/Facade/FromRevit/Panel.cs
+++ b/Revit_Core_Engine/Convert/Facade/FromRevit/Panel.cs
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.Engine.Facade;
+using BH.Engine.Geometry;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Geometry;
+using BH.oM.Physical.Constructions;
+using BH.oM.Facade.Elements;
+using BH.oM.Facade.SectionProperties;
+using System;
+using System.Collections.Generic;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        public static oM.Facade.Elements.Panel FacadePanelFromRevit(this FamilyInstance familyInstance, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            BH.Engine.Reflection.Compute.RecordError("Conversion of Panels from Revit for the Facade discipline is not yet implemented.");
+            return null;
+        }
+
+        /***************************************************/
+
+        public static oM.Facade.Elements.Panel FacadePanelFromRevit(this Wall wall, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            BH.Engine.Reflection.Compute.RecordError("Conversion of Panels from Revit for the Facade discipline is not yet implemented.");
+            return null;
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -157,15 +157,15 @@ namespace BH.Revit.Engine.Core
                 case Discipline.Structural:
                     result = wall.StructuralPanelsFromRevit(settings, refObjects);
                     break;
-                case Discipline.Architecture:
-                case Discipline.Physical:
-                    result = new List<IElement2D> { wall.WallFromRevit(settings, refObjects) };
-                    break;
                 case Discipline.Facade:
                     if (wall.CurtainGrid != null)
                         result = new List<IElement2D> { wall.FacadeCurtainWallFromRevit(settings, refObjects) };
                     else
                         result = new List<IElement2D> { wall.FacadePanelFromRevit(settings, refObjects) };
+                    break;
+                case Discipline.Architecture:
+                case Discipline.Physical:
+                    result = new List<IElement2D> { wall.WallFromRevit(settings, refObjects) };
                     break;
             }
 
@@ -188,6 +188,7 @@ namespace BH.Revit.Engine.Core
                 case Discipline.Environmental:
                     result = ceiling.EnvironmentPanelsFromRevit(settings, refObjects);
                     break;
+                case Discipline.Facade:
                 case Discipline.Architecture:
                 case Discipline.Physical:
                     result = new List<IElement2D> { ceiling.CeilingFromRevit(settings, refObjects) };
@@ -216,6 +217,7 @@ namespace BH.Revit.Engine.Core
                 case Discipline.Structural:
                     result = floor.StructuralPanelsFromRevit(settings, refObjects);
                     break;
+                case Discipline.Facade:
                 case Discipline.Architecture:
                 case Discipline.Physical:
                     result = new List<IElement2D> { floor.FloorFromRevit(settings, refObjects) };
@@ -244,6 +246,7 @@ namespace BH.Revit.Engine.Core
                 case Discipline.Structural:
                     result = roofBase.StructuralPanelsFromRevit(settings, refObjects);
                     break;
+                case Discipline.Facade:
                 case Discipline.Architecture:
                 case Discipline.Physical:
                     result = new List<IElement2D> { roofBase.RoofFromRevit(settings, refObjects) };
@@ -267,6 +270,7 @@ namespace BH.Revit.Engine.Core
             {
                 case Discipline.Structural:
                     return hostObjAttributes.SurfacePropertyFromRevit(null, settings, refObjects) as IBHoMObject;
+                case Discipline.Facade:
                 case Discipline.Architecture:
                 case Discipline.Physical:
                 case Discipline.Environmental:
@@ -481,6 +485,7 @@ namespace BH.Revit.Engine.Core
                 case Discipline.Environmental:
                     result = spatialElement.SpaceFromRevit(settings, refObjects);
                     break;
+                case Discipline.Facade:
                 case Discipline.Architecture:
                 case Discipline.Physical:
                     result = spatialElement.RoomFromRevit(settings, refObjects);
@@ -503,6 +508,7 @@ namespace BH.Revit.Engine.Core
             IElement2D result = null;
             switch (discipline)
             {
+                case Discipline.Facade:
                 case Discipline.Environmental:
                 case Discipline.Architecture:
                 case Discipline.Physical:
@@ -526,6 +532,7 @@ namespace BH.Revit.Engine.Core
             IElement2D result = null;
             switch (discipline)
             {
+                case Discipline.Facade:
                 case Discipline.Environmental:
                 case Discipline.Architecture:
                 case Discipline.Physical:
@@ -549,6 +556,7 @@ namespace BH.Revit.Engine.Core
             IElement2D result = null;
             switch (discipline)
             {
+                case Discipline.Facade:
                 case Discipline.Environmental:
                 case Discipline.Architecture:
                 case Discipline.Physical:
@@ -608,6 +616,7 @@ namespace BH.Revit.Engine.Core
                     return material.SolidMaterialFromRevit(settings, refObjects);
                 case Discipline.Structural:
                     return material.MaterialFragmentFromRevit(null, settings, refObjects);
+                case Discipline.Facade:
                 case Discipline.Physical:
                     return material.MaterialFromRevit(null, settings, refObjects);
                 default:

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -112,6 +112,12 @@ namespace BH.Revit.Engine.Core
                     case Discipline.Environmental:
                         result = new List<IElement> { familyInstance.EnvironmentPanelFromRevit(settings, refObjects) };
                         break;
+                    case Discipline.Facade:
+                        if (typeof(BH.oM.Facade.Elements.Opening).BuiltInCategories().Contains((BuiltInCategory)familyInstance.Category.Id.IntegerValue))
+                            result = new List<IElement> { familyInstance.FacadeOpeningFromRevit(settings, refObjects) };
+                        else if (typeof(BH.oM.Facade.Elements.FrameEdge).BuiltInCategories().Contains((BuiltInCategory)familyInstance.Category.Id.IntegerValue))
+                            result = new List<IElement> { familyInstance.FacadeFrameEdgeFromRevit(settings, refObjects) };
+                        break;
                 }
 
                 if (result != null && transform?.IsIdentity == false)

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -116,7 +116,7 @@ namespace BH.Revit.Engine.Core
                         if (typeof(BH.oM.Facade.Elements.Opening).BuiltInCategories().Contains((BuiltInCategory)familyInstance.Category.Id.IntegerValue))
                             result = new List<IElement> { familyInstance.FacadeOpeningFromRevit(settings, refObjects) };
                         else if (typeof(BH.oM.Facade.Elements.FrameEdge).BuiltInCategories().Contains((BuiltInCategory)familyInstance.Category.Id.IntegerValue))
-                            result = new List<IElement> { familyInstance.FacadeFrameEdgeFromRevit(settings, refObjects) };
+                            result = new List<IElement> { familyInstance.FrameEdgeFromRevit(settings, refObjects) };
                         break;
                 }
 
@@ -159,7 +159,7 @@ namespace BH.Revit.Engine.Core
                     break;
                 case Discipline.Facade:
                     if (wall.CurtainGrid != null)
-                        result = new List<IElement2D> { wall.FacadeCurtainWallFromRevit(settings, refObjects) };
+                        result = new List<IElement2D> { wall.CurtainWallFromRevit(settings, refObjects) };
                     else
                         result = new List<IElement2D> { wall.FacadePanelFromRevit(settings, refObjects) };
                     break;

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -155,6 +155,12 @@ namespace BH.Revit.Engine.Core
                 case Discipline.Physical:
                     result = new List<IElement2D> { wall.WallFromRevit(settings, refObjects) };
                     break;
+                case Discipline.Facade:
+                    if (wall.CurtainGrid != null)
+                        result = new List<IElement2D> { wall.FacadeCurtainWallFromRevit(settings, refObjects) };
+                    else
+                        result = new List<IElement2D> { wall.FacadePanelFromRevit(settings, refObjects) };
+                    break;
             }
 
             if (result != null && transform?.IsIdentity == false)

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Wall.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Wall.cs
@@ -52,9 +52,9 @@ namespace BH.Revit.Engine.Core
                 return null;
 
             if (wall.CurtainGrid != null)
-                bHoMWall = wall.CurtainWallFromRevit(settings, refObjects);
+                bHoMWall = wall.WallFromRevit_Curtain(settings, refObjects);
             else
-                bHoMWall = wall.SolidWallFromRevit(settings, refObjects);
+                bHoMWall = wall.WallFromRevit_Solid(settings, refObjects);
 
             if (bHoMWall == null)
                 return null;
@@ -80,7 +80,7 @@ namespace BH.Revit.Engine.Core
         /****              Private Methods              ****/
         /***************************************************/
 
-        private static oM.Physical.Elements.Wall SolidWallFromRevit(this Wall wall, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        private static oM.Physical.Elements.Wall WallFromRevit_Solid(this Wall wall, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             ISurface location = null;
             List<BH.oM.Physical.Elements.IOpening> openings = new List<oM.Physical.Elements.IOpening>();
@@ -138,7 +138,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        private static oM.Physical.Elements.Wall CurtainWallFromRevit(this Wall wall, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        private static oM.Physical.Elements.Wall WallFromRevit_Curtain(this Wall wall, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             List<BH.oM.Physical.Elements.IOpening> curtainPanels = wall.CurtainGrid.CurtainPanels(wall.Document, settings, refObjects);
             

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -161,7 +161,14 @@ namespace BH.Revit.Engine.Core
                     Autodesk.Revit.DB.BuiltInCategory.OST_StructuralStiffener,
                     Autodesk.Revit.DB.BuiltInCategory.OST_StructuralFramingOther
                 }
-            }
+            },
+            {
+                typeof (BH.oM.Facade.Elements.Opening), new BuiltInCategory[]
+                {
+                    Autodesk.Revit.DB.BuiltInCategory.OST_Doors,
+                    Autodesk.Revit.DB.BuiltInCategory.OST_Windows,
+                }
+            },
         };
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -25,6 +25,7 @@ using BH.Engine.Adapters.Revit;
 using BH.oM.Base;
 using BH.oM.Physical.Elements;
 using BH.oM.Structure.Elements;
+using BH.oM.Facade.Elements;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -167,6 +168,12 @@ namespace BH.Revit.Engine.Core
                 {
                     Autodesk.Revit.DB.BuiltInCategory.OST_Doors,
                     Autodesk.Revit.DB.BuiltInCategory.OST_Windows,
+                }
+            },
+            {
+                typeof (FrameEdge), new BuiltInCategory[]
+                {
+                    Autodesk.Revit.DB.BuiltInCategory.OST_CurtainWallMullions,
                 }
             },
         };

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -169,6 +169,16 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Environment_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Facade_Engine">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Facade_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Facade_oM">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Facade_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Geometry_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
       <Private>False</Private>
@@ -299,6 +309,7 @@
     <Compile Include="Compute\PrepareForLinkDimensioning.cs" />
     <Compile Include="Compute\SplitRequestTreeByLinks.cs" />
     <Compile Include="Convert\Architecture\FromRevit\Room.cs" />
+    <Compile Include="Convert\Facade\FromRevit\FrameEdge.cs" />
     <Compile Include="Convert\MEP\FromRevit\CableTray.cs" />
     <Compile Include="Convert\MEP\FromRevit\Duct.cs" />
     <Compile Include="Convert\MEP\FromRevit\Pipe.cs" />
@@ -404,6 +415,9 @@
     <Compile Include="Create\Options.cs" />
     <Compile Include="Compute\LoadFamily.cs" />
     <Compile Include="Modify\AddOrReplace.cs" />
+    <Compile Include="Convert\Facade\FromRevit\Opening.cs" />
+    <Compile Include="Convert\Facade\FromRevit\Panel.cs" />
+    <Compile Include="Convert\Facade\FromRevit\CurtainWall.cs" />
     <Compile Include="Convert\Architecture\FromRevit\Ceiling.cs" />
     <Compile Include="Convert\Revit\FromRevit\ViewPlan.cs" />
     <Compile Include="Convert\Structure\FromRevit\MaterialFragment.cs" />

--- a/Revit_Engine/Query/Discipline.cs
+++ b/Revit_Engine/Query/Discipline.cs
@@ -56,6 +56,9 @@ namespace BH.Engine.Adapters.Revit
             if (type.Namespace.StartsWith("BH.oM.Physical"))
                 return oM.Adapters.Revit.Enums.Discipline.Physical;
 
+            if (type.Namespace.StartsWith("BH.oM.Facade"))
+                return oM.Adapters.Revit.Enums.Discipline.Facade;
+
             return oM.Adapters.Revit.Enums.Discipline.Undefined;
         }
 

--- a/Revit_oM/Enums/Discipline.cs
+++ b/Revit_oM/Enums/Discipline.cs
@@ -39,7 +39,7 @@ namespace BH.oM.Adapters.Revit.Enums
         Architecture,
         [Description("Elements to be converted to types from BH.oM.Physical. If no suitable conversion exists, default discipline to be used.")]
         Physical,
-        [Description("Elements to be converted to types from BH.oM.Physical. If no suitable conversion exists, default discipline to be used.")]
+        [Description("Elements to be converted to types from BH.oM.Facade. If no suitable conversion exists, default discipline to be used.")]
         Facade,
     }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

Please note this PR addresses phase one of #890 only, covering the initial setup of additional files, the facade enum, and the required convert switch changes to allow for the pull capability pr to follow.  This has been split into two separate PR's as phase one (this PR) is likely to cause merge issues if left as part of the larger effort. Review of this PR should cover maintenance of existing Revit_Toolkit functionality, as well as proper framework for future Facade Discipline pulls as tested in the test script included when pulling `Windows`, `CurtainWalls`, `Walls`, `Doors`, and `Mullions` (all of which should currently return not implemented errors).

### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%23890-FacadeElementPulls?csf=1&web=1&e=ljPS6c

