### PR TITLE
Add new features to Query.LookupParameter

### DIFF
--- a/Revit_Core_Engine/Query/LookupParameter.cs
+++ b/Revit_Core_Engine/Query/LookupParameter.cs
@@ -67,13 +67,13 @@ namespace BH.Revit.Engine.Core
         [Input("parameterName", "Names of the parameter to be iterated over in search for the parameter.")]
         [Input("allowTypeParameters", "Optional, whether or not to also look for Type parameters if no Instance parameters were found.")]
         [Output("parameter", "Parameter extracted from the input Revit Family Instance.")]
-        public static Parameter LookupParameter(this Element element, string parameterName, bool allowTypeParameters = true)
+        public static Parameter LookupParameter(this Element element, string parameterName, bool allowTypeParameters)
         {
             if (element == null || string.IsNullOrEmpty(parameterName))
                 return null;
            
             // Try to return an Instance Parameter
-            Parameter parameter = element.LookupParameter("parameterName");
+            Parameter parameter = element.LookupParameter(parameterName);
             if (parameter != null)
                 return parameter;
 

--- a/Revit_Core_Engine/Query/LookupParameter.cs
+++ b/Revit_Core_Engine/Query/LookupParameter.cs
@@ -347,9 +347,11 @@ namespace BH.Revit.Engine.Core
 
         [Description("Queries a Revit Parameter for its value, regardless of the its storage type.")]
         [Input("parameter", "Revit Parameter to be queried.")]
-        [Input("convertUnits", "If true, the output will be converted double values from Revit internal units to SI.")]
+        [Input("convertDoubleUnits", "If true, the output will convert double values from Revit internal units to SI.")]
+        [Input("convertDoubleToHumanReadable", "If true, the output will convert double values from Revit internal units to Revit document's display unit (mm, cm, degrees, etc).")]
+        [Input("convertIdToHumanReadable", "If true, the output will convert ElementId values from Revit internal units to human readable values, such as Level name.")]
         [Output("value", "Value as object extracted from the input Revit Parameter.")]
-        public static object LookupParameterObject(this Parameter parameter, bool convertUnits = true)
+        public static object LookupParameterObject(this Parameter parameter, bool convertDoubleUnits = false, bool convertDoubleToHumanReadable = false, bool convertIdToHumanReadable = false)
         {
             if (parameter == null || parameter.IsReadOnly)
                 return null;
@@ -357,16 +359,27 @@ namespace BH.Revit.Engine.Core
             switch (parameter.StorageType)
             {
                 case StorageType.Double:
-                    if (convertUnits)
+                    if (convertDoubleUnits)
+#if (REVIT2018 || REVIT2019 || REVIT2020 || REVIT2021)
                         return parameter.AsDouble().ToSI(parameter.Definition.GetSpecTypeId());
+#else
+                        return parameter.AsDouble().ToSI(parameter.Definition.GetDataType());
+#endif
+                    else if (convertDoubleToHumanReadable)
+#if (REVIT2018 || REVIT2019 || REVIT2020)
+                        return UnitUtils.ConvertFromInternalUnits(parameter.AsDouble(), parameter.DisplayUnitType);//parameter.AsDouble();
+#else
+                        return UnitUtils.ConvertFromInternalUnits(parameter.AsDouble(), parameter.GetUnitTypeId());
+#endif
                     else
                         return parameter.AsDouble();
+
                 case StorageType.Integer:
                     return parameter.AsInteger();
                 case StorageType.String:
                     return parameter.AsString();
                 case StorageType.ElementId:
-                    if (parameter.AsElementId() == null || !parameter.HasValue)
+                    if (parameter.AsElementId() == null || !parameter.HasValue || convertIdToHumanReadable)
                         return parameter.AsValueString();
                     else
                         return parameter.AsElementId();

--- a/Revit_Core_Engine/Query/LookupParameter.cs
+++ b/Revit_Core_Engine/Query/LookupParameter.cs
@@ -82,6 +82,7 @@ namespace BH.Revit.Engine.Core
             if (!allowTypeParameters)
                 return null;
             
+            // Try to return a Type Parameter
             Element elementSymbol = element.Document.GetElement(element.GetTypeId());
             return elementSymbol?.LookupParameter(parameterName);
         }

--- a/Revit_Core_Engine/Query/LookupParameter.cs
+++ b/Revit_Core_Engine/Query/LookupParameter.cs
@@ -73,11 +73,9 @@ namespace BH.Revit.Engine.Core
                 return null;
            
             // Try to return an Instance Parameter
-            foreach (Parameter p in element.Parameters)
-            {
-                if (p != null && p.Definition.Name == parameterName)
-                    return p;
-            }
+            Parameter parameter = element.LookupParameter("parameterName");
+            if (parameter != null)
+                return parameter;
 
             if (!allowTypeParameters)
                 return null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1177 

Adds new functionality in `Query.LookupParameter`, to return a parameter from element, including type, that doesn't requires a `MappingSettings`.


### Changelog
Modified `BH.Revit.Engine.Core.Query.LookupParameter`