### PR TITLE
IFromRevit method cleaned up

### DIFF
--- a/Revit_Core_Adapter/AdapterActions/Pull.cs
+++ b/Revit_Core_Adapter/AdapterActions/Pull.cs
@@ -46,16 +46,8 @@ namespace BH.Revit.Adapter.Core
                 return new List<object>();
             }
 
-            // Set config
-            RevitPullConfig pullConfig = actionConfig as RevitPullConfig;
-            if (pullConfig == null)
-            {
-                BH.Engine.Reflection.Compute.RecordNote("Revit Pull Config has not been specified. Default Revit Pull Config is used.");
-                pullConfig = new RevitPullConfig();
-            }
-
             // Read the objects based on the request
-            return Read(request, pullConfig);
+            return Read(request, actionConfig);
         }
 
         /***************************************************/

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -235,7 +235,7 @@ namespace BH.Revit.Adapter.Core
             List<IBHoMObject> result = null;
             try
             {
-                result = element.IFromRevit(discipline, transform, settings, refObjects).ToList();
+                result = element.IFromRevit(discipline, transform, settings, refObjects);
             }
             catch (Exception exception)
             {

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -232,30 +232,21 @@ namespace BH.Revit.Adapter.Core
             if (element == null || !element.IsValidObject)
                 return new List<IBHoMObject>();
 
-            object obj = null;
+            List<IBHoMObject> result = null;
             try
             {
-                obj = element.IFromRevit(discipline, transform, settings, refObjects);
+                result = element.IFromRevit(discipline, transform, settings, refObjects).ToList();
             }
             catch (Exception exception)
             {
                 BH.Engine.Reflection.Compute.RecordError(string.Format("BHoM object could not be properly converted. Element Id: {0}, Element Name: {1}, Exception Message: {2}", element.Id.IntegerValue, element.Name, exception.Message));
             }
-            
-            List<IBHoMObject> result = new List<IBHoMObject>();
-            if (obj != null)
-            {
-                if (obj is IBHoMObject)
-                    result.Add((IBHoMObject)obj);
-                else if (obj is IEnumerable<IBHoMObject>)
-                    result.AddRange((IEnumerable<IBHoMObject>)obj);
-            }
 
-            //Assign Tags
-            string tagsParameterName = null;
-            if (settings != null)
-                tagsParameterName = settings.MappingSettings.TagsParameter;
-
+            if (result == null)
+                return new List<IBHoMObject>();
+                
+            // Set tags
+            string tagsParameterName = settings?.MappingSettings?.TagsParameter;
             if (!string.IsNullOrEmpty(tagsParameterName))
             {
                 foreach(IBHoMObject o in result)

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -48,7 +48,7 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings to be used while performing the convert.")]
         [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("fromRevit", "Resulted BHoM object converted from a Revit Element.")]
-        public static IEnumerable<IBHoMObject> IFromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static List<IBHoMObject> IFromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             return FromRevit(element as dynamic, discipline, transform, settings, refObjects);
         }
@@ -78,7 +78,7 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings to be used while performing the convert.")]
         [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("fromRevit", "Resulted BHoM object converted from a Revit EnergyAnalysisDetailModel.")]
-        public static IEnumerable<IBHoMObject> FromRevit(this EnergyAnalysisDetailModel energyAnalysisModel, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static List<IBHoMObject> FromRevit(this EnergyAnalysisDetailModel energyAnalysisModel, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             if (energyAnalysisModel == null)
             {
@@ -104,7 +104,7 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings to be used while performing the convert.")]
         [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("fromRevit", "Resulted BHoM object converted from a Revit Element.")]
-        public static IEnumerable<IBHoMObject> FromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static List<IBHoMObject> FromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             if (element == null)
             {

--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -48,7 +48,7 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings to be used while performing the convert.")]
         [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("fromRevit", "Resulted BHoM object converted from a Revit Element.")]
-        public static object IFromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        public static IEnumerable<IBHoMObject> IFromRevit(this Element element, Discipline discipline, Transform transform = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             return FromRevit(element as dynamic, discipline, transform, settings, refObjects);
         }

--- a/Revit_Engine/Modify/DefaultIfNull.cs
+++ b/Revit_Engine/Modify/DefaultIfNull.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -48,9 +49,21 @@ namespace BH.Engine.Adapters.Revit
         }
 
         /***************************************************/
+
+        [Description("Sets RevitPullConfig to default value if it is null.")]
+        [Input("pullConfig", "RevitPullConfig to be set to default if null.")]
+        [Output("pullConfig")]
+        public static RevitPullConfig DefaultIfNull(this RevitPullConfig pullConfig)
+        {
+            if (pullConfig == null)
+            {
+                BH.Engine.Reflection.Compute.RecordNote("Revit pull config has not been specified. Default Revit pull config is used.");
+                pullConfig = new RevitPullConfig();
+            }
+
+            return pullConfig;
+        }
+
+        /***************************************************/
     }
 }
-
-
-
-

--- a/Revit_Engine/Query/Discipline.cs
+++ b/Revit_Engine/Query/Discipline.cs
@@ -68,7 +68,7 @@ namespace BH.Engine.Adapters.Revit
         [Input("request", "BHoM Request to be queried.")]
         [Input("defaultDiscipline", "Default discipline set in adapter's ActionConfig (RevitPullConfig).")]
         [Output("discipline")]
-        public static Discipline? Discipline(this IRequest request, Discipline? defaultDiscipline)
+        public static Discipline? Discipline(this IRequest request, Discipline? defaultDiscipline = oM.Adapters.Revit.Enums.Discipline.Undefined)
         {
             Discipline? discipline = defaultDiscipline;
             if (request is ILogicalRequest)

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -30,6 +30,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Adapter_oM">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Analytical_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1128

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Chosen few files from the [standard test files](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPull&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) should be enough.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- return type of `IFromRevit` as well as `Read` methods changed to `List<IBHoMObject>`
- discipline ambiguity removed from `Read` method signatures (input of type `Discipline` removed from all methods taking `RevitPullConfig`)
- `Read(Document, List<ElementId>, RevitPullConfig, RevitSettings)` extracted from the wider Read(Document, IRequest, RevitPullConfig, RevitSettings) method
- minor tweaks to align with the above changes


### Additional comments
<!-- As required -->