### PR TITLE
Revit_Core_Engine: Fitting pull converter implemented

### DIFF
--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -47,6 +47,13 @@ namespace BH.Revit.Engine.Core
         /****      Convert Revit elements to BHoM       ****/
         /***************************************************/
 
+        [Description("Converts a Revit ProjectInfo to a BHoM object based on its discipline.")]
+        [Input("projectInfo", "Revit ProjectInfo to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit ProjectInfo.")]
         public static IBHoMObject FromRevit(this ProjectInfo projectInfo, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -60,6 +67,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit EnergyAnalysisDetailModel to a BHoM object based on its discipline.")]
+        [Input("energyAnalysisModel", "Revit EnergyAnalysisDetailModel to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit EnergyAnalysisDetailModel.")]
         public static IEnumerable<IBHoMObject> FromRevit(this EnergyAnalysisDetailModel energyAnalysisModel, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -72,7 +86,14 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
-
+        
+        [Description("Converts a Revit FamilyInstance to a BHoM object based on its discipline, if it's an adaptive component and, more importantly, on its category. A multitude of instances will fall into this converter, therefore a special care is needed with the category enums in the backend.")]
+        [Input("familyInstance", "Revit FamilyInstance to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit FamilyInstance.")]
         public static IEnumerable<IBHoMObject> FromRevit(this FamilyInstance familyInstance, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             if (AdaptiveComponentInstanceUtils.IsAdaptiveComponentInstance(familyInstance))
@@ -141,6 +162,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit FamilySymbol to a BHoM object based on its discipline.")]
+        [Input("familySymbol", "Revit FamilySymbol to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit FamilySymbol.")]
         public static IBHoMObject FromRevit(this FamilySymbol familySymbol, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -155,6 +183,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit Wall to a BHoM object based on its discipline.")]
+        [Input("wall", "Revit Wall to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Wall.")]
         public static IEnumerable<IBHoMObject> FromRevit(this Wall wall, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IEnumerable<IElement2D> result = null;
@@ -189,6 +224,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit Ceiling to a BHoM object based on its discipline.")]
+        [Input("ceiling", "Revit Ceiling to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Ceiling.")]
         public static IEnumerable<IBHoMObject> FromRevit(this Ceiling ceiling, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IEnumerable<IElement2D> result = null;
@@ -215,6 +257,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit Floor to a BHoM object based on its discipline.")]
+        [Input("floor", "Revit Floor to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Floor.")]
         public static IEnumerable<IBHoMObject> FromRevit(this Floor floor, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IEnumerable<IElement2D> result = null;
@@ -244,6 +293,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit RoofBase to a BHoM object based on its discipline.")]
+        [Input("roofBase", "Revit RoofBase to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit RoofBase.")]
         public static IEnumerable<IBHoMObject> FromRevit(this RoofBase roofBase, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IEnumerable<IElement2D> result = null;
@@ -273,6 +329,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit HostObjAttributes to a BHoM object based on its discipline.")]
+        [Input("hostObjAttributes", "Revit HostObjAttributes to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit HostObjAttributes.")]
         public static IBHoMObject FromRevit(this HostObjAttributes hostObjAttributes, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -291,12 +354,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Convert a Revit cable tray into a BHoM cable tray.")]
-        [Input("cableTray", "Revit cable tray to be converted.")]
+        [Description("Converts a Revit CableTray to a BHoM object based on its discipline.")]
+        [Input("cableTray", "Revit CableTray to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
-        [Input("settings", "Revit adapter settings.")]
-        [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        [Output("cableTrays", "Resulted list of BHoM cable trays converted from a Revit cable trays.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit CableTray.")]
         public static IEnumerable<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Electrical.CableTray cableTray, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IEnumerable<IElement1D> result = null;
@@ -320,12 +384,13 @@ namespace BH.Revit.Engine.Core
         
         /***************************************************/
 
-        [Description("Convert a Revit duct into a BHoM duct.")]
-        [Input("duct", "Revit duct to be converted.")]
+        [Description("Converts a Revit Duct to a BHoM object based on its discipline.")]
+        [Input("duct", "Revit Duct to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
-        [Input("settings", "Revit adapter settings.")]
-        [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        [Output("ducts", "Resulted list of BHoM ducts converted from a Revit ducts.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Duct.")]
         public static IEnumerable<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Mechanical.Duct duct, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IEnumerable<IElement1D> result = null;
@@ -349,12 +414,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
         
-        [Description("Convert a Revit pipe into a BHoM pipe.")]
-        [Input("pipe", "Revit pipe to be converted.")]
+        [Description("Converts a Revit Pipe to a BHoM object based on its discipline.")]
+        [Input("pipe", "Revit Pipe to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
-        [Input("settings", "Revit adapter settings.")]
-        [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        [Output("pipes", "Resulted list of BHoM MEP pipes converted from a Revit pipes.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Pipe.")]
         public static IEnumerable<IBHoMObject> FromRevit(this Autodesk.Revit.DB.Plumbing.Pipe pipe, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IEnumerable<IElement1D> result = null;
@@ -378,12 +444,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Convert a Revit wire into a BHoM wire.")]
-        [Input("wire", "Revit wire to be converted.")]
+        [Description("Converts a Revit Wire to a BHoM object based on its discipline.")]
+        [Input("wire", "Revit Wire to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
-        [Input("settings", "Revit adapter settings.")]
-        [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        [Output("wire", "BHoM wire converted from a Revit wire.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Wire.")]
         public static IBHoMObject FromRevit(this Autodesk.Revit.DB.Electrical.Wire wire, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IElement1D result = null;
@@ -407,6 +474,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit Level to a BHoM object based on its discipline.")]
+        [Input("level", "Revit Level to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Level.")]
         public static IBHoMObject FromRevit(this Level level, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -422,6 +496,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit Grid to a BHoM object based on its discipline.")]
+        [Input("grid", "Revit Grid to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Grid.")]
         public static IBHoMObject FromRevit(this Grid grid, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IElement1D result = null;
@@ -443,6 +524,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit MultiSegmentGrid to a BHoM object based on its discipline.")]
+        [Input("grid", "Revit MultiSegmentGrid to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit MultiSegmentGrid.")]
         public static IBHoMObject FromRevit(this MultiSegmentGrid grid, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IElement1D result = null;
@@ -464,6 +552,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit ElementType to a BHoM object based on its discipline.")]
+        [Input("elementType", "Revit ElementType to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit ElementType.")]
         public static IBHoMObject FromRevit(this ElementType elementType, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -475,6 +570,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit GraphicsStyle to a BHoM object based on its discipline.")]
+        [Input("graphicsStyle", "Revit GraphicsStyle to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit GraphicsStyle.")]
         public static IBHoMObject FromRevit(this GraphicsStyle graphicStyle, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -486,6 +588,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit SpatialElement to a BHoM object based on its discipline.")]
+        [Input("spatialElement", "Revit SpatialElement to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit SpatialElement.")]
         public static IBHoMObject FromRevit(this SpatialElement spatialElement, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IElement2D result = null;
@@ -512,6 +621,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit EnergyAnalysisSpace to a BHoM object based on its discipline.")]
+        [Input("energyAnalysisSpace", "Revit EnergyAnalysisSpace to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit EnergyAnalysisSpace.")]
         public static IBHoMObject FromRevit(this EnergyAnalysisSpace energyAnalysisSpace, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IElement2D result = null;
@@ -536,6 +652,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit EnergyAnalysisSurface to a BHoM object based on its discipline.")]
+        [Input("energyAnalysisSurface", "Revit EnergyAnalysisSurface to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit EnergyAnalysisSurface.")]
         public static IBHoMObject FromRevit(this EnergyAnalysisSurface energyAnalysisSurface, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IElement2D result = null;
@@ -560,6 +683,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit EnergyAnalysisOpening to a BHoM object based on its discipline.")]
+        [Input("energyAnalysisOpening", "Revit EnergyAnalysisOpening to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit EnergyAnalysisOpening.")]
         public static IBHoMObject FromRevit(this EnergyAnalysisOpening energyAnalysisOpening, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             IElement2D result = null;
@@ -584,6 +714,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit ViewSheet to a BHoM object based on its discipline.")]
+        [Input("viewSheet", "Revit ViewSheet to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit ViewSheet.")]
         public static IBHoMObject FromRevit(this ViewSheet viewSheet, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -594,7 +731,14 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
-
+        
+        [Description("Converts a Revit Viewport to a BHoM object based on its discipline.")]
+        [Input("viewport", "Revit Viewport to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Viewport.")]
         public static IBHoMObject FromRevit(this Viewport viewport, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -606,6 +750,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit ViewPlan to a BHoM object based on its discipline.")]
+        [Input("viewPlan", "Revit ViewPlan to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit ViewPlan.")]
         public static IBHoMObject FromRevit(this ViewPlan viewPlan, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -617,6 +768,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit Material to a BHoM object based on its discipline.")]
+        [Input("material", "Revit Material to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Material.")]
         public static IBHoMObject FromRevit(this Material material, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -635,6 +793,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit Family to a BHoM object based on its discipline.")]
+        [Input("family", "Revit Family to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Family.")]
         public static IBHoMObject FromRevit(this Family family, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -646,6 +811,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit CurveElement to a BHoM object based on its discipline.")]
+        [Input("curveElement", "Revit CurveElement to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit CurveElement.")]
         public static IBHoMObject FromRevit(this CurveElement curveElement, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             BH.oM.Adapters.Revit.Elements.IInstance result = null;
@@ -667,6 +839,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Converts a Revit FilledRegion to a BHoM object based on its discipline.")]
+        [Input("filledRegion", "Revit FilledRegion to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit FilledRegion.")]
         public static IBHoMObject FromRevit(this FilledRegion filledRegion, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             switch (discipline)
@@ -681,6 +860,13 @@ namespace BH.Revit.Engine.Core
         /****             Fallback Methods              ****/
         /***************************************************/
 
+        [Description("Fallback method when no suitable Element FromRevit is found.")]
+        [Input("element", "Revit Element to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Null resulted from no suitable Element FromRevit method.")]
         public static IBHoMObject FromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             return null;
@@ -688,6 +874,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Fallback method when no suitable FromRevit for Location is found, e.g. when it's not LocationPoint nor LocationCurve.")]
+        [Input("location", "Revit Location to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Null resulted from no suitable Location FromRevit method.")]
         public static IGeometry FromRevit(this Location location)
         {
             return null;
@@ -698,6 +891,13 @@ namespace BH.Revit.Engine.Core
         /****             Interface Methods             ****/
         /***************************************************/
 
+        [Description("Interface method that tries to find a suitable FromRevit convert for any Revit Element.")]
+        [Input("element", "Revit Element to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Element.")]
         public static object IFromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             if (element == null)
@@ -724,6 +924,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Interface method that tries to find a suitable FromRevit convert for a Revit Location.")]
+        [Input("location", "Revit Location to be converted.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("transform", "Optional, a transform to apply to the converted object.")]
+        [Input("settings", "Optional, Revit adapter settings.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fromRevit", "Resulted BHoM object converted from a Revit Location.")]
         public static IGeometry IFromRevit(this Location location)
         {
             if (location == null)

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -47,7 +47,7 @@ namespace BH.Revit.Engine.Core
         /****      Convert Revit elements to BHoM       ****/
         /***************************************************/
 
-        [Description("Converts a Revit ProjectInfo to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit ProjectInfo to a BHoM object based on the requested engineering discipline.")]
         [Input("projectInfo", "Revit ProjectInfo to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -67,7 +67,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit EnergyAnalysisDetailModel to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit EnergyAnalysisDetailModel to a BHoM object based on the requested engineering discipline.")]
         [Input("energyAnalysisModel", "Revit EnergyAnalysisDetailModel to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -162,7 +162,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit FamilySymbol to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit FamilySymbol to a BHoM object based on the requested engineering discipline.")]
         [Input("familySymbol", "Revit FamilySymbol to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -183,7 +183,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit Wall to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Wall to a BHoM object based on the requested engineering discipline.")]
         [Input("wall", "Revit Wall to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -224,7 +224,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit Ceiling to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Ceiling to a BHoM object based on the requested engineering discipline.")]
         [Input("ceiling", "Revit Ceiling to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -257,7 +257,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit Floor to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Floor to a BHoM object based on the requested engineering discipline.")]
         [Input("floor", "Revit Floor to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -293,7 +293,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit RoofBase to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit RoofBase to a BHoM object based on the requested engineering discipline.")]
         [Input("roofBase", "Revit RoofBase to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -329,7 +329,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit HostObjAttributes to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit HostObjAttributes to a BHoM object based on the requested engineering discipline.")]
         [Input("hostObjAttributes", "Revit HostObjAttributes to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -354,7 +354,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit CableTray to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit CableTray to a BHoM object based on the requested engineering discipline.")]
         [Input("cableTray", "Revit CableTray to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -384,7 +384,7 @@ namespace BH.Revit.Engine.Core
         
         /***************************************************/
 
-        [Description("Converts a Revit Duct to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Duct to a BHoM object based on the requested engineering discipline.")]
         [Input("duct", "Revit Duct to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -414,7 +414,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
         
-        [Description("Converts a Revit Pipe to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Pipe to a BHoM object based on the requested engineering discipline.")]
         [Input("pipe", "Revit Pipe to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -444,7 +444,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit Wire to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Wire to a BHoM object based on the requested engineering discipline.")]
         [Input("wire", "Revit Wire to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -474,7 +474,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit Level to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Level to a BHoM object based on the requested engineering discipline.")]
         [Input("level", "Revit Level to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -496,7 +496,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit Grid to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Grid to a BHoM object based on the requested engineering discipline.")]
         [Input("grid", "Revit Grid to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -524,7 +524,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit MultiSegmentGrid to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit MultiSegmentGrid to a BHoM object based on the requested engineering discipline.")]
         [Input("grid", "Revit MultiSegmentGrid to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -552,7 +552,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit ElementType to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit ElementType to a BHoM object based on the requested engineering discipline.")]
         [Input("elementType", "Revit ElementType to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -570,7 +570,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit GraphicsStyle to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit GraphicsStyle to a BHoM object based on the requested engineering discipline.")]
         [Input("graphicStyle", "Revit GraphicsStyle to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -588,7 +588,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit SpatialElement to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit SpatialElement to a BHoM object based on the requested engineering discipline.")]
         [Input("spatialElement", "Revit SpatialElement to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -621,7 +621,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit EnergyAnalysisSpace to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit EnergyAnalysisSpace to a BHoM object based on the requested engineering discipline.")]
         [Input("energyAnalysisSpace", "Revit EnergyAnalysisSpace to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -652,7 +652,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit EnergyAnalysisSurface to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit EnergyAnalysisSurface to a BHoM object based on the requested engineering discipline.")]
         [Input("energyAnalysisSurface", "Revit EnergyAnalysisSurface to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -683,7 +683,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit EnergyAnalysisOpening to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit EnergyAnalysisOpening to a BHoM object based on the requested engineering discipline.")]
         [Input("energyAnalysisOpening", "Revit EnergyAnalysisOpening to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -714,7 +714,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit ViewSheet to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit ViewSheet to a BHoM object based on the requested engineering discipline.")]
         [Input("viewSheet", "Revit ViewSheet to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -732,7 +732,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
         
-        [Description("Converts a Revit Viewport to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Viewport to a BHoM object based on the requested engineering discipline.")]
         [Input("viewport", "Revit Viewport to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -750,7 +750,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit ViewPlan to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit ViewPlan to a BHoM object based on the requested engineering discipline.")]
         [Input("viewPlan", "Revit ViewPlan to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -768,7 +768,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit Material to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Material to a BHoM object based on the requested engineering discipline.")]
         [Input("material", "Revit Material to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -793,7 +793,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit Family to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit Family to a BHoM object based on the requested engineering discipline.")]
         [Input("family", "Revit Family to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -811,7 +811,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit CurveElement to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit CurveElement to a BHoM object based on the requested engineering discipline.")]
         [Input("curveElement", "Revit CurveElement to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
@@ -839,7 +839,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Converts a Revit FilledRegion to a BHoM object based on its discipline.")]
+        [Description("Converts a Revit FilledRegion to a BHoM object based on the requested engineering discipline.")]
         [Input("filledRegion", "Revit FilledRegion to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -112,9 +112,14 @@ namespace BH.Revit.Engine.Core
                             result = new List<IElement> { familyInstance.BracingFromRevit(settings, refObjects) };
                         else if (typeof(BH.oM.Physical.Elements.Beam).BuiltInCategories().Contains((BuiltInCategory)familyInstance.Category.Id.IntegerValue))
                             result = new List<IElement> { familyInstance.BeamFromRevit(settings, refObjects) };
+                        else if (typeof(BH.oM.MEP.System.Fittings.Fitting).BuiltInCategories().Contains((BuiltInCategory) familyInstance.Category.Id.IntegerValue))
+                            result = new List<IElement> { familyInstance.FittingFromRevit(settings, refObjects) };
                         break;
                     case Discipline.Environmental:
-                        result = new List<IElement> { familyInstance.EnvironmentPanelFromRevit(settings, refObjects) };
+                        if (typeof(BH.oM.MEP.System.Fittings.Fitting).BuiltInCategories().Contains((BuiltInCategory) familyInstance.Category.Id.IntegerValue))
+                            result = new List<IElement> { familyInstance.FittingFromRevit(settings, refObjects) };
+                        else
+                            result = new List<IElement> { familyInstance.EnvironmentPanelFromRevit(settings, refObjects) };
                         break;
                     case Discipline.Facade:
                         if (typeof(BH.oM.Facade.Elements.Opening).BuiltInCategories().Contains((BuiltInCategory)familyInstance.Category.Id.IntegerValue))

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -571,7 +571,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Converts a Revit GraphicsStyle to a BHoM object based on its discipline.")]
-        [Input("graphicsStyle", "Revit GraphicsStyle to be converted.")]
+        [Input("graphicStyle", "Revit GraphicsStyle to be converted.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
         [Input("transform", "Optional, a transform to apply to the converted object.")]
         [Input("settings", "Optional, Revit adapter settings.")]
@@ -876,10 +876,6 @@ namespace BH.Revit.Engine.Core
 
         [Description("Fallback method when no suitable FromRevit for Location is found, e.g. when it's not LocationPoint nor LocationCurve.")]
         [Input("location", "Revit Location to be converted.")]
-        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
-        [Input("transform", "Optional, a transform to apply to the converted object.")]
-        [Input("settings", "Optional, Revit adapter settings.")]
-        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("fromRevit", "Null resulted from no suitable Location FromRevit method.")]
         public static IGeometry FromRevit(this Location location)
         {
@@ -926,10 +922,6 @@ namespace BH.Revit.Engine.Core
 
         [Description("Interface method that tries to find a suitable FromRevit convert for a Revit Location.")]
         [Input("location", "Revit Location to be converted.")]
-        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
-        [Input("transform", "Optional, a transform to apply to the converted object.")]
-        [Input("settings", "Optional, Revit adapter settings.")]
-        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("fromRevit", "Resulted BHoM object converted from a Revit Location.")]
         public static IGeometry IFromRevit(this Location location)
         {

--- a/Revit_Core_Engine/Convert/MEP/FromRevit/Fitting.cs
+++ b/Revit_Core_Engine/Convert/MEP/FromRevit/Fitting.cs
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        [Description("Convert a Revit family instance that is a fitting or an accessory to a BHoM Fitting.")]
+        [Input("revitMepFitting", "Revit family instance to be converted.")]
+        [Input("settings", "Revit adapter settings.")]
+        [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fitting", "BHoM fitting object converted from a Revit family instance element.")]
+        public static BH.oM.MEP.System.Fittings.Fitting FittingFromRevit(this FamilyInstance revitMepFitting, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            settings = settings.DefaultIfNull();
+            
+            // Reuse a BHoM fitting from refObjects it it has been converted before
+            BH.oM.MEP.System.Fittings.Fitting bhomFitting = refObjects.GetValue<BH.oM.MEP.System.Fittings.Fitting>(revitMepFitting.Id);
+            if (bhomFitting != null)
+                return bhomFitting;
+
+            bhomFitting = new BH.oM.MEP.System.Fittings.Fitting()
+            {
+                Location = ((revitMepFitting.Location) as LocationPoint).Point.PointFromRevit(),
+                ConnectionsLocation = Query.MEPConnectorsLocation(revitMepFitting)
+            };
+
+            //Set identifiers, parameters & custom data
+            bhomFitting.SetIdentifiers(revitMepFitting);
+            bhomFitting.CopyParameters(revitMepFitting, settings.ParameterSettings);
+            bhomFitting.SetProperties(revitMepFitting, settings.ParameterSettings);
+
+            refObjects.AddOrReplace(revitMepFitting.Id, bhomFitting);
+            return bhomFitting;
+        }
+        
+        /***************************************************/
+    }
+}
+

--- a/Revit_Core_Engine/Convert/MEP/FromRevit/Fitting.cs
+++ b/Revit_Core_Engine/Convert/MEP/FromRevit/Fitting.cs
@@ -52,8 +52,8 @@ namespace BH.Revit.Engine.Core
 
             bhomFitting = new BH.oM.MEP.System.Fittings.Fitting()
             {
-                Location = ((revitMepFitting.Location) as LocationPoint).Point.PointFromRevit(),
-                ConnectionsLocation = Query.MEPConnectorsLocation(revitMepFitting)
+                Location = (revitMepFitting.Location as LocationPoint)?.Point?.PointFromRevit(),
+                ConnectionsLocation = revitMepFitting.MEPConnectorsLocation()
             };
 
             //Set identifiers, parameters & custom data

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -177,6 +177,16 @@ namespace BH.Revit.Engine.Core
                     Autodesk.Revit.DB.BuiltInCategory.OST_CurtainWallMullions,
                 }
             },
+            {
+                typeof (BH.oM.MEP.System.Fittings.Fitting), new BuiltInCategory[]
+                {
+                    Autodesk.Revit.DB.BuiltInCategory.OST_DuctFitting,
+                    Autodesk.Revit.DB.BuiltInCategory.OST_PipeFitting,
+                    Autodesk.Revit.DB.BuiltInCategory.OST_CableTrayFitting,
+                    Autodesk.Revit.DB.BuiltInCategory.OST_DuctAccessory,
+                    Autodesk.Revit.DB.BuiltInCategory.OST_PipeAccessory,
+                }
+            }
         };
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -56,7 +56,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Queries a BHoM generic object for its Revit BuiltInCategory.")]
-        [Input("family", "BHoM object to be queried.")]
+        [Input("bHoMObject", "BHoM object to be queried.")]
         [Input("document", "Revit current document to be processed.")]
         [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
         [Output("builtInCategories", "Resulted HashSet list of Revit BuiltInCategory.")]
@@ -72,9 +72,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Queries a BHoM Type for its matching Revit BuiltInCategory.")]
-        [Input("family", "Type to be queried.")]
-        [Input("document", "Revit current document to be processed.")]
-        [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
+        [Input("bHoMType", "BHoM Type to be queried.")]
         [Output("builtInCategories", "Resulted HashSet list of Revit BuiltInCategory.")]
         public static HashSet<BuiltInCategory> BuiltInCategories(this Type bHoMType)
         {

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -44,7 +44,7 @@ namespace BH.Revit.Engine.Core
         [Input("family", "BHoM family to be queried.")]
         [Input("document", "Revit current document to be processed.")]
         [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
-        [Output("builtInCategories", "Resulted HashSet list of Revit BuiltInCategory.")]
+        [Output("builtInCategories", "Resulted collection of Revit BuiltInCategory.")]
         public static HashSet<BuiltInCategory> BuiltInCategories(this oM.Adapters.Revit.Elements.Family family, Document document, bool caseSensitive = true)
         {
             if (family?.PropertiesList == null)
@@ -55,11 +55,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Queries a BHoM generic object for its Revit BuiltInCategory.")]
+        [Description("Queries a BHoM IBHoMObject for its Revit BuiltInCategory.")]
         [Input("bHoMObject", "BHoM object to be queried.")]
         [Input("document", "Revit current document to be processed.")]
         [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
-        [Output("builtInCategories", "Resulted HashSet list of Revit BuiltInCategory.")]
+        [Output("builtInCategories", "Resulted collection of Revit BuiltInCategory.")]
         public static HashSet<BuiltInCategory> BuiltInCategories(this IBHoMObject bHoMObject, Document document, bool caseSensitive = true)
         {
             BuiltInCategory category = document.BuiltInCategory(bHoMObject.CategoryName(), caseSensitive);
@@ -71,9 +71,9 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        [Description("Queries a BHoM Type for its matching Revit BuiltInCategory.")]
+        [Description("Queries a BHoM Type for its correspondent Revit BuiltInCategory.")]
         [Input("bHoMType", "BHoM Type to be queried.")]
-        [Output("builtInCategories", "Resulted HashSet list of Revit BuiltInCategory.")]
+        [Output("builtInCategories", "Resulted collection of Revit BuiltInCategory.")]
         public static HashSet<BuiltInCategory> BuiltInCategories(this Type bHoMType)
         {
             HashSet<BuiltInCategory> result = new HashSet<BuiltInCategory>();
@@ -93,7 +93,7 @@ namespace BH.Revit.Engine.Core
         /****             Public dictionary             ****/
         /***************************************************/
 
-        [Description("A dictiory that relates BHoM types with Revit BuiltInCategories.")]
+        [Description("A dictionary that relates BHoM types with Revit BuiltInCategories.")]
         public static readonly Dictionary<Type, BuiltInCategory[]> BuiltInCategoryTable = new Dictionary<Type, BuiltInCategory[]>
         {
             {

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -28,7 +28,9 @@ using BH.oM.Structure.Elements;
 using BH.oM.Facade.Elements;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Revit.Engine.Core
 {
@@ -38,6 +40,11 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
+        [Description("Queries a BHoM Family for its Revit BuiltInCategory.")]
+        [Input("family", "BHoM family to be queried.")]
+        [Input("document", "Revit current document to be processed.")]
+        [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
+        [Output("builtInCategories", "Resulted HashSet list of Revit BuiltInCategory.")]
         public static HashSet<BuiltInCategory> BuiltInCategories(this oM.Adapters.Revit.Elements.Family family, Document document, bool caseSensitive = true)
         {
             if (family?.PropertiesList == null)
@@ -48,6 +55,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Queries a BHoM generic object for its Revit BuiltInCategory.")]
+        [Input("family", "BHoM object to be queried.")]
+        [Input("document", "Revit current document to be processed.")]
+        [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
+        [Output("builtInCategories", "Resulted HashSet list of Revit BuiltInCategory.")]
         public static HashSet<BuiltInCategory> BuiltInCategories(this IBHoMObject bHoMObject, Document document, bool caseSensitive = true)
         {
             BuiltInCategory category = document.BuiltInCategory(bHoMObject.CategoryName(), caseSensitive);
@@ -59,6 +71,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Queries a BHoM Type for its matching Revit BuiltInCategory.")]
+        [Input("family", "Type to be queried.")]
+        [Input("document", "Revit current document to be processed.")]
+        [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
+        [Output("builtInCategories", "Resulted HashSet list of Revit BuiltInCategory.")]
         public static HashSet<BuiltInCategory> BuiltInCategories(this Type bHoMType)
         {
             HashSet<BuiltInCategory> result = new HashSet<BuiltInCategory>();
@@ -74,11 +91,11 @@ namespace BH.Revit.Engine.Core
             return result;
         }
 
-
         /***************************************************/
         /****             Public dictionary             ****/
         /***************************************************/
 
+        [Description("A dictiory that relates BHoM types with Revit BuiltInCategories.")]
         public static readonly Dictionary<Type, BuiltInCategory[]> BuiltInCategoryTable = new Dictionary<Type, BuiltInCategory[]>
         {
             {

--- a/Revit_Core_Engine/Query/MEPConnectorsLocation.cs
+++ b/Revit_Core_Engine/Query/MEPConnectorsLocation.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Reflection.Attributes;
 
@@ -41,18 +42,29 @@ namespace BH.Revit.Engine.Core
         [Output("mepConnectorsLocation", "The list of points representing the connector's location points.")]
         public static List<BH.oM.Geometry.Point> MEPConnectorsLocation(this FamilyInstance mepInstance, RevitSettings settings = null)
         {
+            settings = settings.DefaultIfNull();
             MEPModel mepModel = mepInstance.MEPModel;
 
-            if (mepModel != null)
+            if (mepModel == null)
             {
-                ConnectorManager connectorManager = mepModel.ConnectorManager;
-                ConnectorSet connectorSet = connectorManager.Connectors;
-                List<Connector> connectors = connectorSet.Cast<Connector>().ToList();
-                return connectors.Select(x => x.Origin.PointFromRevit()).ToList();
+                BH.Engine.Reflection.Compute.RecordError("The input fitting does not have any connectors.");
+                return null;
             }
 
-            return new List<BH.oM.Geometry.Point>();
+            ConnectorManager connectorManager = mepModel.ConnectorManager;
+            if (connectorManager == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("The input fitting does not have any connectors.");
+                return null;
+            }
+                    
+            ConnectorSet connectorSet = connectorManager.Connectors;
+            List<Connector> connectors = connectorSet.Cast<Connector>().ToList();
+            
+            return connectors.Select(x => x.Origin.PointFromRevit()).ToList();
+            
         }
+        
         /***************************************************/
     }
 }

--- a/Revit_Core_Engine/Query/MEPConnectorsLocation.cs
+++ b/Revit_Core_Engine/Query/MEPConnectorsLocation.cs
@@ -43,6 +43,13 @@ namespace BH.Revit.Engine.Core
         public static List<BH.oM.Geometry.Point> MEPConnectorsLocation(this FamilyInstance mepInstance, RevitSettings settings = null)
         {
             settings = settings.DefaultIfNull();
+
+            if (mepInstance == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Input mepInstance is null or empty.");
+                return null;
+            }
+            
             MEPModel mepModel = mepInstance.MEPModel;
 
             if (mepModel == null)

--- a/Revit_Core_Engine/Query/MEPConnectorsLocation.cs
+++ b/Revit_Core_Engine/Query/MEPConnectorsLocation.cs
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Autodesk.Revit.DB;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Reflection.Attributes;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Queries a Family Instance that contains MEP connectors for their locations.")]
+        [Input("mepInstance", "Revit family instance to be queried for their MEP connectors.")]
+        [Input("settings", "Revit adapter settings.")]
+        [Output("mepConnectorsLocation", "The list of points representing the connector's location points.")]
+        public static List<BH.oM.Geometry.Point> MEPConnectorsLocation(this FamilyInstance mepInstance, RevitSettings settings = null)
+        {
+            MEPModel mepModel = mepInstance.MEPModel;
+
+            if (mepModel != null)
+            {
+                ConnectorManager connectorManager = mepModel.ConnectorManager;
+                ConnectorSet connectorSet = connectorManager.Connectors;
+                List<Connector> connectors = connectorSet.Cast<Connector>().ToList();
+                return connectors.Select(x => x.Origin.PointFromRevit()).ToList();
+            }
+
+            return new List<BH.oM.Geometry.Point>();
+        }
+        /***************************************************/
+    }
+}
+

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -312,6 +312,7 @@
     <Compile Include="Convert\Facade\FromRevit\FrameEdge.cs" />
     <Compile Include="Convert\MEP\FromRevit\CableTray.cs" />
     <Compile Include="Convert\MEP\FromRevit\Duct.cs" />
+    <Compile Include="Convert\MEP\FromRevit\Fitting.cs" />
     <Compile Include="Convert\MEP\FromRevit\Pipe.cs" />
     <Compile Include="Convert\Geometry\FromRevit\Basis.cs" />
     <Compile Include="Convert\Geometry\FromRevit\Transform.cs" />
@@ -347,6 +348,7 @@
     <Compile Include="Query\FacadeCurtainPanels.cs" />
     <Compile Include="Query\CurtainWallMullions.cs" />
     <Compile Include="Query\FrameEdgeProperty.cs" />
+    <Compile Include="Query\MEPConnectorsLocation.cs" />
     <Compile Include="Query\MullionElementProperty.cs" />
     <Compile Include="Query\GlazingConstruction.cs" />
     <Compile Include="Query\DuctSectionProfile.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #864 

Implements the pull converter for MEP fittings. Currently duct fittings, duct accessories, pipe fittings, pipe accessories and cable tray fittings categories have been bundled to convert to a ` BH.oM.MEP.System.Fittings.Fitting`. This is a generic approach that aims to enable users to start performing graph operations in these objects.

A future task is suggested to further refine these categories, by for example taking advantage of the Fitting property `FittingType`, that uses undefined value for now.


### Test files
[Here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%23864%2DImplementMEPFittingConverter)  for Revit 2020. @michaelhoehn @kayleighhoude could you please be the functionality reviewers here? Please make sure that the revit's test file system is relevant, but also feel free to use any project file as it should still work.


### Changelog

- Added `BH.Revit.Engine.Core.Convert.FittingFromRevit`
- Added `BH.Revit.Engine.Core.Query.MEPConnectorsLocation`
- Modified `BH.Revit.Engine.Core.Convert.FromRevit`
- Modified `BH.Revit.Engine.Core.Query.BuiltInCategories`


### Additional comments
@pawelbaran I'm conscious that this PR will clash with https://github.com/BHoM/Revit_Toolkit/pull/1055, keen to follow any suggestion you have.