### PR TITLE
Add method for placing Family Instance on MEPCurve objects

### DIFF
--- a/Revit_Core_Engine/Compute/Warnings.cs
+++ b/Revit_Core_Engine/Compute/Warnings.cs
@@ -457,6 +457,13 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        internal static void PlaceElementOnMEPCurveWarning(this FamilyInstance familyInstance)
+        {
+            BH.Engine.Reflection.Compute.RecordWarning($"Family needs to have orientation perpendiculator to the MEPCurve line, therefore transform out of MEPCurve plane has been ignored. ElementId: {familyInstance?.Id.IntegerValue}");
+        }
+
+        /***************************************************/
+
         internal static void ProjectedOnViewPlaneWarning(this FamilyInstance familyInstance)
         {
             BH.Engine.Reflection.Compute.RecordWarning($"Drafting family needs to have orientation perpendicular to the view plane, therefore transform out of view plane has been ignored. BHoM Guid: ElementId: {familyInstance?.Id.IntegerValue}");


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1035 

<!-- Add short description of what has been fixed -->
Added method for placing Family Instance elements (Pipe Accessories, Duct Accessories) at specific point on MEPCurve element.

### Test files
<!-- Link to test files to validate the proposed changes -->
Revit 2018 file - views `Level 01 - Floor Plan TEST` and `3D View TEST`.
Grasshopper file - works for all elements in the test model - switch all Pull and Push to active, one after another.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

### Additional comments
<!-- As required -->
- Method works only for Pipes and Ducts. Cable Trays are not supported by RevitAPI `BreakCurve` method.
- Errors occured when rotating some types of family instances - family must be created correctly with good location of insert point and connectors.
- Be careful when changing the orientation for rectangular duct accessories - only 4 ways are valid, but the method can successfully rotate element with any orientation.