### PR TITLE
FamilyLibrary re-enabled on ElementType query

### DIFF
--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -103,7 +103,7 @@ namespace BH.Revit.Engine.Core
             string familyName, familyTypeName;
             bHoMObject.FamilyAndTypeNames(out familyName, out familyTypeName);
 
-            return document.ElementType(familyName, familyTypeName, builtInCategories);
+            return document.ElementType(familyName, familyTypeName, builtInCategories, settings);
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1039

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FFamilyLibrary) - on `master` it simply does not work, while on this branch should 🙈 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
@enarhi @tiagogrossi I would be thankful for the review of one of you - this is pretty urgent as the bug should be removed before the Beta release. Thanks!