### PR TITLE
RoomFromRevit stopped from crashing on rooms without outlines

### DIFF
--- a/Revit_Core_Engine/Convert/Architecture/FromRevit/Room.cs
+++ b/Revit_Core_Engine/Convert/Architecture/FromRevit/Room.cs
@@ -52,7 +52,7 @@ namespace BH.Revit.Engine.Core
 
             room = new oM.Architecture.Elements.Room()
             {
-                Perimeter = spatialElement.Perimeter(settings).First()
+                Perimeter = spatialElement.Perimeter(settings).FirstOrDefault()
             };
             room.Name = spatialElement.Name;
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1208

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231209%2DRoomFromRevitBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->