### PR TITLE
Revit_Core_Engine: Handle secondary exception when pulling curved Revit walls

### DIFF
--- a/Revit_Core_Engine/Query/PanelSurfaces.cs
+++ b/Revit_Core_Engine/Query/PanelSurfaces.cs
@@ -194,6 +194,9 @@ namespace BH.Revit.Engine.Core
         private static Dictionary<PlanarSurface, List<PlanarSurface>> PanelSurfaces_LinkDocument(this HostObject hostObject, IEnumerable<ElementId> insertsToIgnore = null, RevitSettings settings = null)
         {
             List<Autodesk.Revit.DB.Face> faces = hostObject.ILinkPanelFaces(settings);
+            if (faces == null)
+                return null;
+
             List<PlanarFace> planarFaces = faces.Where(x => x is PlanarFace).Cast<PlanarFace>().ToList();
             if (faces.Count != planarFaces.Count)
                 BH.Engine.Base.Compute.RecordWarning($"Some faces of the link element were not planar and could not be retrieved.\n ElementId: {hostObject.Id} Document: {hostObject.Document.PathName}");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1210 

<!-- Add short description of what has been fixed -->
On pulling a curved Revit wall, the first error is recorded right but that doesn't block a second error message due to `faces` being null.

![image](https://user-images.githubusercontent.com/102604891/174267044-a1891f0b-b6a8-4699-bcee-91bdedb8d7c5.png)

![image](https://user-images.githubusercontent.com/102604891/174267205-5f779ac6-7eb9-41d0-87b7-d074a1110ec0.png)

### Test files
<!-- Link to test files to validate the proposed changes -->
[Revit file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/Revit_Toolkit/Pull/PullRepresentations.rvt?csf=1&web=1&e=5Bi3aQ)
[Gh file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/Revit_Toolkit/Pull/PullRepresentations.gh?csf=1&web=1&e=Bt0tJI)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Handle secondary exception when pulling curved Revit walls.