### PR TITLE
Revit_oM: `RevitComparisonConfig` to inherit from `BaseComparisonConfig`, not `ComparisonConfig`

### DIFF
--- a/Revit_oM/Config/RevitComparisonConfig.cs
+++ b/Revit_oM/Config/RevitComparisonConfig.cs
@@ -30,7 +30,7 @@ using System.ComponentModel;
 namespace BH.oM.Adapters.Revit
 {
     [Description("Settings to determine the uniqueness of an Object for comparison (e.g. when Diffing or computing an object Hash).")]
-    public class RevitComparisonConfig : ComparisonConfig
+    public class RevitComparisonConfig : BaseComparisonConfig
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1138

<!-- Add short description of what has been fixed -->
No functional change, just a minor compliance fix. 

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EsE5svn2eC9EsBM8PZtEOh4BzurxPs9qU6RlYsbd1b-K_g?e=cTccfB

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->