### PR TITLE
Calling Create method rather than constructor for MaterialComposition

### DIFF
--- a/Revit_Core_Engine/Query/MaterialTakeoff.cs
+++ b/Revit_Core_Engine/Query/MaterialTakeoff.cs
@@ -67,7 +67,7 @@ namespace BH.Revit.Engine.Core
             }
 
             if (takeoff.Count != 0)
-                return new RevitMaterialTakeOff(totalVolume, new oM.Physical.Materials.MaterialComposition(takeoff.Keys, takeoff.Values.Select(x => x / totalVolume)));
+                return new RevitMaterialTakeOff(totalVolume, BH.Engine.Matter.Create.MaterialComposition(takeoff.Keys, takeoff.Values.Select(x => x / totalVolume)));
             else
                 return null;
         }

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -236,6 +236,9 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Library_Engine.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Matter_Engine">
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Matter_Engine.dll</HintPath>
     </Reference>
     <Reference Include="MEP_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\MEP_Engine.dll</HintPath>

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -238,7 +238,9 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Matter_Engine">
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Matter_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Matter_Engine.dll</HintPath>
+	  <Private>False</Private>
+	  <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="MEP_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\MEP_Engine.dll</HintPath>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

Does not depend on for compilation, but done in alignment with https://github.com/BHoM/BHoM/pull/1341 and https://github.com/BHoM/BHoM_Engine/pull/2733.
Checks done in constructor migrated to engine Create method.   

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Calling Create method rather than constructor straight away to ensure checks and potential error messages are raised appropriately

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->