### PR TITLE
Revit_Core_Engine: Fix MEP linear objects converts

### DIFF
--- a/Revit_Core_Engine/Convert/MEP/FromRevit/CableTray.cs
+++ b/Revit_Core_Engine/Convert/MEP/FromRevit/CableTray.cs
@@ -28,7 +28,6 @@ using BH.Engine.Adapters.Revit;
 using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
-using BH.oM.MEP.System.ConnectionProperties;
 using BH.oM.MEP.System;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Geometry;
@@ -67,12 +66,8 @@ namespace BH.Revit.Engine.Core
             // Orientation angle
             double orientationAngle = revitCableTray.OrientationAngle(settings);
 
-            bool isStartConnected = false;
-            bool isEndConnected = false;
-            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitCableTray, out isStartConnected, out isEndConnected, settings);
+            List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitCableTray, settings);
 
-            Vector revitCableTrayVector = BH.Engine.Geometry.Modify.RoundCoordinates(VectorFromRevit((revitCableTray.Location as LocationCurve).Curve.GetEndPoint(0) - (revitCableTray.Location as LocationCurve).Curve.GetEndPoint(1)),4).Normalise();
-            
             for (int i = 0; i < queried.Count; i++)
             {
                 BH.oM.Geometry.Line segment = queried[i];
@@ -81,59 +76,8 @@ namespace BH.Revit.Engine.Core
                     StartPoint = segment.StartPoint(),
                     EndPoint = segment.EndPoint(),
                     SectionProperty = sectionProperty,
-                    ConnectionProperty = new CableTrayConnectionProperty(),
                     OrientationAngle = orientationAngle
                 };
-                
-                Vector bhomCableTrayVector = BH.Engine.Geometry.Modify.RoundCoordinates((thisSegment.StartPoint - thisSegment.EndPoint),4).Normalise();
-
-                if (queried.Count > 1)
-                {
-                    if (i == 0) //meaning it's the start segment of the revit cable tray that was split
-                    {
-                        if (BH.Engine.Geometry.Query.IsEqual(revitCableTrayVector, bhomCableTrayVector))
-                        {
-                            thisSegment.ConnectionProperty.IsStartConnected = isStartConnected;
-                            thisSegment.ConnectionProperty.IsEndConnected = true;
-                        }
-                        else
-                        {
-                            thisSegment.ConnectionProperty.IsStartConnected = true;
-                            thisSegment.ConnectionProperty.IsEndConnected = isStartConnected;   
-                        }
-                    }
-                    else if (i == queried.Count - 1) //meaning it's the end segment of the revit cable tray that was split
-                    {
-                        if (BH.Engine.Geometry.Query.IsEqual(revitCableTrayVector, bhomCableTrayVector))
-                        {
-                            thisSegment.ConnectionProperty.IsStartConnected = true;
-                            thisSegment.ConnectionProperty.IsEndConnected = isEndConnected;
-                        }
-                        else
-                        {
-                            thisSegment.ConnectionProperty.IsStartConnected = isEndConnected;
-                            thisSegment.ConnectionProperty.IsEndConnected = true;   
-                        }
-                    }
-                    else //meaning it's all mid segments of the revit cable tray that was split
-                    {
-                        thisSegment.ConnectionProperty.IsStartConnected = true;
-                        thisSegment.ConnectionProperty.IsEndConnected = true;
-                    }
-                }
-                else
-                {
-                    if (BH.Engine.Geometry.Query.IsEqual(revitCableTrayVector, bhomCableTrayVector))
-                    {
-                        thisSegment.ConnectionProperty.IsStartConnected = isStartConnected;
-                        thisSegment.ConnectionProperty.IsEndConnected = isEndConnected;
-                    }
-                    else
-                    {
-                        thisSegment.ConnectionProperty.IsStartConnected = isEndConnected;
-                        thisSegment.ConnectionProperty.IsEndConnected = isStartConnected;   
-                    }
-                }
 
                 //Set identifiers, parameters & custom data
                 thisSegment.SetIdentifiers(revitCableTray);

--- a/Revit_Core_Engine/Query/LocationCurve.cs
+++ b/Revit_Core_Engine/Query/LocationCurve.cs
@@ -41,6 +41,10 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
+        [Description("Queries a FamilyInstance to find its start and end points.")]
+        [Input("familyInstance", "Revit FamilyInstance to be queried.")]
+        [Input("settings", "Optional, the RevitSettings to be used.")]
+        [Output("locationCurveFraming", "BHoM curve queried from the Family Instance.")]
         public static ICurve LocationCurve(this FamilyInstance familyInstance, RevitSettings settings = null)
         {
             settings = settings.DefaultIfNull();
@@ -56,6 +60,10 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
         
+        [Description("Queries a FamilyInstance to find its start and end points, intended usage for framings.")]
+        [Input("familyInstance", "Revit FamilyInstance to be queried.")]
+        [Input("settings", "Optional, the RevitSettings to be used.")]
+        [Output("locationCurveFraming", "BHoM curve queried from the Family Instance.")]
         public static ICurve LocationCurveFraming(this FamilyInstance familyInstance, RevitSettings settings = null)
         {
             settings = settings.DefaultIfNull();
@@ -94,6 +102,10 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Queries a FamilyInstance to find its start and end points, intended usage for Columns.")]
+        [Input("familyInstance", "Revit FamilyInstance to be queried.")]
+        [Input("settings", "Optional, the RevitSettings to be used.")]
+        [Output("locationCurveColumn", "BHoM line queried from the Family Instance.")]
         public static BH.oM.Geometry.Line LocationCurveColumn(this FamilyInstance familyInstance, RevitSettings settings = null)
         {
             settings = settings.DefaultIfNull();
@@ -146,6 +158,7 @@ namespace BH.Revit.Engine.Core
         
         [Description("Queries an MEPCurve to find its start and end points, creating multiple lines segments if it contains points in between.")]
         [Input("mepCurve", "Revit MEPCurve to be queried.")]
+        [Input("settings", "Optional, the RevitSettings to be used.")]
         [Output("locationCurveMEP", "BHoM lines list queried from the MEPCurve.")]
         public static List<BH.oM.Geometry.Line> LocationCurveMEP(this MEPCurve mepCurve, RevitSettings settings = null)
         {            

--- a/Revit_Core_Engine/Query/LocationCurve.cs
+++ b/Revit_Core_Engine/Query/LocationCurve.cs
@@ -144,231 +144,26 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
         
-        [Description("Queries an MEPCurve and its fitting connectors to create a list of BHoM lines.")]
+        [Description("Queries an MEPCurve to find its start and end points, creating multiple lines segments if it contains points in between.")]
         [Input("mepCurve", "Revit MEPCurve to be queried.")]
-        [Input("isStartConnected", "An OUT operator to also extract whether the start of the MEPCurve is connected to something.")]
-        [Input("isEndConnected", "An OUT operator to also extract whether the end of the MEPCurve is connected to something.")]
-        [Output("locationCurveMEP", "BHoM lines list queried from the MEPCurve and its fitting connectors.")]
-        public static List<BH.oM.Geometry.Line> LocationCurveMEP(this MEPCurve mepCurve, out bool isStartConnected, out bool isEndConnected, RevitSettings settings = null)
+        [Output("locationCurveMEP", "BHoM lines list queried from the MEPCurve.")]
+        public static List<BH.oM.Geometry.Line> LocationCurveMEP(this MEPCurve mepCurve, RevitSettings settings = null)
         {            
-            settings = settings.DefaultIfNull();
-            
-            // Determine start and end points, which if the MEP linear object is connected to
-            // a fitting then uses the fitting origin as either start/end
-            List<BH.oM.Geometry.Point> allPoints = new List<BH.oM.Geometry.Point>();
-            
-            var tolerance = BH.oM.Adapters.Revit.Tolerance.Vertex.FromSI(UnitType.UT_Length);
-            
-            //add placeholder for extra lines required to snap multi-connected fittings
-            BH.oM.Geometry.Line extraLine1 = null;
-            BH.oM.Geometry.Line extraLine2 = null;
+            //sometimes an mepcurve will be connected without fittings
+            //causing connections to occur in the middle of the locationcurve
+            //hence the best approach is to also query the connections that are not end, to split curve there
+            //so it becomes a node in a network and not ignored
 
-            //save points to recreate line later
-            List<BH.oM.Geometry.Point> endPoints = new List<BH.oM.Geometry.Point>();
-            List<BH.oM.Geometry.Point> midPoints = new List<BH.oM.Geometry.Point>();
-
-            // Get connectors
             ConnectorManager connectorManager = mepCurve.ConnectorManager;
             ConnectorSet connectorSet = connectorManager.Connectors;
-            List<Connector> c1Connectors = connectorSet.Cast<Connector>().ToList();
-            isStartConnected = false;
-            isEndConnected = false;
+            List<Connector> connectors = connectorSet.Cast<Connector>().ToList();
             
-            // the following logic is applied below
-            // we must get both END connectors of mepcurve SELF 
-            // for each END connector c1 check if it's connected
-            // if connected check its references (every object that refers to it)
-            // and grab c2 that is not from SELF (meaning the fitting connected to it)
-            // grab c2 object owner, if it's a fitting then get all connectors
-            // grab c3 from fitting 1 that is not c2 (retrieves the other end of fitting 1)
-            // if c3 is connected then get its references
-            // and grab c4 that is not c3
-            // grab c4 object owner, if it's a fitting then get all connectors
-            // grab c5 from fitting 2 that is not c4 (retrieves the other end of fitting 1)
+            List<BH.oM.Geometry.Point> endPoints = connectors.Where(x => x.ConnectorType == ConnectorType.End).Select(x => x.Origin.PointFromRevit()).ToList();
+            List<BH.oM.Geometry.Point> midPoints = connectors.Where(x => x.ConnectorType != ConnectorType.End).Select(x => x.Origin.PointFromRevit()).ToList();
             
-            // depending on the conditions above it'll try to recreate the linear object
-            // either by a simple straight line from connector to connector
-            //     - MEP curve without fittings
-            //     - or MEP curve that connects with/without fitting
-            // or adds extra lines if MEP curve is connected by a chain (up to 2 devices) of fittings
-            //     - if this is the case then it performs the aforementioned loop to find all possible connections
-            // also any connectors that are not END in the beginning must be accounted
-            //     - mid connectors means mep curves connected without fittings (in particular cable trays)
-            
-            for (int i = 0; i < c1Connectors.Count; i++)
-            {
-                BH.oM.Geometry.Point locationToSnap = null;
-                BH.oM.Geometry.Point locationFromSnap = null;
-                
-                Connector c1 = c1Connectors[i];
-                if (c1.ConnectorType == ConnectorType.End)
-                {
-                    locationFromSnap = BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4);
-                    if (c1.IsConnected)
-                    {
-                        List<Connector> c2Connectors = (c1.AllRefs).Cast<Connector>().ToList();
-                        for (int j = 0; j < c2Connectors.Count; j++)
-                        {
-                            Connector c2 = c2Connectors[j];
-                            if (c2.Owner.Id != c1.Owner.Id)
-                            {
-                                if (!(c2.Owner is MEPCurve))
-                                {
-                                    FamilyInstance familyInstance1 = c2.Owner as FamilyInstance;
-                                    ConnectorManager connectorManager1 = familyInstance1.MEPModel.ConnectorManager;
-                                    List<Connector> c3Connectors = (connectorManager1.Connectors).Cast<Connector>().ToList();
-                                    if (c3Connectors.Count == 2)
-                                    {
-                                        for (int k = 0; k < c3Connectors.Count; k++)
-                                        {
-                                            Connector c3 = c3Connectors[k];
-                                            if (c3.Origin.DistanceTo(c1.Origin) > tolerance)
-                                            {
-                                                if (c3.IsConnected)
-                                                {
-                                                    List<Connector> c4Connectors = (c3.AllRefs).Cast<Connector>().ToList();
-                                                    for (int l = 0; l < c4Connectors.Count; l++)
-                                                    {
-                                                        Connector c4 = c4Connectors[l];
-                                                        if (c4.Owner.Id != c2.Owner.Id && c4.Owner.Id != c1.Owner.Id)
-                                                        {
-                                                            if (!(c4.Owner is MEPCurve))
-                                                            {
-                                                                FamilyInstance familyInstance2 = c4.Owner as FamilyInstance;
-                                                                ConnectorManager connectorManager2 = familyInstance2.MEPModel.ConnectorManager;
-                                                                List<Connector> c5Connectors = (connectorManager2.Connectors).Cast<Connector>().ToList();
-                                                                if (c5Connectors.Count == 2)
-                                                                {
-                                                                    for (int m = 0; m < c5Connectors.Count; m++)
-                                                                    {
-                                                                        Connector c5 = c5Connectors[m];
-                                                                        if (c5.Origin.DistanceTo(c4.Origin) > tolerance)
-                                                                        {
-                                                                            locationToSnap = BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c5.Origin),4);
-                                                                            BH.oM.Geometry.Line longLine = BH.Engine.Geometry.Create.Line(locationToSnap, locationFromSnap);
-                                                                            locationToSnap = BH.Engine.Geometry.Modify.RoundCoordinates(longLine.PointAtParameter(0.5),4);
-                                                                            
-                                                                            endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
-                                                                            BH.oM.Geometry.Line shortLine = BH.Engine.Geometry.Create.Line(locationToSnap, locationFromSnap);
-
-                                                                            if (c1.Id == 0)
-                                                                            {
-                                                                                extraLine1 = shortLine;
-                                                                                if (c5.IsConnected)
-                                                                                    isStartConnected = true;
-                                                                            }
-                                                                            else
-                                                                            {
-                                                                                extraLine2 = shortLine;
-                                                                                if (c5.IsConnected)
-                                                                                    isEndConnected = true;
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                                else
-                                                                {
-                                                                    //meaning this fitting could be a T or a cross shape
-                                                                    locationToSnap = BH.Engine.Geometry.Modify.RoundCoordinates(Convert.FromRevit((familyInstance2.Location) as LocationPoint),4);
-                                                                    BH.oM.Geometry.Line shortLine = BH.Engine.Geometry.Create.Line(locationToSnap, locationFromSnap);
-                                                                    endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
-                                                                    
-                                                                    if (c1.Id == 0)
-                                                                    {
-                                                                        extraLine1 = shortLine;
-                                                                        if (c5Connectors.Any(x => x.IsConnected == true))
-                                                                            isStartConnected = true;
-                                                                    }
-                                                                    else
-                                                                    {
-                                                                        extraLine2 = shortLine;
-                                                                        if (c5Connectors.Any(x => x.IsConnected == true))
-                                                                            isEndConnected = true;
-                                                                    }
-                                                                }
-                                                            }
-                                                            else
-                                                            {
-                                                                endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.FromRevit((c3.Owner.Location) as LocationPoint),4));
-                                                                if (c1.Id == 0)
-                                                                    isStartConnected = true;
-                                                                else
-                                                                    isEndConnected = true;
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                                else
-                                                {
-                                                    endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin), 4));
-                                                    locationToSnap = BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c3.Origin), 4);
-                                                    BH.oM.Geometry.Line shortLine = BH.Engine.Geometry.Create.Line(locationToSnap, locationFromSnap);
-
-                                                    if (c1.Id == 0)
-                                                    {
-                                                        extraLine1 = shortLine;
-                                                    }
-                                                    else
-                                                    {
-                                                        extraLine2 = shortLine;
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                    else
-                                    {
-                                        //meaning fitting could be a T or a cross
-                                        endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.FromRevit((familyInstance1.Location)as LocationPoint),4));
-                                        if (c1.Id == 0)
-                                        {
-                                            if (c3Connectors.Any(x => x.IsConnected == true))
-                                                isStartConnected = true;
-                                        }
-                                        else
-                                        {
-                                            if (c3Connectors.Any(x => x.IsConnected == true))
-                                                isEndConnected = true;
-                                        }
-                                    }
-                                }
-                                else
-                                {
-                                    endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
-                                    if (c1.Id == 0)
-                                    {
-                                        isStartConnected = true; // because c1 is connected
-                                    }
-                                    else
-                                    {
-                                        isEndConnected = true; //because c1 is connected
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        endPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
-                    }
-                }
-                else
-                {
-                    //if MEP linear object has connections that don't take fitting,
-                    //then we need to store the point to later split the curve
-                    midPoints.Add(BH.Engine.Geometry.Modify.RoundCoordinates(Convert.PointFromRevit(c1.Origin),4));
-                }
-            }
-
-            //split MEP linear object if there was any other MEP linear object connected to it without fitting
             BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(endPoints[0], endPoints[1]);
             List<BH.oM.Geometry.Line> result = new List<BH.oM.Geometry.Line>();
-            
-            if (extraLine1 != null) 
-            {
-                result.Add(extraLine1);
-            }
-            
+
             if (midPoints.Any())
             {
                 result.AddRange(line.SplitAtPoints(midPoints));
@@ -377,50 +172,10 @@ namespace BH.Revit.Engine.Core
             {
                 result.Add(line);
             }
-            
-            if (extraLine2 != null) 
-            {
-                result.Add(extraLine2);
-            }
 
-            return MatchRevitOrder(result,mepCurve);
+            return result;
         }
-        
-        /***************************************************/
-        
-        [Description("Queries an MEPCurve and its fitting connectors to create a list of BHoM lines.")]
-        [Input("mepCurve", "Revit MEPCurve to be queried.")]
-        [Output("locationCurveMEP", "BHoM lines list queried from the MEPCurve and its fitting connectors.")]
-        public static List<BH.oM.Geometry.Line> LocationCurveMEP(this MEPCurve mepCurve, RevitSettings settings = null)
-        {
-            return new List<oM.Geometry.Line> { ((mepCurve?.Location as LocationCurve)?.Curve as Autodesk.Revit.DB.Line)?.FromRevit() };
-        }
-        
-        /***************************************************/
-        /****              Private Methods              ****/
-        /***************************************************/
-        
-        [Description("Re-orders converted BHoM Line list to match the direction from the reference MEPCurve.")]
-        [Input("linesToMatch", "The BHoM lines list to be re-ordered.")]
-        [Input("reference", "The MEPCurve to reference the direction order.")]
-        [Output("matchRevitOrder", "BHoM lines re-ordered to match reference MEPCurve direction.")]
-        private static List<BH.oM.Geometry.Line> MatchRevitOrder(List<BH.oM.Geometry.Line> linesToMatch, MEPCurve reference)
-        {
-            LocationCurve locationCurve = reference.Location as LocationCurve;
-            Curve curve = locationCurve.Curve;
-            BH.oM.Geometry.Point referenceStart = curve.GetEndPoint(0).PointFromRevit().RoundCoordinates(4);
-            BH.oM.Geometry.Point referenceEnd = curve.GetEndPoint(1).PointFromRevit().RoundCoordinates(4);
 
-            List<BH.oM.Geometry.Point> controlPoints = linesToMatch.SelectMany(x => x.ControlPoints()).ToList().CullDuplicates();
-            Polyline polyline = BH.Engine.Geometry.Create.Polyline(controlPoints);
-
-            if (referenceStart.IsEqual(polyline.StartPoint()) || referenceEnd.IsEqual(polyline.EndPoint()))
-                return polyline.SubParts();
-            else
-                return polyline.Flip().SubParts();    
-            
-        }
-        
         /***************************************************/
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
[BHoM/BHoM#1248](https://github.com/BHoM/BHoM/pull/1248)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1036

Simplifies the converts `FromRevit` for the linear MEP objects (cable tray, duct and pipe).


### Test files
Test files `PullCableTrays.rvt` and `PullCableTrays.gh` are [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&sortField=LinkFilename&isAscending=true&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPull)


### Changelog
Modified `BH.Revit.Engine.Core.Convert.CableTrayFromRevit`
Modified `BH.Revit.Engine.Core.Query.LocationCurveMEP`


### Additional comments
A follow up PR will address the addition of the MEP fitting object convert. This PR has simplified the converts of linear objects to not take fittings in consideration.