### PR TITLE
Bug in Create.FamilyInstance for one level based, non-hosted families fixed

### DIFF
--- a/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
@@ -58,7 +58,10 @@ namespace BH.Revit.Engine.Core
             switch (familySymbol.Family.FamilyPlacementType)
             {
                 case FamilyPlacementType.OneLevelBased:
-                    return Create.FamilyInstance_OneLevelBased(document, familySymbol, origin, orientation, host, settings);
+                    if (host is MEPCurve)
+                        return Create.FamilyInstance_OneLevelBased(document, familySymbol, origin, orientation, (MEPCurve)host, settings);
+                    else
+                        return Create.FamilyInstance_OneLevelBased(document, familySymbol, origin, orientation, host, settings);
                 case FamilyPlacementType.OneLevelBasedHosted:
                     return Create.FamilyInstance_OneLevelBasedHosted(document, familySymbol, origin, orientation, host as dynamic, settings);
                 case FamilyPlacementType.TwoLevelsBased:
@@ -189,7 +192,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        private static FamilyInstance FamilyInstance_OneLevelBasedHosted(Document document, FamilySymbol familySymbol, XYZ origin, Transform orientation, MEPCurve host, RevitSettings settings)
+        private static FamilyInstance FamilyInstance_OneLevelBased(Document document, FamilySymbol familySymbol, XYZ origin, Transform orientation, MEPCurve host, RevitSettings settings)
         {
             //Check inputs
             if (familySymbol == null)

--- a/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
@@ -58,9 +58,9 @@ namespace BH.Revit.Engine.Core
             switch (familySymbol.Family.FamilyPlacementType)
             {
                 case FamilyPlacementType.OneLevelBased:
-                    return Create.FamilyInstance_OneLevelBased(document, familySymbol, origin, orientation, host as dynamic, settings);
+                    return Create.FamilyInstance_OneLevelBased(document, familySymbol, origin, orientation, host, settings);
                 case FamilyPlacementType.OneLevelBasedHosted:
-                    return Create.FamilyInstance_OneLevelBasedHosted(document, familySymbol, origin, orientation, host, settings);
+                    return Create.FamilyInstance_OneLevelBasedHosted(document, familySymbol, origin, orientation, host as dynamic, settings);
                 case FamilyPlacementType.TwoLevelsBased:
                     return Create.FamilyInstance_TwoLevelBased(document, familySymbol, origin, orientation, host, settings);
                 case FamilyPlacementType.WorkPlaneBased:
@@ -189,7 +189,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        private static FamilyInstance FamilyInstance_OneLevelBased(Document document, FamilySymbol familySymbol, XYZ origin, Transform orientation, MEPCurve host, RevitSettings settings)
+        private static FamilyInstance FamilyInstance_OneLevelBasedHosted(Document document, FamilySymbol familySymbol, XYZ origin, Transform orientation, MEPCurve host, RevitSettings settings)
         {
             //Check inputs
             if (familySymbol == null)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1093

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPush&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4):
- _CreateUpdateIInstances.rvt_ + _CreateUpdateIInstances.gh_
- _PlaceFamilyInstanceOnMEPCurve.rvt_ + _PlaceFamilyInstanceOnMEPCurve.gh_

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->