### PR TITLE
Pushing braces based on object name matching fixed

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/ToRevit/FamilyInstance.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/FamilyInstance.cs
@@ -208,7 +208,7 @@ namespace BH.Revit.Engine.Core
             categories.Add(BuiltInCategory.OST_StructuralFraming);
             FamilySymbol familySymbol = framingElement.Property.ToRevitElementType(document, categories, settings, refObjects);
             if (familySymbol == null)
-                familySymbol = framingElement.ElementType(document, settings) as FamilySymbol;
+                familySymbol = framingElement.ElementType(document, categories, settings) as FamilySymbol;
 
             if (familySymbol == null)
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1119

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231120%2DPushBracingBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->