### PR TITLE
Dynamo stopped from crashing because of BHoM loading different version of assemblies on startup 

### DIFF
--- a/Revit_Core_Adapter/Listener/RevitListener.cs
+++ b/Revit_Core_Adapter/Listener/RevitListener.cs
@@ -159,6 +159,9 @@ namespace BH.Revit.Adapter.Core
 
         public Result OnStartup(UIControlledApplication uIControlledApplication)
         {
+            // Load sensitive Dynamo assemblies prior to BHoM to prevent the former from crashing.
+            BH.Revit.Engine.Core.Compute.LoadSensitiveDynamoAssemblies();
+
             UIControlledApplication = uIControlledApplication;
 
             //Make sure all BHoM assemblies and methods are loaded

--- a/Revit_Core_Engine/Compute/LoadSensitiveDynamoAssemblies.cs
+++ b/Revit_Core_Engine/Compute/LoadSensitiveDynamoAssemblies.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Prioritises loading the Dynamo-specific versions of chosen assemblies on BHoM startup, preventing the former from crashing.\n" +
+                     "This is a hacky solution, but nothing else works due to the rubbish (no?) assembly resolution system on Dynamo side.")]
+        public static void LoadSensitiveDynamoAssemblies()
+        {
+            string revitDir = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
+
+            string pythonPath = Path.Combine(revitDir, "AddIns", "DynamoForRevit", "Python.Runtime.dll");
+            if (File.Exists(pythonPath))
+            {
+                try
+                {
+                    Assembly a = Assembly.LoadFrom(pythonPath);
+                }
+                catch
+                {
+
+                }
+            }
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -89,6 +89,9 @@
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <AssemblyName>Revit_Core_Engine_2020</AssemblyName>
+    <DebugEngines>{351668CC-8477-4fbf-BFE3-5F1006E4DB1F}</DebugEngines>
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files\Autodesk\Revit 2020\Revit.exe</StartProgram>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2020|AnyCPU'">
     <OutputPath>..\Build\</OutputPath>
@@ -133,6 +136,9 @@
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AssemblyName>Revit_Core_Engine_2022</AssemblyName>
+    <DebugEngines>{351668CC-8477-4fbf-BFE3-5F1006E4DB1F}</DebugEngines>
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files\Autodesk\Revit 2022\Revit.exe</StartProgram>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2022|AnyCPU'">
     <OutputPath>..\Build\</OutputPath>
@@ -335,6 +341,7 @@
     <Compile Include="Compute\Activate.cs" />
     <Compile Include="Compute\CheckFamilyMapUsage.cs" />
     <Compile Include="Compute\Errors.cs" />
+    <Compile Include="Compute\LoadSensitiveDynamoAssemblies.cs" />
     <Compile Include="Compute\PrepareForLinkDimensioning.cs" />
     <Compile Include="Compute\SplitRequestTreeByLinks.cs" />
     <Compile Include="Convert\Architecture\FromRevit\Opening.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1136

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Ideally run the installer from [this SP folder](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&isAscending=true&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231137%2DLoadDynamoAssemblies&sortField=LinkFilename&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b) (or compile the code) and see if you are able to run Dynamo in Revit **_on each version_**.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
The problem turned to lie in the version of Python.Runtime used by Dynamo (2.5 or similar) vs recent versions loaded by BHoM (~3.7). As usual, [Autodesk is very helpful when it comes to supporting their user base](https://knowledge.autodesk.com/support/revit/troubleshooting/caas/sfdcarticles/sfdcarticles/Dynamo-is-not-launching-from-the-manage-tab-in-Revit.html), so I needed to build a workaround that loads the obsolete version of Python on startup of BHoM. This is a bit of a crowbar solution, but I will let myself quote @IsakNaslundBh here:

![image](https://user-images.githubusercontent.com/26874773/145055453-639215b8-a5eb-4a0c-a98a-e77acbca4fb3.png)


🙈 