### PR TITLE
Reimplement versioning for deleted panel create methods.

### DIFF
--- a/Revit_Engine/Versioning_50.json
+++ b/Revit_Engine/Versioning_50.json
@@ -1,6 +1,8 @@
 ﻿{
   "MessageForDeleted": {
     "BH.Engine.Adapters.Revit.Query.LinkPath(BH.oM.Base.IBHoMObject)": "Link path information has been replaced with link document name stored under LinkDocument property and avaialble through LinkDocument query.",
-    "BH.Engine.Adapters.Revit.Query.HostId(BH.oM.Base.IBHoMObject)": "HostId query has been replaced with a more comprehensive query available under HostInformation."
+    "BH.Engine.Adapters.Revit.Query.HostId(BH.oM.Base.IBHoMObject)": "HostId query has been replaced with a more comprehensive query available under HostInformation.",
+    "BH.Engine.Adapters.Revit.Create.Panel(BH.oM.Geometry.ICurve, System.Double, System.String)": "The method has been deleted because it was not a Revit method.",
+    "BH.Engine.Adapters.Revit.Create.Panel(System.Collections.Generic.IEnumerable<BH.oM.Geometry.Point>, System.String)": "The method has been deleted because it was not a Revit method."
   }
 }


### PR DESCRIPTION
Fixes Versioning Checks.

@alelom @pawelbaran can we be careful to ensure any rebased PRs don't change files they shouldn't be changing as part of their work please - the rebase for diffing removed the additions to `Versioning50.json` for deleted panels. Just a gentle reminder! 😸 