### PR TITLE
RevitTypeFragment introduced and BHoM converts fixed to pass the type information to the output object

### DIFF
--- a/Revit_Core_Engine/Convert/Architecture/FromRevit/Opening.cs
+++ b/Revit_Core_Engine/Convert/Architecture/FromRevit/Opening.cs
@@ -22,6 +22,7 @@
 
 using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Base.Attributes;
@@ -96,6 +97,16 @@ namespace BH.Revit.Engine.Core
             else
                 BH.Engine.Base.Compute.RecordWarning($"The depth of the opening could not be extracted from the Revit element because the correspondent parameter could not be found. Revit ElementId: {instance.Id}"
                     + "\nTo link the specific parameter values with opening depth, add relevant ParameterMap to RevitSettings.MappingSettings.");
+
+            // Revit element type proxy
+            RevitTypeFragment typeFragment = null;
+            ElementType type = instance.Document.GetElement(instance.GetTypeId()) as ElementType;
+            if (type != null)
+                typeFragment = type.TypeFragmentFromRevit(settings, refObjects);
+
+            // Set the type fragment
+            if (typeFragment != null)
+                opening.Fragments.Add(typeFragment);
 
             //Set identifiers, parameters & custom data
             opening.SetIdentifiers(instance);

--- a/Revit_Core_Engine/Convert/Architecture/FromRevit/Room.cs
+++ b/Revit_Core_Engine/Convert/Architecture/FromRevit/Room.cs
@@ -59,7 +59,10 @@ namespace BH.Revit.Engine.Core
             //Set location
             if (spatialElement.Location != null && spatialElement.Location is LocationPoint)
                 room.Location = ((LocationPoint)spatialElement.Location).FromRevit();
-            
+
+            //Set type
+            spatialElement.CopySpatialElementTypeToFragment(room, settings, refObjects);
+
             //Set identifiers, parameters & custom data
             room.SetIdentifiers(spatialElement);
             room.CopyParameters(spatialElement, settings.MappingSettings);

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Space.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Space.cs
@@ -125,6 +125,9 @@ namespace BH.Revit.Engine.Core
             //TODO: Implement ConnectedElements
             space.AddFragment(spaceContext);
 
+            //Set type
+            spatialElement.CopySpatialElementTypeToFragment(space, settings, refObjects);
+
             //Set identifiers, parameters & custom data
             space.SetIdentifiers(spatialElement);
             space.CopyParameters(spatialElement, settings.MappingSettings);
@@ -190,6 +193,9 @@ namespace BH.Revit.Engine.Core
             spaceContext.SetProperties(energyAnalysisSpace, settings.MappingSettings);
             spaceContext.SetProperties(spatialElement, settings.MappingSettings);
             space.AddFragment(spaceContext);
+
+            //Set type
+            spatialElement.CopyTypeToFragment(space, settings, refObjects);
 
             //Set identifiers, parameters & custom data
             space.SetIdentifiers(spatialElement);

--- a/Revit_Core_Engine/Convert/MEP/FromRevit/CableTray.cs
+++ b/Revit_Core_Engine/Convert/MEP/FromRevit/CableTray.cs
@@ -20,17 +20,16 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Collections.Generic;
-using System.Linq;
-using System.ComponentModel;
 using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
 using BH.Engine.Geometry;
+using BH.oM.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
-using BH.oM.MEP.System;
 using BH.oM.Base.Attributes;
-using BH.oM.Geometry;
+using BH.oM.MEP.System;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core
 {
@@ -66,6 +65,12 @@ namespace BH.Revit.Engine.Core
             // Orientation angle
             double orientationAngle = revitCableTray.OrientationAngle(settings);
 
+            // Revit element type proxy
+            RevitTypeFragment typeFragment = null;
+            ElementType type = revitCableTray.Document.GetElement(revitCableTray.GetTypeId()) as ElementType;
+            if (type != null)
+                typeFragment = type.TypeFragmentFromRevit(settings, refObjects);
+
             List<BH.oM.Geometry.Line> queried = Query.LocationCurveMEP(revitCableTray, settings);
 
             for (int i = 0; i < queried.Count; i++)
@@ -78,6 +83,10 @@ namespace BH.Revit.Engine.Core
                     SectionProperty = sectionProperty,
                     OrientationAngle = orientationAngle
                 };
+
+                // Set the type fragment
+                if (typeFragment != null)
+                    thisSegment.Fragments.Add(typeFragment);
 
                 //Set identifiers, parameters & custom data
                 thisSegment.SetIdentifiers(revitCableTray);

--- a/Revit_Core_Engine/Convert/MEP/FromRevit/Duct.cs
+++ b/Revit_Core_Engine/Convert/MEP/FromRevit/Duct.cs
@@ -22,13 +22,14 @@
 
 using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
+using BH.Engine.Geometry;
+using BH.oM.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Base.Attributes;
+using BH.oM.MEP.System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using BH.Engine.Geometry;
-using BH.oM.MEP.System;
 
 namespace BH.Revit.Engine.Core
 {
@@ -66,6 +67,12 @@ namespace BH.Revit.Engine.Core
             // Orientation angle
             double orientationAngle = revitDuct.OrientationAngle(settings); //ToDo - resolve in next issue, specific issue being raised
 
+            // Revit element type proxy
+            RevitTypeFragment typeFragment = null;
+            ElementType type = revitDuct.Document.GetElement(revitDuct.GetTypeId()) as ElementType;
+            if (type != null)
+                typeFragment = type.TypeFragmentFromRevit(settings, refObjects);
+
             for (int i = 0; i < queried.Count; i++)
             {
                 BH.oM.Geometry.Line segment = queried[i];
@@ -77,6 +84,11 @@ namespace BH.Revit.Engine.Core
                     SectionProperty = sectionProperty,
                     OrientationAngle = orientationAngle
                 };
+
+                // Set the type fragment
+                if (typeFragment != null)
+                    thisSegment.Fragments.Add(typeFragment);
+
                 //Set identifiers, parameters & custom data
                 thisSegment.SetIdentifiers(revitDuct);
                 thisSegment.CopyParameters(revitDuct, settings.MappingSettings);

--- a/Revit_Core_Engine/Convert/MEP/FromRevit/Fitting.cs
+++ b/Revit_Core_Engine/Convert/MEP/FromRevit/Fitting.cs
@@ -56,6 +56,9 @@ namespace BH.Revit.Engine.Core
                 ConnectionsLocation = revitMepFitting.MEPConnectorsLocation()
             };
 
+            //Set type
+            revitMepFitting.CopyTypeToFragment(bhomFitting, settings, refObjects);
+
             //Set identifiers, parameters & custom data
             bhomFitting.SetIdentifiers(revitMepFitting);
             bhomFitting.CopyParameters(revitMepFitting, settings.MappingSettings);

--- a/Revit_Core_Engine/Convert/MEP/FromRevit/Pipe.cs
+++ b/Revit_Core_Engine/Convert/MEP/FromRevit/Pipe.cs
@@ -22,13 +22,14 @@
 
 using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
+using BH.Engine.Geometry;
+using BH.oM.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Base.Attributes;
+using BH.oM.MEP.System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using BH.Engine.Geometry;
-using BH.oM.MEP.System;
 
 namespace BH.Revit.Engine.Core
 {
@@ -63,6 +64,12 @@ namespace BH.Revit.Engine.Core
             double flowRate = revitPipe.LookupParameterDouble(BuiltInParameter.RBS_PIPE_FLOW_PARAM); // Flow rate 
             // Pipe section property
             BH.oM.MEP.System.SectionProperties.PipeSectionProperty sectionProperty = revitPipe.PipeSectionProperty(settings);
+            
+            // Revit element type proxy
+            RevitTypeFragment typeFragment = null;
+            ElementType type = revitPipe.Document.GetElement(revitPipe.GetTypeId()) as ElementType;
+            if (type != null)
+                typeFragment = type.TypeFragmentFromRevit(settings, refObjects);
 
             for (int i = 0; i < queried.Count; i++)
             {
@@ -74,6 +81,11 @@ namespace BH.Revit.Engine.Core
                     FlowRate = flowRate,
                     SectionProperty = sectionProperty
                 };
+
+                // Set the type fragment
+                if (typeFragment != null)
+                    thisSegment.Fragments.Add(typeFragment);
+
                 //Set identifiers, parameters & custom data
                 thisSegment.SetIdentifiers(revitPipe);
                 thisSegment.CopyParameters(revitPipe, settings.MappingSettings);

--- a/Revit_Core_Engine/Convert/MEP/FromRevit/Wire.cs
+++ b/Revit_Core_Engine/Convert/MEP/FromRevit/Wire.cs
@@ -22,10 +22,11 @@
 
 using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
-using BH.oM.MEP.System;
 using BH.oM.Base.Attributes;
+using BH.oM.MEP.System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -57,8 +58,18 @@ namespace BH.Revit.Engine.Core
             BH.oM.Geometry.Point endPoint = curve.GetEndPoint(1).PointFromRevit();
             BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(startPoint, endPoint); // BHoM line
 
+            // Revit element type proxy
+            RevitTypeFragment typeFragment = null;
+            ElementType type = revitWire.Document.GetElement(revitWire.GetTypeId()) as ElementType;
+            if (type != null)
+                typeFragment = type.TypeFragmentFromRevit(settings, refObjects);
+
             // Wire
             bhomWire = new BH.oM.MEP.System.Wire { WireSegments = new List<WireSegment> { BH.Engine.MEP.Create.WireSegment(line) } };
+
+            // Set the type fragment
+            if (typeFragment != null)
+                bhomWire.Fragments.Add(typeFragment);
 
             //Set identifiers, parameters & custom data
             bhomWire.SetIdentifiers(revitWire);

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Construction.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Construction.cs
@@ -88,11 +88,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        //[Description("Converts a Revit HostObjAttributes to BH.oM.Physical.Constructions.Construction.")]
-        //[Input("hostObjAttributes", "Revit HostObjAttributes to be converted.")]
-        //[Input("settings", "Revit adapter settings to be used while performing the convert.")]
-        //[Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        //[Output("construction", "BH.oM.Physical.Constructions.Construction resulting from converting the input Revit HostObjAttributes.")]
+        [Description("Converts a Revit FamilySymbol to BH.oM.Physical.Constructions.Construction.")]
+        [Input("familySymbol", "Revit FamilySymbol to be converted.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("construction", "BH.oM.Physical.Constructions.Construction resulting from converting the input Revit FamilySymbol.")]
         public static oM.Physical.Constructions.Construction ConstructionFromRevit(this FamilySymbol familySymbol, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
@@ -115,5 +115,3 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
     }
 }
-
-

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Construction.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Construction.cs
@@ -57,7 +57,7 @@ namespace BH.Revit.Engine.Core
         public static oM.Physical.Constructions.Construction ConstructionFromRevit(this HostObjAttributes hostObjAttributes, string materialGrade = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
-            
+
             string refId = hostObjAttributes.Id.ReferenceIdentifier(materialGrade);
             oM.Physical.Constructions.Construction construction = refObjects.GetValue<oM.Physical.Constructions.Construction>(refId);
             if (construction != null)
@@ -83,6 +83,32 @@ namespace BH.Revit.Engine.Core
             construction.SetProperties(hostObjAttributes, settings.MappingSettings);
 
             refObjects.AddOrReplace(refId, construction);
+            return construction;
+        }
+
+        /***************************************************/
+
+        //[Description("Converts a Revit HostObjAttributes to BH.oM.Physical.Constructions.Construction.")]
+        //[Input("hostObjAttributes", "Revit HostObjAttributes to be converted.")]
+        //[Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        //[Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        //[Output("construction", "BH.oM.Physical.Constructions.Construction resulting from converting the input Revit HostObjAttributes.")]
+        public static oM.Physical.Constructions.Construction ConstructionFromRevit(this FamilySymbol familySymbol, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            settings = settings.DefaultIfNull();
+
+            oM.Physical.Constructions.Construction construction = refObjects.GetValue<oM.Physical.Constructions.Construction>(familySymbol.Id);
+            if (construction != null)
+                return construction;
+
+            construction = BH.Engine.Physical.Create.Construction(familySymbol.FamilyTypeFullName());
+
+            //Set identifiers, parameters & custom data
+            construction.SetIdentifiers(familySymbol);
+            construction.CopyParameters(familySymbol, settings.MappingSettings);
+            construction.SetProperties(familySymbol, settings.MappingSettings);
+
+            refObjects.AddOrReplace(familySymbol.Id, construction);
             return construction;
         }
 

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
@@ -81,7 +81,9 @@ namespace BH.Revit.Engine.Core
             }
 
             door = new Door { Location = location, Name = familyInstance.FamilyTypeFullName() };
-            
+            FamilySymbol familySymbol = familyInstance.Document.GetElement(familyInstance.GetTypeId()) as FamilySymbol;
+            door.Construction = familySymbol?.ConstructionFromRevit(settings, refObjects);
+
             //Set identifiers, parameters & custom data
             door.SetIdentifiers(familyInstance);
             door.CopyParameters(familyInstance, settings.MappingSettings);

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
@@ -81,7 +81,9 @@ namespace BH.Revit.Engine.Core
             }
 
             window = new Window { Location = location, Name = familyInstance.FamilyTypeFullName() };
-            
+            FamilySymbol familySymbol = familyInstance.Document.GetElement(familyInstance.GetTypeId()) as FamilySymbol;
+            window.Construction = familySymbol?.ConstructionFromRevit(settings, refObjects);
+
             //Set identifiers, parameters & custom data
             window.SetIdentifiers(familyInstance);
             window.CopyParameters(familyInstance, settings.MappingSettings);

--- a/Revit_Core_Engine/Convert/Revit/FromRevit/TypeFragment.cs
+++ b/Revit_Core_Engine/Convert/Revit/FromRevit/TypeFragment.cs
@@ -38,11 +38,11 @@ namespace BH.Revit.Engine.Core
         /****               Public Methods              ****/
         /***************************************************/
 
-        //[Description("Converts a Revit Element to a generic BHoM object, either ModelInstance or DraftingInstance (if the element has location in space) or a BHoMObject otherwise.")]
-        //[Input("element", "Revit Element to be converted.")]
-        //[Input("settings", "Revit adapter settings to be used while performing the convert.")]
-        //[Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        //[Output("object", "BHoM object resulting from converting the given Revit Element.")]
+        [Description("Converts a given Revit element type to a BHoM RevitTypeFragment.")]
+        [Input("elementType", "Revit element type to be converted.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fragment", "BHoM RevitTypeFragment converted from the input Revit element type.")]
         public static RevitTypeFragment TypeFragmentFromRevit(this ElementType elementType, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             return TypeFragmentFromRevit(elementType as Element);
@@ -50,11 +50,11 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        //[Description("Converts a Revit Element to a generic BHoM object, either ModelInstance or DraftingInstance (if the element has location in space) or a BHoMObject otherwise.")]
-        //[Input("element", "Revit Element to be converted.")]
-        //[Input("settings", "Revit adapter settings to be used while performing the convert.")]
-        //[Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        //[Output("object", "BHoM object resulting from converting the given Revit Element.")]
+        [Description("Converts a given Revit HVAC load type to a BHoM RevitTypeFragment.")]
+        [Input("elementType", "Revit HVAC load type to be converted.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fragment", "BHoM RevitTypeFragment converted from the input Revit HVAC load type.")]
         public static RevitTypeFragment TypeFragmentFromRevit(this HVACLoadType elementType, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             return TypeFragmentFromRevit(elementType as Element);
@@ -88,6 +88,3 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
     }
 }
-
-
-

--- a/Revit_Core_Engine/Convert/Revit/FromRevit/TypeFragment.cs
+++ b/Revit_Core_Engine/Convert/Revit/FromRevit/TypeFragment.cs
@@ -65,7 +65,7 @@ namespace BH.Revit.Engine.Core
         /****               Private Methods             ****/
         /***************************************************/
 
-        public static RevitTypeFragment TypeFragmentFromRevit(this Element element, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        private static RevitTypeFragment TypeFragmentFromRevit(this Element element, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             if (element == null)
                 return null;

--- a/Revit_Core_Engine/Convert/Revit/FromRevit/TypeFragment.cs
+++ b/Revit_Core_Engine/Convert/Revit/FromRevit/TypeFragment.cs
@@ -21,6 +21,7 @@
  */
 
 using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Analysis;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
@@ -44,20 +45,42 @@ namespace BH.Revit.Engine.Core
         //[Output("object", "BHoM object resulting from converting the given Revit Element.")]
         public static RevitTypeFragment TypeFragmentFromRevit(this ElementType elementType, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
-            if (elementType == null)
+            return TypeFragmentFromRevit(elementType as Element);
+        }
+
+        /***************************************************/
+
+        //[Description("Converts a Revit Element to a generic BHoM object, either ModelInstance or DraftingInstance (if the element has location in space) or a BHoMObject otherwise.")]
+        //[Input("element", "Revit Element to be converted.")]
+        //[Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        //[Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        //[Output("object", "BHoM object resulting from converting the given Revit Element.")]
+        public static RevitTypeFragment TypeFragmentFromRevit(this HVACLoadType elementType, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            return TypeFragmentFromRevit(elementType as Element);
+        }
+
+
+        /***************************************************/
+        /****               Private Methods             ****/
+        /***************************************************/
+
+        public static RevitTypeFragment TypeFragmentFromRevit(this Element element, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            if (element == null)
                 return null;
 
             settings = settings.DefaultIfNull();
 
-            RevitTypeFragment typeFragment = refObjects.GetValue<RevitTypeFragment>(elementType.Id);
+            RevitTypeFragment typeFragment = refObjects.GetValue<RevitTypeFragment>(element.Id);
             if (typeFragment != null)
                 return typeFragment;
 
             typeFragment = new RevitTypeFragment();
-            typeFragment.Name = elementType.Name;
-            typeFragment.SetIdentifiers(elementType);
-            typeFragment.CopyParameters(elementType, settings.MappingSettings);
-            refObjects.AddOrReplace(elementType.Id, typeFragment);
+            typeFragment.Name = element.Name;
+            typeFragment.SetIdentifiers(element);
+            typeFragment.CopyParameters(element, settings.MappingSettings);
+            refObjects.AddOrReplace(element.Id, typeFragment);
 
             return typeFragment;
         }

--- a/Revit_Core_Engine/Convert/Revit/FromRevit/TypeFragment.cs
+++ b/Revit_Core_Engine/Convert/Revit/FromRevit/TypeFragment.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        //[Description("Converts a Revit Element to a generic BHoM object, either ModelInstance or DraftingInstance (if the element has location in space) or a BHoMObject otherwise.")]
+        //[Input("element", "Revit Element to be converted.")]
+        //[Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        //[Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        //[Output("object", "BHoM object resulting from converting the given Revit Element.")]
+        public static RevitTypeFragment TypeFragmentFromRevit(this ElementType elementType, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            if (elementType == null)
+                return null;
+
+            settings = settings.DefaultIfNull();
+
+            RevitTypeFragment typeFragment = refObjects.GetValue<RevitTypeFragment>(elementType.Id);
+            if (typeFragment != null)
+                return typeFragment;
+
+            typeFragment = new RevitTypeFragment();
+            typeFragment.Name = elementType.Name;
+            typeFragment.SetIdentifiers(elementType);
+            typeFragment.CopyParameters(elementType, settings.MappingSettings);
+            refObjects.AddOrReplace(elementType.Id, typeFragment);
+
+            return typeFragment;
+        }
+
+        /***************************************************/
+    }
+}
+
+
+

--- a/Revit_Core_Engine/Modify/CopySpatialElementTypeToFragment.cs
+++ b/Revit_Core_Engine/Modify/CopySpatialElementTypeToFragment.cs
@@ -39,10 +39,12 @@ namespace BH.Revit.Engine.Core
         /****              Public Methods               ****/
         /***************************************************/
 
-        //[Description("Adds or replaces the collection of BHoM objects stored under the given key in the refObjects dictionary.")]
-        //[Input("refObjects", "Dictionary of objects already processed in the current adapter action, to be updated.")]
-        //[Input("key", "Key of the refObjects dictionary to be updated.")]
-        //[Input("values", "Collection of BHoM objects to be assigned to the input key of refObjects.")]
+        [Description("Converts the element type of the source Revit spatial element to RevitTypeFragment and attaches it to the target BHoM object." +
+                     "\nPrimary source of the type information is Space Type parameter of the source Revit element.")]
+        [Input("source", "Revit spatial element to get the element type from.")]
+        [Input("target", "Target BHoM to set the Revit type fragment to.")]
+        [Input("settings", "Revit adapter settings to be used while performing the operation.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
         public static void CopySpatialElementTypeToFragment(this SpatialElement source, BHoMObject target, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();

--- a/Revit_Core_Engine/Modify/CopySpatialElementTypeToFragment.cs
+++ b/Revit_Core_Engine/Modify/CopySpatialElementTypeToFragment.cs
@@ -21,6 +21,7 @@
  */
 
 using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Analysis;
 using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
@@ -46,9 +47,9 @@ namespace BH.Revit.Engine.Core
         {
             settings = settings.DefaultIfNull();
             ElementId spaceTypeId = source.get_Parameter(BuiltInParameter.ROOM_SPACE_TYPE_PARAM)?.AsElementId();
-            if (spaceTypeId != null)
+            if (spaceTypeId != ElementId.InvalidElementId)
             {
-                ElementType type = source.Document.GetElement(spaceTypeId) as ElementType;
+                HVACLoadType type = source.Document.GetElement(spaceTypeId) as HVACLoadType;
                 target.Fragments.Add(type.TypeFragmentFromRevit(settings, refObjects));
             }
             else

--- a/Revit_Core_Engine/Modify/CopySpatialElementTypeToFragment.cs
+++ b/Revit_Core_Engine/Modify/CopySpatialElementTypeToFragment.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /****              Public Methods               ****/
+        /***************************************************/
+
+        //[Description("Adds or replaces the collection of BHoM objects stored under the given key in the refObjects dictionary.")]
+        //[Input("refObjects", "Dictionary of objects already processed in the current adapter action, to be updated.")]
+        //[Input("key", "Key of the refObjects dictionary to be updated.")]
+        //[Input("values", "Collection of BHoM objects to be assigned to the input key of refObjects.")]
+        public static void CopySpatialElementTypeToFragment(this SpatialElement source, BHoMObject target, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            settings = settings.DefaultIfNull();
+            ElementId spaceTypeId = source.get_Parameter(BuiltInParameter.ROOM_SPACE_TYPE_PARAM)?.AsElementId();
+            if (spaceTypeId != null)
+            {
+                ElementType type = source.Document.GetElement(spaceTypeId) as ElementType;
+                target.Fragments.Add(type.TypeFragmentFromRevit(settings, refObjects));
+            }
+            else
+                source.CopyTypeToFragment(target, settings, refObjects);
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/Revit_Core_Engine/Modify/CopyTypeToFragment.cs
+++ b/Revit_Core_Engine/Modify/CopyTypeToFragment.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /****              Public Methods               ****/
+        /***************************************************/
+
+        //[Description("Adds or replaces the collection of BHoM objects stored under the given key in the refObjects dictionary.")]
+        //[Input("refObjects", "Dictionary of objects already processed in the current adapter action, to be updated.")]
+        //[Input("key", "Key of the refObjects dictionary to be updated.")]
+        //[Input("values", "Collection of BHoM objects to be assigned to the input key of refObjects.")]
+        public static void CopyTypeToFragment(this Element source, BHoMObject target, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            settings = settings.DefaultIfNull();
+
+            ElementType type = source.Document.GetElement(source.GetTypeId()) as ElementType;
+            if (type != null)
+                target.Fragments.Add(type.TypeFragmentFromRevit(settings, refObjects));
+            else
+                BH.Engine.Base.Compute.RecordWarning($"Revit element type could not be extracted from the Revit element, so it has been skipped on convert. Element id: {source.Id.IntegerValue}");
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/Revit_Core_Engine/Modify/CopyTypeToFragment.cs
+++ b/Revit_Core_Engine/Modify/CopyTypeToFragment.cs
@@ -25,10 +25,8 @@ using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Base.Attributes;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 
 namespace BH.Revit.Engine.Core
 {
@@ -38,10 +36,11 @@ namespace BH.Revit.Engine.Core
         /****              Public Methods               ****/
         /***************************************************/
 
-        //[Description("Adds or replaces the collection of BHoM objects stored under the given key in the refObjects dictionary.")]
-        //[Input("refObjects", "Dictionary of objects already processed in the current adapter action, to be updated.")]
-        //[Input("key", "Key of the refObjects dictionary to be updated.")]
-        //[Input("values", "Collection of BHoM objects to be assigned to the input key of refObjects.")]
+        [Description("Converts the element type of the source Revit element to RevitTypeFragment and attaches it to the target BHoM object.")]
+        [Input("source", "Revit element to get the element type from.")]
+        [Input("target", "Target BHoM to set the Revit type fragment to.")]
+        [Input("settings", "Revit adapter settings to be used while performing the operation.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
         public static void CopyTypeToFragment(this Element source, BHoMObject target, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();

--- a/Revit_Core_Engine/Query/Construction.cs
+++ b/Revit_Core_Engine/Query/Construction.cs
@@ -48,7 +48,12 @@ namespace BH.Revit.Engine.Core
             if (element == null)
                 return null;
 
-            return Query.Construction(element.FamilyTypeFullName(), energyAnalysisOpening.OpeningType.ToString());
+            oM.Physical.Constructions.Construction construction = Query.Construction(element.FamilyTypeFullName(), energyAnalysisOpening.OpeningType.ToString());
+            if (construction == null)
+                return null;
+
+            element.CopyTypeToFragment(construction);
+            return construction;
         }
 
 

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -356,9 +356,12 @@
     <Compile Include="Convert\MEP\ToRevit\ElementType.cs" />
     <Compile Include="Convert\Physical\FromRevit\Layer.cs" />
     <Compile Include="Convert\Physical\ToRevit\ElementType.cs" />
+    <Compile Include="Convert\Revit\FromRevit\TypeFragment.cs" />
     <Compile Include="Convert\Revit\Internal\ToSolid.cs" />
     <Compile Include="Convert\Physical\ToRevit\Rebar.cs" />
     <Compile Include="Convert\Revit\ToRevit\ParameterElement.cs" />
+    <Compile Include="Modify\CopySpatialElementTypeToFragment.cs" />
+    <Compile Include="Modify\CopyTypeToFragment.cs" />
     <Compile Include="Modify\SetInsulation.cs" />
     <Compile Include="Create\CategorySet.cs" />
     <Compile Include="Create\Definition\Parameter.cs" />

--- a/Revit_Engine/Query/GetRevitElementType.cs
+++ b/Revit_Engine/Query/GetRevitElementType.cs
@@ -96,29 +96,6 @@ namespace BH.Engine.Adapters.Revit
             return bHoMObject.Construction;
         }
 
-        /***************************************************/
-
-        private static IBHoMObject GetRevitElementType(this BH.oM.MEP.System.CableTray bHoMObject)
-        {
-            return bHoMObject.SectionProperty;
-        }
-
-        /***************************************************/
-
-        private static IBHoMObject GetRevitElementType(this BH.oM.MEP.System.Duct bHoMObject)
-        {
-            return bHoMObject.SectionProperty;
-        }
-
-        /***************************************************/
-
-        private static IBHoMObject GetRevitElementType(this BH.oM.MEP.System.Pipe bHoMObject)
-        {
-            return bHoMObject.SectionProperty;
-        }
-
-        /***************************************************/
-
         private static IBHoMObject GetRevitElementType(this IFramingElement bHoMObject)
         {
             return bHoMObject.Property;

--- a/Revit_Engine/Query/GetRevitElementType.cs
+++ b/Revit_Engine/Query/GetRevitElementType.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
+using BH.oM.Adapters.Revit;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Architecture.Elements;
 using BH.oM.Base;
@@ -61,16 +63,16 @@ namespace BH.Engine.Adapters.Revit
 
         /***************************************************/
 
-        private static IBHoMObject GetRevitElementType(this BH.oM.Architecture.BuildersWork.Opening bHoMObject)
+        private static IBHoMObject GetRevitElementType(this BH.oM.Environment.Elements.Panel bHoMObject)
         {
-            return bHoMObject.Profile;
+            return bHoMObject.Construction;
         }
 
         /***************************************************/
 
-        private static IBHoMObject GetRevitElementType(this BH.oM.Environment.Elements.Panel bHoMObject)
+        private static IBHoMObject GetRevitElementType(this BH.oM.Environment.Elements.Opening bHoMObject)
         {
-            return bHoMObject.Construction;
+            return bHoMObject.OpeningConstruction;
         }
 
         /***************************************************/
@@ -192,8 +194,11 @@ namespace BH.Engine.Adapters.Revit
 
         private static IBHoMObject GetRevitElementType(this IBHoMObject bHoMObject)
         {
-            BH.Engine.Base.Compute.RecordError($"BHoM object of type {bHoMObject.GetType().FullName} does not store the information about correspondent Revit element type.");
-            return null;
+            RevitTypeFragment fragment = bHoMObject.FindFragment<RevitTypeFragment>();
+            if (fragment == null)
+                BH.Engine.Base.Compute.RecordError($"BHoM object of type {bHoMObject.GetType().FullName} does not store the information about correspondent Revit element type.");
+
+            return fragment;
         }
 
         /***************************************************/

--- a/Revit_oM/Misc/RevitTypeFragment.cs
+++ b/Revit_oM/Misc/RevitTypeFragment.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System.ComponentModel;
+
+namespace BH.oM.Adapters.Revit
+{
+    //[Description("An object representing a cloned Revit type, to be pushed in order to create a new type.")]
+    public class RevitTypeFragment : BHoMObject, IFragment
+    {
+        /***************************************************/
+        /****             Public Properties             ****/
+        /***************************************************/
+
+
+
+        /***************************************************/
+    }
+}
+
+
+
+

--- a/Revit_oM/Misc/RevitTypeFragment.cs
+++ b/Revit_oM/Misc/RevitTypeFragment.cs
@@ -25,7 +25,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit
 {
-    //[Description("An object representing a cloned Revit type, to be pushed in order to create a new type.")]
+    [Description("Fragment containing information about element type of the Revit element correspondent to the object that owns it.")]
     public class RevitTypeFragment : BHoMObject, IFragment
     {
         /***************************************************/

--- a/Revit_oM/Revit_oM.csproj
+++ b/Revit_oM/Revit_oM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -101,6 +101,7 @@
     <Compile Include="Misc\RevitHostFragment.cs" />
     <Compile Include="Misc\RevitMaterialTakeOff.cs" />
     <Compile Include="Misc\RevitRepresentation.cs" />
+    <Compile Include="Misc\RevitTypeFragment.cs" />
     <Compile Include="Misc\Tolerance.cs" />
     <Compile Include="Mapping\ElementTypeParameterLink.cs" />
     <Compile Include="Misc\FamilyLibrary.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Covers large portion of #1169

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
PR-specific test file on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231174%2DRevitTypeHandling&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).
Builders work openings can be tested using [this script](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231127%2DOpeningConverts%2FOpenings&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b)
BEnv openings can be test using PullBEnvModel from [this folder](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FRevit%5FToolkit%2FPull&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `RevitTypeFragment` introduced
- BHoM converts fixed to pass the type information to the output object:
    - `BH.oM.Architecture.BuildersWork.Opening` - `RevitTypeFragment` is added along with `Profile`, which is not necessarily related to the element type (it is based on parameter values of the element itself)
    - `BH.oM.Architecture.Elements.Room` - `RevitTypeFragment` added because the object does not have a defining property
    - `BH.oM.Environment.Elements.Opening` - fixed to pass the parameters to `OpeningConstruction`
    - `BH.oM.Environment.Elements.Space` - `RevitTypeFragment` added because the object does not have a defining property
    - `BH.oM.MEP.System.CableTray` - `RevitTypeFragment` is added along with `SectionProperty`, which is not related to the element type (it is based on parameter values of the element itself)
    - `BH.oM.MEP.System.Duct` - `RevitTypeFragment` is added along with `SectionProperty`, which is not related to the element type (it is based on parameter values of the element itself)
    - `BH.oM.MEP.System.Fittings.Fitting` - `RevitTypeFragment` added because the object does not have a defining property
    - `BH.oM.MEP.System.Pipe` - `RevitTypeFragment` is added along with `SectionProperty`, which is not related to the element type (it is based on parameter values of the element itself)
    - `BH.oM.MEP.System.Wire` - `RevitTypeFragment` added because the object does not have a defining property
    - `BH.oM.Physical.Elements.Door` - convert fixed to create an empty `Construction` that represents the element type (and contains its parameters)
    - `BH.oM.Physical.Elements.Window` - convert fixed to create an empty `Construction` that represents the element type (and contains its parameters)


### Additional comments
<!-- As required -->
Added @enarhi for reference - might be a good inspiration for fixing Facade converts.