### PR TITLE
Null checks added to stop geometry processing from crashing when extracting panel/opening surface

### DIFF
--- a/Revit_Core_Engine/Query/OpeningSurface.cs
+++ b/Revit_Core_Engine/Query/OpeningSurface.cs
@@ -276,10 +276,10 @@ namespace BH.Revit.Engine.Core
                     if (planes.Count == 0)
                         continue;
 
-                    List<Solid> fullSolids = h.Solids(new Options()).SelectMany(x => SolidUtils.SplitVolumes(x)).ToList();
+                    List<Solid> fullSolids = h.Solids(new Options()).SelectMany(x => SolidUtils.SplitVolumes(x)).Where(x => x != null).ToList();
                     if (h is Wall)
                     {
-                        fullSolids = fullSolids.Select(x => BooleanOperationsUtils.CutWithHalfSpace(x, planes[0])).ToList();
+                        fullSolids = fullSolids.Select(x => BooleanOperationsUtils.CutWithHalfSpace(x, planes[0])).Where(x => x != null).ToList();
                         planes[0] = Autodesk.Revit.DB.Plane.CreateByNormalAndOrigin(-planes[0].Normal, planes[0].Origin);
                     }
 

--- a/Revit_Core_Engine/Query/PanelSurfaces.cs
+++ b/Revit_Core_Engine/Query/PanelSurfaces.cs
@@ -114,16 +114,16 @@ namespace BH.Revit.Engine.Core
                 else
                     fullSolids = solidsWithOpenings;
 
-                fullSolids = fullSolids.SelectMany(x => SolidUtils.SplitVolumes(x)).ToList();
+                fullSolids = fullSolids.SelectMany(x => SolidUtils.SplitVolumes(x)).Where(x => x != null).ToList();
                 if (hostObject is Wall)
                 {
                     fullSolids.ForEach(x => BooleanOperationsUtils.CutWithHalfSpaceModifyingOriginalSolid(x, planes[0]));
+                    fullSolids = fullSolids.Where(x => x != null).ToList();
                     Autodesk.Revit.DB.Plane flippedPlane = Autodesk.Revit.DB.Plane.CreateByNormalAndOrigin(-planes[0].Normal, planes[0].Origin + planes[0].Normal * 1e-3);
                     fullSolids.ForEach(x => BooleanOperationsUtils.CutWithHalfSpaceModifyingOriginalSolid(x, flippedPlane));
-                    fullSolids = fullSolids.SelectMany(x => SolidUtils.SplitVolumes(x)).ToList();
+                    fullSolids = fullSolids.Where(x => x != null).SelectMany(x => SolidUtils.SplitVolumes(x)).ToList();
                     planes[0] = Autodesk.Revit.DB.Plane.CreateByNormalAndOrigin(-planes[0].Normal, planes[0].Origin);
                 }
-
 
                 foreach (Autodesk.Revit.DB.Plane plane in planes)
                 {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1195

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint]()


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->