### PR TITLE
Change SetInsulation return type

### DIFF
--- a/Revit_Core_Engine/Modify/SetInsulation.cs
+++ b/Revit_Core_Engine/Modify/SetInsulation.cs
@@ -75,6 +75,7 @@ namespace BH.Revit.Engine.Core
                     BH.Engine.Base.Compute.RecordError("Insulation could not be created. Host element type does not support insulation adding functionality.");
                     return false;
                 }
+                return true;
             }
             else if (insIds.Count == 1)
             {
@@ -92,8 +93,8 @@ namespace BH.Revit.Engine.Core
                 else
                 {
                     doc.Delete(insId);
-                    return true;
                 }
+                return true;
             }
             else if (insIds.Count > 1)
             {

--- a/Revit_Core_Engine/Modify/SetInsulation.cs
+++ b/Revit_Core_Engine/Modify/SetInsulation.cs
@@ -41,17 +41,17 @@ namespace BH.Revit.Engine.Core
         [Input("insulationType", "Type of insulation to be added or updated on the host object. Null value removes insulation from the host if it exist.")]
         [Input("insulationThickness", "Thickness of insulation to be added or updated on the host object.")]
         [Output("insulation", "Insulation that has been added or updated on the host element.")]
-        public static void SetInsulation(this Element host, ElementType insulationType, double insulationThickness)
+        public static bool SetInsulation(this Element host, ElementType insulationType, double insulationThickness)
         {
             if (host == null)
             {
                 BH.Engine.Base.Compute.RecordError("Insulation could not be created. Host element not found.");
-                return;
+                return false;
             }
             if (insulationType != null && insulationThickness < BH.oM.Geometry.Tolerance.Distance)
             {
                 BH.Engine.Base.Compute.RecordError("Insulation thickness cannot be 0 or negative. To remove existing host insulation, set insulation type as null.");
-                return;
+                return false;
             }
 
             Document doc = host.Document;
@@ -73,7 +73,7 @@ namespace BH.Revit.Engine.Core
                 else
                 {
                     BH.Engine.Base.Compute.RecordError("Insulation could not be created. Host element type does not support insulation adding functionality.");
-                    return;
+                    return false;
                 }
             }
             else if (insIds.Count == 1)
@@ -92,14 +92,15 @@ namespace BH.Revit.Engine.Core
                 else
                 {
                     doc.Delete(insId);
-                    return;
+                    return true;
                 }
             }
             else if (insIds.Count > 1)
             {
-                BH.Engine.Base.Compute.RecordError("Insulation could not be changed. Not supported type of host insulation.");
-                return;
+                BH.Engine.Base.Compute.RecordError("Insulation could not be changed. Not supported type of host insulation.";
             }
+
+            return false;
         }
     }
 

--- a/Revit_Core_Engine/Modify/SetInsulation.cs
+++ b/Revit_Core_Engine/Modify/SetInsulation.cs
@@ -41,17 +41,17 @@ namespace BH.Revit.Engine.Core
         [Input("insulationType", "Type of insulation to be added or updated on the host object. Null value removes insulation from the host if it exist.")]
         [Input("insulationThickness", "Thickness of insulation to be added or updated on the host object.")]
         [Output("insulation", "Insulation that has been added or updated on the host element.")]
-        public static bool SetInsulation(this Element host, ElementType insulationType, double insulationThickness)
+        public static InsulationLiningBase SetInsulation(this Element host, ElementType insulationType, double insulationThickness)
         {
             if (host == null)
             {
                 BH.Engine.Base.Compute.RecordError("Insulation could not be created. Host element not found.");
-                return false;
+                return null;
             }
             if (insulationType != null && insulationThickness < BH.oM.Geometry.Tolerance.Distance)
             {
                 BH.Engine.Base.Compute.RecordError("Insulation thickness cannot be 0 or negative. To remove existing host insulation, set insulation type as null.");
-                return false;
+                return null;
             }
 
             Document doc = host.Document;
@@ -73,9 +73,7 @@ namespace BH.Revit.Engine.Core
                 else
                 {
                     BH.Engine.Base.Compute.RecordError("Insulation could not be created. Host element type does not support insulation adding functionality.");
-                    return false;
                 }
-                return true;
             }
             else if (insIds.Count == 1)
             {
@@ -94,14 +92,13 @@ namespace BH.Revit.Engine.Core
                 {
                     doc.Delete(insId);
                 }
-                return true;
             }
             else if (insIds.Count > 1)
             {
-                BH.Engine.Base.Compute.RecordError("Insulation could not be changed. Not supported type of host insulation.";
+                BH.Engine.Base.Compute.RecordError("Insulation could not be changed. Not supported type of host insulation.");
             }
 
-            return false;
+            return ins;
         }
     }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1191 

<!-- Add short description of what has been fixed -->
Changing `SetInsulation` return type from `void` to `InsulationLiningBase` to have better control when used in other methods.

### Test files
<!-- Link to test files to validate the proposed changes -->

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->