### PR TITLE
Revit_Core_Engine: Add Color convert Rebased

### DIFF
--- a/Revit_Core_Engine/Convert/Revit/FromRevit/Color.cs
+++ b/Revit_Core_Engine/Convert/Revit/FromRevit/Color.cs
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using System.Drawing;
+using BH.oM.Base.Attributes;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        [Description("Converts a Revit API color to a System.Drawing color.")]
+        [Input("color","Revit color to be converted.")]
+        [Output("color", "The System.Drawing converted from a Revit API color.")]
+        public static Color FromRevit(this Autodesk.Revit.DB.Color color)
+        {
+            return Color.FromArgb(color.Red, color.Green, color.Blue);
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/Revit_Core_Engine/Convert/Revit/ToRevit/Color.cs
+++ b/Revit_Core_Engine/Convert/Revit/ToRevit/Color.cs
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using System.Drawing;
+using BH.oM.Base.Attributes;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        [Description("Converts a System.Drawing Color to a Revit API Color.")]
+        [Input("color","System color to be converted.")]
+        [Output("color", "The Revit API Color converted from a System.Drawing color.")]
+        public static  Autodesk.Revit.DB.Color ToRevit(this Color color)
+        {
+            return new Autodesk.Revit.DB.Color(color.R, color.G, color.B);
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -356,9 +356,11 @@
     <Compile Include="Convert\MEP\ToRevit\ElementType.cs" />
     <Compile Include="Convert\Physical\FromRevit\Layer.cs" />
     <Compile Include="Convert\Physical\ToRevit\ElementType.cs" />
+    <Compile Include="Convert\Revit\FromRevit\Color.cs" />
     <Compile Include="Convert\Revit\FromRevit\TypeFragment.cs" />
     <Compile Include="Convert\Revit\Internal\ToSolid.cs" />
     <Compile Include="Convert\Physical\ToRevit\Rebar.cs" />
+    <Compile Include="Convert\Revit\ToRevit\Color.cs" />
     <Compile Include="Convert\Revit\ToRevit\ParameterElement.cs" />
     <Compile Include="Modify\CopySpatialElementTypeToFragment.cs" />
     <Compile Include="Modify\CopyTypeToFragment.cs" />


### PR DESCRIPTION
## This is a rebase of #1185 - comparison with the original PR available [here](https://github.com/BHoM/Revit_Toolkit/compare/6ee68514e221d8a10507747fb18e8a229dd70502..2ed81843c238001937bed1a43495034db16dc127)

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1184 

Color convert added, from System.Drawing to Revit API and vice-versa.


### Test files
N/A

### Changelog
Added `BH.Revit.Engine.Core.Convert.Color.ToRevit`
Added `BH.Revit.Engine.Core.Convert.Color.FromRevit`