### PR TITLE
Element type query centralised and made more logical

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/ToRevit/FamilyInstance.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/FamilyInstance.cs
@@ -96,7 +96,7 @@ namespace BH.Revit.Engine.Core
 
             Line columnLine = framingElement.Location.IToRevit() as Line;
 
-            FamilySymbol familySymbol = framingElement.ElementType(document, settings, refObjects);
+            FamilySymbol familySymbol = framingElement.ElementType(document, settings);
             if (familySymbol == null)
             {
                 Compute.ElementTypeNotFoundWarning(framingElement);
@@ -200,7 +200,7 @@ namespace BH.Revit.Engine.Core
 
             Level level = document.LevelBelow(framingElement.Location, settings);
 
-            FamilySymbol familySymbol = framingElement.ElementType(document, settings, refObjects);
+            FamilySymbol familySymbol = framingElement.ElementType(document, settings);
             if (familySymbol == null)
             {
                 Compute.ElementTypeNotFoundWarning(framingElement);

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/FamilyInstance.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/FamilyInstance.cs
@@ -96,10 +96,7 @@ namespace BH.Revit.Engine.Core
 
             Line columnLine = framingElement.Location.IToRevit() as Line;
 
-            FamilySymbol familySymbol = framingElement.Property.ToRevitElementType(document, framingElement.BuiltInCategories(document), settings, refObjects);
-            if (familySymbol == null)
-                familySymbol = framingElement.ElementType(document, settings) as FamilySymbol;
-
+            FamilySymbol familySymbol = framingElement.ElementType(document, settings, refObjects);
             if (familySymbol == null)
             {
                 Compute.ElementTypeNotFoundWarning(framingElement);
@@ -203,13 +200,7 @@ namespace BH.Revit.Engine.Core
 
             Level level = document.LevelBelow(framingElement.Location, settings);
 
-            // Always taking StructuralFraming category because most families belong to it.
-            HashSet<BuiltInCategory> categories = framingElement.BuiltInCategories(document);
-            categories.Add(BuiltInCategory.OST_StructuralFraming);
-            FamilySymbol familySymbol = framingElement.Property.ToRevitElementType(document, categories, settings, refObjects);
-            if (familySymbol == null)
-                familySymbol = framingElement.ElementType(document, categories, settings) as FamilySymbol;
-
+            FamilySymbol familySymbol = framingElement.ElementType(document, settings, refObjects);
             if (familySymbol == null)
             {
                 Compute.ElementTypeNotFoundWarning(framingElement);

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
@@ -59,7 +59,7 @@ namespace BH.Revit.Engine.Core
 
             settings = settings.DefaultIfNull();
 
-            FloorType floorType = floor.ElementType(document, settings, refObjects);
+            FloorType floorType = floor.ElementType(document, settings);
             if (floorType == null)
             {
                 Compute.ElementTypeNotFoundWarning(floor);

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
@@ -59,10 +59,7 @@ namespace BH.Revit.Engine.Core
 
             settings = settings.DefaultIfNull();
 
-            FloorType floorType = floor.Construction?.ToRevitElementType(document, new List<BuiltInCategory> { BuiltInCategory.OST_Floors, BuiltInCategory.OST_StructuralFoundation }, settings, refObjects) as FloorType;
-            if (floorType == null)
-                floorType = floor.ElementType(document, settings);
-
+            FloorType floorType = floor.ElementType(document, settings, refObjects);
             if (floorType == null)
             {
                 Compute.ElementTypeNotFoundWarning(floor);

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/RoofBase.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/RoofBase.cs
@@ -59,10 +59,7 @@ namespace BH.Revit.Engine.Core
 
             settings = settings.DefaultIfNull();
 
-            RoofType roofType = roof.Construction?.ToRevitElementType(document, new List<BuiltInCategory> { BuiltInCategory.OST_Roofs }, settings, refObjects) as RoofType;
-            if (roofType == null)
-                roofType = roof.ElementType(document, settings);
-
+            RoofType roofType = roof.ElementType(document, settings, refObjects);
             if (roofType == null)
             {
                 Compute.ElementTypeNotFoundWarning(roof);

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/RoofBase.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/RoofBase.cs
@@ -59,7 +59,7 @@ namespace BH.Revit.Engine.Core
 
             settings = settings.DefaultIfNull();
 
-            RoofType roofType = roof.ElementType(document, settings, refObjects);
+            RoofType roofType = roof.ElementType(document, settings);
             if (roofType == null)
             {
                 Compute.ElementTypeNotFoundWarning(roof);

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Wall.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Wall.cs
@@ -59,7 +59,7 @@ namespace BH.Revit.Engine.Core
 
             settings = settings.DefaultIfNull();
 
-            WallType wallType = wall.ElementType(document, settings, refObjects);
+            WallType wallType = wall.ElementType(document, settings);
             if (wallType == null)
             {
                 Compute.ElementTypeNotFoundWarning(wall);

--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Wall.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Wall.cs
@@ -59,10 +59,7 @@ namespace BH.Revit.Engine.Core
 
             settings = settings.DefaultIfNull();
 
-            WallType wallType = wall.Construction.ToRevitElementType(document, new List<BuiltInCategory> { BuiltInCategory.OST_Walls }, settings, refObjects) as WallType;
-            if (wallType == null)
-                wallType = wall.ElementType(document,settings);
-
+            WallType wallType = wall.ElementType(document, settings, refObjects);
             if (wallType == null)
             {
                 Compute.ElementTypeNotFoundWarning(wall);

--- a/Revit_Core_Engine/Convert/Revit/ToRevit/Element.cs
+++ b/Revit_Core_Engine/Convert/Revit/ToRevit/Element.cs
@@ -80,7 +80,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                ElementType elementType = modelInstance.ElementType(document, settings, refObjects);
+                ElementType elementType = modelInstance.ElementType(document, settings);
                 element = modelInstance.IToRevitElement(elementType, settings);
             }
             
@@ -123,7 +123,7 @@ namespace BH.Revit.Engine.Core
             if (view == null)
                 return null;
 
-            ElementType elementType = draftingInstance.ElementType(document, settings, refObjects);
+            ElementType elementType = draftingInstance.ElementType(document, settings);
             element = draftingInstance.IToRevitElement(elementType, view, settings);
             
             if (element == null)

--- a/Revit_Core_Engine/Convert/Revit/ToRevit/Element.cs
+++ b/Revit_Core_Engine/Convert/Revit/ToRevit/Element.cs
@@ -80,7 +80,7 @@ namespace BH.Revit.Engine.Core
             }
             else
             {
-                ElementType elementType = modelInstance.Properties.ElementType(document, new List<BuiltInCategory> { builtInCategory }, settings);
+                ElementType elementType = modelInstance.ElementType(document, settings, refObjects);
                 element = modelInstance.IToRevitElement(elementType, settings);
             }
             
@@ -123,7 +123,7 @@ namespace BH.Revit.Engine.Core
             if (view == null)
                 return null;
 
-            ElementType elementType = draftingInstance.Properties.ElementType(document, draftingInstance.BuiltInCategories(document), settings);
+            ElementType elementType = draftingInstance.ElementType(document, settings, refObjects);
             element = draftingInstance.IToRevitElement(elementType, view, settings);
             
             if (element == null)

--- a/Revit_Core_Engine/Modify/SetType.cs
+++ b/Revit_Core_Engine/Modify/SetType.cs
@@ -49,11 +49,7 @@ namespace BH.Revit.Engine.Core
             if (element.TrySetTypeFromString(bHoMObject, settings))
                 return true;
 
-            Document doc = element.Document;
-            FamilySymbol familySymbol = bHoMObject.Property.ToRevitElementType(doc, bHoMObject.BuiltInCategories(doc), settings);
-            if (familySymbol == null)
-                familySymbol = bHoMObject.IElementType(doc, settings) as FamilySymbol;
-
+            FamilySymbol familySymbol = bHoMObject.ElementType(element.Document, settings);
             if (familySymbol == null)
             {
                 Compute.ElementTypeNotFoundWarning(bHoMObject);
@@ -75,11 +71,7 @@ namespace BH.Revit.Engine.Core
             if (element.TrySetTypeFromString(bHoMObject, settings))
                 return true;
 
-            Document doc = element.Document;
-            HostObjAttributes hostObjAttr = bHoMObject.Construction.ToRevitElementType(doc, bHoMObject.BuiltInCategories(doc), settings);
-            if (hostObjAttr == null)
-                hostObjAttr = bHoMObject.IElementType(doc, settings) as HostObjAttributes;
-
+            HostObjAttributes hostObjAttr = bHoMObject.IElementType(element.Document, settings) as HostObjAttributes;
             if (hostObjAttr != null && hostObjAttr.Id.IntegerValue != element.GetTypeId().IntegerValue)
                 return element.SetParameter(BuiltInParameter.ELEM_TYPE_PARAM, hostObjAttr.Id);
 
@@ -98,10 +90,7 @@ namespace BH.Revit.Engine.Core
             if (element.TrySetTypeFromString(instance, settings))
                 return true;
 
-            ElementType elementType = instance.Properties.ElementType(element.Document, settings);
-            if (elementType == null)
-                elementType = instance.IElementType(element.Document, settings);
-
+            ElementType elementType = instance.ElementType(element.Document, settings);
             if (elementType != null)
             {
                 try

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -207,6 +207,25 @@ namespace BH.Revit.Engine.Core
                 {
                     Autodesk.Revit.DB.BuiltInCategory.OST_GenericModel,
                 }
+            },
+            {
+                typeof (BH.oM.Physical.Elements.Wall), new BuiltInCategory[]
+                {
+                    Autodesk.Revit.DB.BuiltInCategory.OST_Walls,
+                }
+            },
+            {
+                typeof (BH.oM.Physical.Elements.Floor), new BuiltInCategory[]
+                {
+                    Autodesk.Revit.DB.BuiltInCategory.OST_Floors,
+                    Autodesk.Revit.DB.BuiltInCategory.OST_StructuralFoundation,
+                }
+            },
+            {
+                typeof (BH.oM.Physical.Elements.Roof), new BuiltInCategory[]
+                {
+                    Autodesk.Revit.DB.BuiltInCategory.OST_Roofs,
+                }
             }
         };
 

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -280,10 +280,10 @@ namespace BH.Revit.Engine.Core
             {
                 elementType = surface.ElementType<T>(document);
                 if (elementType != null && differentNames)
-                    BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {surface.BHoM_Guid}");
+                    BH.Engine.Base.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {surface.BHoM_Guid}");
             }
             else if (differentNames)
-                BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {surface.BHoM_Guid}");
+                BH.Engine.Base.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {surface.BHoM_Guid}");
 
             return elementType;
         }
@@ -302,10 +302,10 @@ namespace BH.Revit.Engine.Core
             {
                 elementType = bhomObject.ElementType(document, categories, settings);
                 if (elementType != null && differentNames)
-                    BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {bhomObject.BHoM_Guid}");
+                    BH.Engine.Base.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {bhomObject.BHoM_Guid}");
             }
             else if (differentNames)
-                BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {bhomObject.BHoM_Guid}");
+                BH.Engine.Base.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {bhomObject.BHoM_Guid}");
 
             return elementType;
         }

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -54,6 +54,11 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
+        [Description("Returns the Revit element type to be used when converting a given BHoM framing element to Revit.")]
+        [Input("framingElement", "BHoM framing element to find a correspondent Revit element type for.")]
+        [Input("document", "Revit document to parse in search for the element type.")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
+        [Output("framingType", "Revit element type to be used when converting the input BHoM object to Revit.")]
         public static FamilySymbol ElementType(this BH.oM.Physical.Elements.IFramingElement framingElement, Document document, RevitSettings settings = null)
         {
             HashSet<BuiltInCategory> categories = framingElement.BuiltInCategories(document);
@@ -67,6 +72,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Returns the Revit element type to be used when converting a given BHoM IInstance to Revit.")]
+        [Input("instance", "BHoM IInstance to find a correspondent Revit element type for.")]
+        [Input("document", "Revit document to parse in search for the element type.")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
+        [Output("elementType", "Revit element type to be used when converting the input BHoM object to Revit.")]
         public static ElementType ElementType(this BH.oM.Adapters.Revit.Elements.IInstance instance, Document document, RevitSettings settings = null)
         {
             return instance.ElementTypeInclProperty(instance.Properties, document, new HashSet<BuiltInCategory> { instance.BuiltInCategory(document) }, settings);

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -88,13 +88,11 @@ namespace BH.Revit.Engine.Core
             if (bhomType == null)
                 return null;
 
-            HashSet<BuiltInCategory> categories = new HashSet<BuiltInCategory> { instance.BuiltInCategory(document) };
-
             bool differentNames = !string.IsNullOrWhiteSpace(instance?.Properties?.Name) && !string.IsNullOrWhiteSpace(instance?.Name) && instance.Properties.Name != instance.Name;
-            ElementType elementType = instance.Properties.ElementType(document, categories, settings);
+            ElementType elementType = instance.Properties.ToRevitElementType(document, settings);
             if (elementType == null)
             {
-                elementType = instance.ElementType(document, categories, settings);
+                elementType = instance.ElementType(document, new HashSet<BuiltInCategory> { instance.BuiltInCategory(document) }, settings);
                 if (elementType != null && differentNames)
                     BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Adapters.Revit.Elements.IInstance.Properties)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {instance.BHoM_Guid}");
             }
@@ -313,6 +311,4 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
     }
 }
-
-
 

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -270,10 +270,10 @@ namespace BH.Revit.Engine.Core
             {
                 elementType = surface.ElementType<T>(document);
                 if (elementType != null && differentNames)
-                    BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {surface.BHoM_Guid}");
+                    BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {surface.BHoM_Guid}");
             }
             else if (differentNames)
-                BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {surface.BHoM_Guid}");
+                BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {surface.BHoM_Guid}");
 
             return elementType;
         }
@@ -292,10 +292,10 @@ namespace BH.Revit.Engine.Core
             {
                 elementType = bhomObject.ElementType(document, categories, settings);
                 if (elementType != null && differentNames)
-                    BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {bhomObject.BHoM_Guid}");
+                    BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {bhomObject.BHoM_Guid}");
             }
             else if (differentNames)
-                BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {bhomObject.BHoM_Guid}");
+                BH.Engine.Reflection.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {bhomObject.BHoM_Guid}");
 
             return elementType;
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1146

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231154%2DSetTypeCleanup&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Revit element type search centralised for creation and update of the elements based on the BHoM objects
- informative warnings added to explain to the user what is the source of the element type information for given convert (BHoM object name vs name of its defining property like `Construction`)
- `Query.ElementType` stopped from modifying the queried Revit element types


### Additional comments
<!-- As required -->
The problem proved to be much more complex than originally stated #1146. There were 3 parallel challenges to deal with:
- element type query being different on creation and update of the Revit elements based on BHoM objects
- not enough feedback  on how what is happening on type update
- element type query being able to modify the queried type

First two were rather straightforward to capture and fix, just a matter of pulling the strings together. The 3rd one, however, was a bit more tricky. Until now, when `Query.ElementType` was called on physical `Wall`, `Beam` etc., `ToRevitElementType` method was called from within. This resulted in an attempt to convert and overwrite the parameters of the existing type (if found) instead of simply querying it. This, I believe, is fundamentally wrong, so this has been changed to `Query.ElementType` only querying the element type, but never modifying it.

The above is a breaking change, but I believe it is a step in the right direction, plus it is likely to be left unnoticed by the users. The only scenario affected by the change is a `Push` of an object with its defining property (e.g. `Construction`) having modified Revit parameter values (not properties) using `SetRevitParameter` method. Now, after the change, `Push` of elements affects the elements, while modification of element types can be achieved by pushing the element types themselves.

Sorry for the non-Revit users trying to understand the above 🙈 