### PR TITLE
Add tolerance parameter for pull with PlanarSurface and IsClosed methods

### DIFF
--- a/Revit_Core_Engine/Convert/Revit/FromRevit/DraftingInstance.cs
+++ b/Revit_Core_Engine/Convert/Revit/FromRevit/DraftingInstance.cs
@@ -65,7 +65,7 @@ namespace BH.Revit.Engine.Core
                 curves.Add(loop.FromRevit());
             }
 
-            List<PlanarSurface> surfaces = BH.Engine.Geometry.Create.PlanarSurface(curves);
+            List<PlanarSurface> surfaces = BH.Engine.Geometry.Create.PlanarSurface(curves, settings.DistanceTolerance);
             if (surfaces.Count == 1)
                 draftingInstance = new DraftingInstance { Properties = instanceProperties, ViewName = view.Name, Location = surfaces[0] };
             else

--- a/Revit_Core_Engine/Convert/Revit/FromRevit/DraftingInstance.cs
+++ b/Revit_Core_Engine/Convert/Revit/FromRevit/DraftingInstance.cs
@@ -28,6 +28,7 @@ using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
+using BH.Engine.Reflection;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -66,7 +67,12 @@ namespace BH.Revit.Engine.Core
             }
 
             List<PlanarSurface> surfaces = BH.Engine.Geometry.Create.PlanarSurface(curves, settings.DistanceTolerance);
-            if (surfaces.Count == 1)
+            if (surfaces.Count == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordWarning("No location was returned for filled region with Element ID = " + filledRegion.Id.ToString() + ". Location has been set to null.");
+                draftingInstance = new DraftingInstance { Properties = instanceProperties, ViewName = view.Name, Location = null };
+            }
+            else if (surfaces.Count == 1)
                 draftingInstance = new DraftingInstance { Properties = instanceProperties, ViewName = view.Name, Location = surfaces[0] };
             else
                 draftingInstance = new DraftingInstance { Properties = instanceProperties, ViewName = view.Name, Location = new PolySurface { Surfaces = surfaces.Cast<ISurface>().ToList() } };

--- a/Revit_Core_Engine/Query/AnalyticalOutlines.cs
+++ b/Revit_Core_Engine/Query/AnalyticalOutlines.cs
@@ -41,8 +41,8 @@ namespace BH.Revit.Engine.Core
 
         [Description("Gets AnalyticalOutlines of a host object.")]
         [Input("hostObject", "Object to get AnalyticalOutlines from.")]
-        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
-        [Output("outlines", "The AnalyticalOutlines of the host object..")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
+        [Output("outlines", "The analytical outlines of the host object.")]
         public static List<ICurve> AnalyticalOutlines(this HostObject hostObject, RevitSettings settings = null)
         {
             AnalyticalModel analyticalModel = hostObject.GetAnalyticalModel();
@@ -61,7 +61,7 @@ namespace BH.Revit.Engine.Core
                 return null;
             }
 
-            List<ICurve> result = BH.Engine.Geometry.Compute.IJoin(wallCurves).ConvertAll(c => c as ICurve);
+            List<ICurve> result = BH.Engine.Geometry.Compute.IJoin(wallCurves, settings.DistanceTolerance).ConvertAll(c => c as ICurve);
             if (result.Any(x => !x.IIsClosed(settings.DistanceTolerance)))
             {
                 hostObject.NonClosedOutlineWarning();

--- a/Revit_Core_Engine/Query/AnalyticalOutlines.cs
+++ b/Revit_Core_Engine/Query/AnalyticalOutlines.cs
@@ -26,7 +26,9 @@ using BH.Engine.Adapters.Revit;
 using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace BH.Revit.Engine.Core
@@ -37,6 +39,10 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
+        [Description("Gets AnalyticalOutlines of a host object.")]
+        [Input("hostObject", "Object to get AnalyticalOutlines from.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Output("outlines", "The AnalyticalOutlines of the host object..")]
         public static List<ICurve> AnalyticalOutlines(this HostObject hostObject, RevitSettings settings = null)
         {
             AnalyticalModel analyticalModel = hostObject.GetAnalyticalModel();

--- a/Revit_Core_Engine/Query/AnalyticalOutlines.cs
+++ b/Revit_Core_Engine/Query/AnalyticalOutlines.cs
@@ -56,7 +56,7 @@ namespace BH.Revit.Engine.Core
             }
 
             List<ICurve> result = BH.Engine.Geometry.Compute.IJoin(wallCurves).ConvertAll(c => c as ICurve);
-            if (result.Any(x => !x.IIsClosed()))
+            if (result.Any(x => !x.IIsClosed(settings.DistanceTolerance)))
             {
                 hostObject.NonClosedOutlineWarning();
                 return null;


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1062 
Closes #1008 
(#1008 is closed primarily by the previous Tolerance parameter capabilities, as the issue can be solved with current Revit_Toolkit capabilities along with a tolerance input value on the IArea method that matches the RevitSettings.DistanceTolerance value accordingly.)

Allows for tolerance set in RevitSettings to be applied to Planar Surface creation, thereby allowing pulling closed regions such as a FilledRegion where the region is closed per Revit tolerances, but not per default BHoM tolerances.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%231062-PlanarSurfaceTolerance?csf=1&web=1&e=kDTc7h

Test by checking with the different tolerances to confirm pull failure when tolerance value is too low, and success when tolerance is higher. Note that Rhino unit tolerance will drive the Surface component at the end, so you should set your tolerance low in Rhino (recommend 0.0001m) to ensure proper functionality (Rhino tolerance is inverse to the input revit tolerances here, since it drives the joining of curves to create the surface and a value too high causes errant Grasshopper-side snapping of curves when joining/converting to a surface.
