### PR TITLE
RevitComparisonConfig.NumericTolerance overridden

### DIFF
--- a/Revit_oM/Config/RevitComparisonConfig.cs
+++ b/Revit_oM/Config/RevitComparisonConfig.cs
@@ -68,6 +68,12 @@ namespace BH.oM.Adapters.Revit
         [Description("(Defaults to `true`) If false, if an object has a RevitParameter with a null Value deleted from it, then the owner object is NOT considered 'Modified' and the Comparison will NOT return this difference.")]
         public virtual bool RevitParams_ConsiderRemovedUnassigned { get; set; } = true;
 
+        [Description("Numeric tolerance for property values, applied to all numerical properties. Defaults to 1e-6." +
+                     "\nApplies rounding for numbers smaller than this." +
+                     "\nYou can override on a per-property basis by using `PropertyNumericTolerances`." +
+                     "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
+        public override double NumericTolerance { get; set; } = 1e-6;
+
         /***************************************************/
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1199

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Invoke the RevitDiffing tests in [DiffingTests_Prototypes ](https://github.com/BHoM/DiffingTests_Prototypes). They should all pass.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- The default NumericalTolerance for RevitDiffing is now set to **`1e-6`** instead of `Double.MaxValue`. This will affect every Diffing done with RevitDiffing from now on. Comparisons on the same sets of objects done previously with RevitDiffing will return different results after this PR, if the default tolerance of was used. To replicate the same results as before, set `Double.MaxValue` manually on the NumericTolerance property of the RevitComparisonConfig before triggering the RevitDiffing.

### Additional comments
<!-- As required -->