### PR TITLE
Revit_Core_Engine: Allow custom boundingbox for isometric 3D views

### DIFF
--- a/Revit_Core_Engine/Create/View/View3D.cs
+++ b/Revit_Core_Engine/Create/View/View3D.cs
@@ -37,10 +37,11 @@ namespace BH.Revit.Engine.Core
         [Description("Creates and returns a new ISOMETRIC 3D view in the current Revit file.")]
         [Input("document", "Revit current document to be processed.")]
         [Input("viewName", "Optional, name of the new view.")]
+        [Input("boundingBoxXyz", "Optional, the cuboid BoundingBoxXYZ to fit isometric view.")]
         [Input("viewTemplateId", "Optional, the View Template Id to be applied in the view.")]
         [Input("viewDetailLevel", "Optional, the Detail Level of the view.")]        
         [Output("view3D", "The new view.")]        
-        public static View View3D(this Document document, string viewName = null, ElementId viewTemplateId = null, ViewDetailLevel viewDetailLevel = ViewDetailLevel.Coarse)
+        public static View View3D(this Document document, string viewName = null, BoundingBoxXYZ boundingBoxXyz = null, ElementId viewTemplateId = null, ViewDetailLevel viewDetailLevel = ViewDetailLevel.Coarse)
         {
             View result = null;
 
@@ -49,6 +50,18 @@ namespace BH.Revit.Engine.Core
             result = Autodesk.Revit.DB.View3D.CreateIsometric(document, vft.Id);
             
             Modify.SetViewDetailLevel(result, viewDetailLevel);
+
+            if (boundingBoxXyz != null)
+            {
+                try
+                {
+                    (result as View3D).SetSectionBox(boundingBoxXyz);
+                }
+                catch (Exception)
+                {
+                    BH.Engine.Reflection.Compute.RecordWarning("Could not apply the custom BoundingboxXYZ the created 3D view, the default global BoundiboxXYZ has been used instead.");
+                }
+            }
 
             if (viewTemplateId != null)
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1052 

<!-- Add short description of what has been fixed -->
Adds an optional input field in the `Create.View3D` method that uses BoundingBoxXYZ to crop the 3D view to fit it.

### Changelog
Modified `BH.Revit.Engine.Core.Create.View3D`
