### PR TITLE
Revit_Engine: aligments and simplifications of the RevitDiffing backend

### DIFF
--- a/Revit_Engine/Query/ComparisonInclusion.cs
+++ b/Revit_Engine/Query/ComparisonInclusion.cs
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Base;
+using BH.oM.Adapters.Revit;
+using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Adapters.Revit.Parameters;
+using BH.oM.Base;
+using BH.oM.Diffing;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace BH.Engine.Adapters.Revit
+{
+    public static partial class Query
+    {
+        [Description("When Diffing (Comparing objects), determine if and how RevitParameters should be considered.")]
+        [Input("parameter1", "First RevitParameter that is being compared.")]
+        [Input("parameter2", "Second RevitParameter that is being compared.")]
+        [Input("propertyFullName", "The Full Name of the RevitParameter stored on the object whose Comparison is being computed.")]
+        [Input("comparisonConfig", "Additional comparison configurations. You can specify a `ComparisonConfig` or a `RevitComparisonConfig`.")]
+        public static ComparisonInclusion ComparisonInclusion(this RevitParameter parameter1, RevitParameter parameter2, string propertyFullName, BaseComparisonConfig comparisonConfig)
+        {
+            ComparisonInclusion result = new ComparisonInclusion();
+            result.DisplayName = parameter1.Name + " (RevitParameter)"; // differences in any property of RevitParameters will be displayed like this.
+
+            // Check if we have a RevitComparisonConfig input.
+            RevitComparisonConfig rcc = comparisonConfig as RevitComparisonConfig;
+            if (rcc != null)
+            {
+                // Check the ParametersToConsider: if there is at least one name in the list, make sure that the current revitParameter's Name is contained in the list.
+                if ((rcc.ParametersToConsider?.Any() ?? false) && !rcc.ParametersToConsider.Any(ptc => parameter1.Name == ptc || parameter1.Name.WildcardMatch(ptc)))
+                {
+                    // The parameter is not within the ParametersToConsider.
+                    result.Include = false; // RevitParameter must be skipped
+                    return result;
+                }
+
+                // Check if the current revitParameter is within the ParametersExceptions.
+                if ((rcc.ParametersExceptions?.Any() ?? false) && rcc.ParametersExceptions.Any(ptc => parameter1.Name == ptc || parameter1.Name.WildcardMatch(ptc))) 
+                {
+                    result.Include = false; // RevitParameter must be skipped
+                    return result;
+                }
+
+                // Check the difference in the RevitParameters is a numerical difference, and if so whether it should be included given the input tolerances/significantFigures.
+                if (!BH.Engine.Diffing.Query.NumericalDifferenceInclusion(parameter1.Value, parameter2.Value, parameter1.Name, rcc.ParameterNumericTolerances, rcc.NumericTolerance, rcc.ParameterSignificantFigures, rcc.SignificantFigures))
+                {
+                    result.Include = false; // RevitParameter must be skipped
+                    return result;
+                }
+            }
+
+            return result; // pass the RevitParameter (do not skip it)
+        }
+    }
+}
+
+

--- a/Revit_Engine/Query/HashString.cs
+++ b/Revit_Engine/Query/HashString.cs
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Reflection;
+using BH.oM.Adapters.Revit;
+using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Adapters.Revit.Parameters;
+using BH.oM.Base;
+using BH.oM.Diffing;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace BH.Engine.Adapters.Revit
+{
+    public static partial class Query
+    {
+        [Description("Computes the Hash string for a Revit Parameter. This will then be used by the Hash algorithm to compute the overall Hash of an object owning Revit Parameters.")]
+        [Input("propertyFullName", "Full name of the RevitParameter property whose Hash is being computed. This name will be used to seek matches in the ComparisonConfig custom named tolerances/significant figures to determine if any custom numerical approximation should be done.")]
+        [Input("comparisonConfig", "Settings specified for this Hash computation. This can be a RevitComparisonConfig object.")]
+        public static string HashString(this RevitParameter revitParameter, string propertyFullName = null, BaseComparisonConfig comparisonConfig = null)
+        {
+            // Null check.
+            if (revitParameter == null)
+                return null;
+
+            string hashString = revitParameter.Name + revitParameter.Value;
+
+            // Check if we have a RevitComparisonConfig input.
+            RevitComparisonConfig rcc = comparisonConfig as RevitComparisonConfig;
+            if (rcc != null)
+            {
+                // If there is at least one name in the ParametersToConsider, make sure that the current revitParameter's Name is contained in the list.
+                if ((rcc.ParametersToConsider?.Any() ?? false) && !rcc.ParametersToConsider.Contains(revitParameter.Name))
+                    // The parameter is not within the ParametersToConsider. RevitParameter must be skipped
+                    return null;
+
+                // Check if the current revitParameter is within the ParametersExceptions.
+                if (rcc.ParametersExceptions?.Contains(revitParameter.Name) ?? false)
+                    // The parameter is not within the ParametersToConsider. RevitParameter must be skipped
+                    return null;
+
+                // If the RevitParameter is numeric, take care of custom tolerances/significant figures.
+                if (revitParameter.Value.GetType().IsNumeric())
+                {
+                    // If we didn't specify any custom tolerance/significant figures, just return the input.
+                    if (rcc.NumericTolerance == double.MinValue && rcc.SignificantFigures == int.MaxValue
+                        && (!rcc.ParameterNumericTolerances?.Any() ?? true) && (!rcc.ParameterSignificantFigures?.Any() ?? true))
+                        return hashString;
+
+                    // Otherwise, return the approximated value.
+                    return BH.Engine.Base.Query.NumericalApproximation(
+                        double.Parse(revitParameter.Value.ToString()), propertyFullName, rcc.ParameterNumericTolerances, rcc.NumericTolerance, rcc.ParameterSignificantFigures, rcc.SignificantFigures)
+                        .ToString();
+                }
+            }
+
+            // Pass the RevitParameter (do not skip it). Return a string that represents this RevitParameter.
+            return $"{revitParameter.Name}:{revitParameter.Value}";
+        }
+    }
+}
+
+

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -189,6 +189,8 @@
     <Compile Include="Modify\SetTag.cs" />
     <Compile Include="Modify\Move.cs" />
     <Compile Include="Modify\Transform.cs" />
+    <Compile Include="Query\HashString.cs" />
+    <Compile Include="Query\ComparisonInclusion.cs" />
     <Compile Include="Query\FilterDescription.cs" />
     <Compile Include="Query\HostInformation.cs" />
     <Compile Include="Query\LinkDocument.cs" />

--- a/Revit_Engine/Versioning_50.json
+++ b/Revit_Engine/Versioning_50.json
@@ -1,8 +1,6 @@
 ﻿{
   "MessageForDeleted": {
     "BH.Engine.Adapters.Revit.Query.LinkPath(BH.oM.Base.IBHoMObject)": "Link path information has been replaced with link document name stored under LinkDocument property and avaialble through LinkDocument query.",
-    "BH.Engine.Adapters.Revit.Query.HostId(BH.oM.Base.IBHoMObject)": "HostId query has been replaced with a more comprehensive query available under HostInformation.",
-    "BH.Engine.Adapters.Revit.Create.Panel(BH.oM.Geometry.ICurve, System.Double, System.String)": "The method has been deleted because it was not a Revit method.",
-    "BH.Engine.Adapters.Revit.Create.Panel(System.Collections.Generic.IEnumerable<BH.oM.Geometry.Point>, System.String)": "The method has been deleted because it was not a Revit method."
+    "BH.Engine.Adapters.Revit.Query.HostId(BH.oM.Base.IBHoMObject)": "HostId query has been replaced with a more comprehensive query available under HostInformation."
   }
 }

--- a/Revit_oM/Config/RevitComparisonConfig.cs
+++ b/Revit_oM/Config/RevitComparisonConfig.cs
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter;
+using BH.oM.Adapters.Revit.Enums;
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.oM.Adapters.Revit
+{
+    [Description("Settings to determine the uniqueness of an Object for comparison (e.g. when Diffing or computing an object Hash).")]
+    public class RevitComparisonConfig : ComparisonConfig
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Names of any Revit Parameter that should not be considered for the comparison.")]
+        public virtual List<string> ParametersExceptions { get; set; } = new List<string>() { };
+
+        [Description("Names of the Revit Parameters that will be considered for the comparison." +
+            "By default, this list is empty, so all parameters are considered (except possibly those included in the other property `ParametersExceptions`)." +
+            "If this list is populated with one or more values, it takes higher priority over `ParametersExceptions`.")]
+        public virtual List<string> ParametersToConsider { get; set; } = new List<string>() { };
+
+        [Description("Tolerance used for individual RevitParameters. When computing Hash or the property Diffing, if the analysed property name is found in this collection, the corresponding tolerance is applied." +
+            "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
+            "\nIf a match is found, this take precedence over the global `NumericTolerance`." +
+            "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
+        public virtual HashSet<NamedNumericTolerance> ParameterNumericTolerances { get; set; } = new HashSet<NamedNumericTolerance>();
+
+        [Description("Number of significant figures allowed for numerical data on a per-RevitParameter base. " +
+             "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
+             "\nIf a match is found, this take precedence over the global `SignificantFigures`." +
+             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
+        public virtual HashSet<NamedSignificantFigures> ParameterSignificantFigures { get; set; } = new HashSet<NamedSignificantFigures>();
+
+        /***************************************************/
+    }
+}
+

--- a/Revit_oM/Revit_oM.csproj
+++ b/Revit_oM/Revit_oM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -86,6 +86,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config\RevitComparisonConfig.cs" />
     <Compile Include="Config\PullGeometryConfig.cs" />
     <Compile Include="Config\PullRepresentationConfig.cs" />
     <Compile Include="Config\RevitRemoveConfig.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Engine/pull/2699
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/Revit_Toolkit/issues/1117

<!-- Add short description of what has been fixed -->
See the changelog below and the description in https://github.com/BHoM/BHoM_Engine/pull/2699 and https://github.com/BHoM/BHoM/pull/1306.

**Note**: this replaces https://github.com/BHoM/Revit_Toolkit/pull/1109 due to rebase conflicts.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EsE5svn2eC9EsBM8PZtEOh4BzurxPs9qU6RlYsbd1b-K_g?e=mxisBC

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- The new public `RevitDiffing` methods are simpler and offer multiple usage options to users
- Added a new `RevitComparisonConfig` for Revit-specific diffing options
- Implemented the `Query.ComparisonInclusion()` function that takes a `RevitParameter` input; it also uses the `RevitComparisonConfig` for revit-specific options. This `Query.ComparisonInclusion()` function is called automatically by the Diffing/Hash functions, and it determines if and how `RevitParameter`'s properties should be included.
- The private `Diffing` method is also simpler and leverages the new mechanism above