### PR TITLE
Revit_Core_Engine: Handled exceptions on obtaining ceiling pattern lines

### DIFF
--- a/Revit_Core_Engine/Query/CeilingPattern.cs
+++ b/Revit_Core_Engine/Query/CeilingPattern.cs
@@ -68,10 +68,12 @@ namespace BH.Revit.Engine.Core
 
             double rotation;
             XYZ alignment = ceiling.CeilingPatternAlignment(material, settings, out rotation);
+
             if (alignment == null)
             {
                 // Try getting pattern of the main painted material if any
                 var paintedMaterialIds = ceiling.GetMaterialIds(true);
+
                 if (paintedMaterialIds.Count > 0)
                 {
                     var mainPaintedId = paintedMaterialIds.Aggregate((id1, id2) => ceiling.GetMaterialArea(id1, true) > ceiling.GetMaterialArea(id2, true) ? id1 : id2);
@@ -79,6 +81,7 @@ namespace BH.Revit.Engine.Core
                     alignment = ceiling.CeilingPatternAlignment(material, settings, out rotation);
                 }
             }
+
             if (alignment == null)
             {
                 BH.Engine.Base.Compute.RecordWarning($"Ceiling patterns could not be pulled because the material of Revit ElementId {ceiling.Id} has no Foreground Surface Pattern.");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1201 

<!-- Add short description of what has been fixed -->
Fixed the method for extracting pattern lines of a Revit ceiling being pulled. Also, added code for looking up a painted material if the compound structure's material doesn't have a surface pattern. This is based on ceilings in Kayleigh's test file which have painted materials.

### Test files
<!-- Link to test files to validate the proposed changes -->
Same file Kayleigh sent us before but with one ceiling changed to the "GWB" type. The ceiling type triggered the issue, not the number of ceilings selected before the pull.
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/Revit_Core_Engine-%231201-HandlePullingCeilingsWithoutValidMaterialPatterns?csf=1&web=1&e=bWOGJW

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Handled pulling ceilings where their surface patterns are painted or unavailable.