### PR TITLE
GetRevitElementType and GetRevitTypeParameterValue methods added

### DIFF
--- a/Revit_Engine/Query/GetRevitElementType.cs
+++ b/Revit_Engine/Query/GetRevitElementType.cs
@@ -1,0 +1,204 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Architecture.Elements;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Physical.Elements;
+using System.ComponentModel;
+
+namespace BH.Engine.Adapters.Revit
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Extracts Revit element type representation from a given BHoM object pulled from Revit.")]
+        [Input("bHoMObject", "BHoMObject to be queried for Revit element type representation.")]
+        [Output("elementType", "Revit element type representation extracted from the input BHoM object pulled from Revit.")]
+        public static IBHoMObject IGetRevitElementType(this IBHoMObject bHoMObject)
+        {
+            if (bHoMObject == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not extract Revit element type representation from a null BHoM object.");
+                return null;
+            }
+
+            return (GetRevitElementType(bHoMObject as dynamic));
+        }
+
+
+        /***************************************************/
+        /****              Private methods              ****/
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this Ceiling bHoMObject)
+        {
+            return bHoMObject.Construction;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.Architecture.BuildersWork.Opening bHoMObject)
+        {
+            return bHoMObject.Profile;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.Environment.Elements.Panel bHoMObject)
+        {
+            return bHoMObject.Construction;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.Facade.Elements.FrameEdge bHoMObject)
+        {
+            return bHoMObject.FrameEdgeProperty;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.Facade.Elements.Opening bHoMObject)
+        {
+            return bHoMObject.OpeningConstruction;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.Facade.Elements.Panel bHoMObject)
+        {
+            return bHoMObject.Construction;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.MEP.System.CableTray bHoMObject)
+        {
+            return bHoMObject.SectionProperty;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.MEP.System.Duct bHoMObject)
+        {
+            return bHoMObject.SectionProperty;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.MEP.System.Pipe bHoMObject)
+        {
+            return bHoMObject.SectionProperty;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this IFramingElement bHoMObject)
+        {
+            return bHoMObject.Property;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this Door bHoMObject)
+        {
+            return bHoMObject.Construction;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this ISurface bHoMObject)
+        {
+            return bHoMObject.Construction;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this Window bHoMObject)
+        {
+            return bHoMObject.Construction;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this IInstance bHoMObject)
+        {
+            return bHoMObject.Properties;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this Sheet bHoMObject)
+        {
+            return bHoMObject.InstanceProperties;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this Viewport bHoMObject)
+        {
+            return bHoMObject.InstanceProperties;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this ViewPlan bHoMObject)
+        {
+            return bHoMObject.InstanceProperties;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.Structure.Elements.Bar bHoMObject)
+        {
+            return bHoMObject.SectionProperty;
+        }
+
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.Structure.Elements.Panel bHoMObject)
+        {
+            return bHoMObject.Property;
+        }
+
+
+        /***************************************************/
+        /****              Fallback methods             ****/
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this IBHoMObject bHoMObject)
+        {
+            BH.Engine.Base.Compute.RecordError($"BHoM object of type {bHoMObject.GetType().FullName} does not store the information about correspondent Revit element type.");
+            return null;
+        }
+
+        /***************************************************/
+    }
+}
+
+
+

--- a/Revit_Engine/Query/GetRevitTypeParameterValue.cs
+++ b/Revit_Engine/Query/GetRevitTypeParameterValue.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapters.Revit.Parameters;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace BH.Engine.Adapters.Revit
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Retrieves value of a parameter from a Revit element type representation attached to a BHoM object pulled from Revit.")]
+        [Input("bHoMObject", "BHoMObject to which the parameters will be attached.")]
+        [Input("parameterName", "Name of the parameter to be sought for.")]
+        [Output("value")]
+        public static object GetRevitTypeParameterValue(this IBHoMObject bHoMObject, string parameterName)
+        {
+            if (bHoMObject == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not extract Revit element type parameter value from a null BHoM object.");
+                return null;
+            }
+
+            return bHoMObject.IGetRevitElementType()?.GetRevitParameterValue(parameterName);
+        }
+
+        /***************************************************/
+    }
+}
+
+
+

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -95,6 +95,9 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Environment_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Facade_oM">
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Facade_oM.dll</HintPath>
+    </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
@@ -115,6 +118,9 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Library_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="MEP_oM">
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\MEP_oM.dll</HintPath>
+    </Reference>
     <Reference Include="Physical_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_Engine.dll</HintPath>
@@ -129,6 +135,10 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Spatial_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Spatial_oM.dll</HintPath>
     </Reference>
     <Reference Include="Structure_oM">
       <SpecificVersion>False</SpecificVersion>
@@ -189,6 +199,8 @@
     <Compile Include="Modify\SetTag.cs" />
     <Compile Include="Modify\Move.cs" />
     <Compile Include="Modify\Transform.cs" />
+    <Compile Include="Query\GetRevitElementType.cs" />
+    <Compile Include="Query\GetRevitTypeParameterValue.cs" />
     <Compile Include="Query\HashString.cs" />
     <Compile Include="Query\ComparisonInclusion.cs" />
     <Compile Include="Query\FilterDescription.cs" />

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -96,7 +96,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Facade_oM">
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Facade_oM.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Facade_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>
@@ -119,7 +121,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="MEP_oM">
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\MEP_oM.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\MEP_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Physical_Engine">
       <SpecificVersion>False</SpecificVersion>
@@ -136,9 +140,10 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="Spatial_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Spatial_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Spatial_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Spatial_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Structure_oM">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1165

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint]().


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
The methods yield correct results only for the BHoM types that have Revit element type information processed on `FromRevit` convert, i.e. major `Physical` types, `Structural` panels etc. Converts of many other types will need to be reviewed and potentially improved to convert the underlying element type and its params - a follow-up issue to be raised once this PR gets merged.