### PR TITLE
Return type of wire convert aligned

### DIFF
--- a/Revit_Core_Engine/Convert/MEP/FromRevit/Wire.cs
+++ b/Revit_Core_Engine/Convert/MEP/FromRevit/Wire.cs
@@ -42,12 +42,12 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("wireSegment", "BHoM wire segment converted from a Revit wire.")]
-        public static BH.oM.MEP.System.WireSegment WireFromRevit(this Autodesk.Revit.DB.Electrical.Wire revitWire, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static BH.oM.MEP.System.Wire WireFromRevit(this Autodesk.Revit.DB.Electrical.Wire revitWire, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
 
             // Reuse a BHoM duct from refObjects it it has been converted before
-            BH.oM.MEP.System.WireSegment bhomWire = refObjects.GetValue<BH.oM.MEP.System.WireSegment>(revitWire.Id);
+            BH.oM.MEP.System.Wire bhomWire = refObjects.GetValue<BH.oM.MEP.System.Wire>(revitWire.Id);
             if (bhomWire != null)
                 return bhomWire;
             
@@ -58,7 +58,7 @@ namespace BH.Revit.Engine.Core
             BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startPoint, endPoint); // BHoM line
 
             // Wire
-            bhomWire = BH.Engine.MEP.Create.WireSegment(line);
+            bhomWire = new BH.oM.MEP.System.Wire { WireSegments = new List<WireSegment> { BH.Engine.MEP.Create.WireSegment(line) } };
 
             //Set identifiers, parameters & custom data
             bhomWire.SetIdentifiers(revitWire);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1083

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
_PullWires_ from [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPull&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
I do not think wire converts were heavily used, so I am quite comfortable with this last minute breaking change.