### PR TITLE
ElementTypeNotFoundWarning made even more informative

### DIFF
--- a/Revit_Core_Engine/Compute/Warnings.cs
+++ b/Revit_Core_Engine/Compute/Warnings.cs
@@ -324,7 +324,7 @@ namespace BH.Revit.Engine.Core
             string message = "Element type has not been found for given BHoM Object. Please make sure the name of the BHoM object (or its type property, e.g. Construction) is matching the Revit family type name.";
 
             if (iBHoMObject != null)
-                message = string.Format("{0} BHoM Guid: {1}", message, iBHoMObject.BHoM_Guid);
+                message = $"{message}\nObject name: {iBHoMObject.Name}, object type: {iBHoMObject.GetType().FullName}, BHoM_Guid: {iBHoMObject.BHoM_Guid}";
 
             BH.Engine.Reflection.Compute.RecordError(message);
         }

--- a/Revit_Core_Engine/Compute/Warnings.cs
+++ b/Revit_Core_Engine/Compute/Warnings.cs
@@ -324,7 +324,7 @@ namespace BH.Revit.Engine.Core
             string message = "Element type has not been found for given BHoM Object. Please make sure the name of the BHoM object (or its type property, e.g. Construction) is matching the Revit family type name.";
 
             if (iBHoMObject != null)
-                message = $"{message}\nObject name: {iBHoMObject.Name}, object type: {iBHoMObject.GetType().FullName}, BHoM_Guid: {iBHoMObject.BHoM_Guid}";
+                message = $"{message}\nObject name: {iBHoMObject.Name}, object type: {iBHoMObject.GetType().FullName}.";
 
             BH.Engine.Reflection.Compute.RecordError(message);
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1013

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231092%2DTypeNotFoundWarningMadeMoreInformative&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
This is a further refinement of https://github.com/BHoM/Revit_Toolkit/pull/1092 requested by @JosefTaylor.