### PR TITLE
Scenario filtering empty parameter fix

### DIFF
--- a/Revit_Core_Engine/Query/Passes.cs
+++ b/Revit_Core_Engine/Query/Passes.cs
@@ -254,7 +254,7 @@ namespace BH.Revit.Engine.Core
                 return false;
 
 
-            double paramValue;
+            double paramValue = double.NaN;
             if (parameter.HasValue)
             {
                 if (parameter.StorageType == StorageType.Double)
@@ -269,10 +269,6 @@ namespace BH.Revit.Engine.Core
                 else
                     return false;
             }
-            else
-            {
-                paramValue = double.NaN;
-            }
 
             double comparisonValue = request.Value;
             double comparisonTolerance = request.Tolerance;
@@ -286,7 +282,7 @@ namespace BH.Revit.Engine.Core
             switch (request.NumberComparisonType)
             {
                 case NumberComparisonType.Equal:
-                    return Math.Abs(paramValue - comparisonValue) <= comparisonTolerance;
+                    return Math.Abs(paramValue - comparisonValue) <= comparisonTolerance || (double.IsNaN(paramValue) && double.IsNaN(comparisonValue));
                 case NumberComparisonType.Greater:
                     return paramValue - comparisonValue > comparisonTolerance;
                 case NumberComparisonType.GreaterOrEqual:


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1217 

<!-- Add short description of what has been fixed -->
Fixed `Passes` method to work with empty parameter values correctly.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Revit 2018 model](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BuroHappoldEngineering/BuroHappold_Revit_Toolkit/%23461-InsulationToolQA?csf=1&web=1&e=l586BA)

1. Open Insulation Tool setting window
2. Set filtering in scenario for any parameter as Not Equal or Not Contains (may be Comments)
3. Run apply method

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->