### PR TITLE
DoesIntersect method for checking the intersection between elements

### DIFF
--- a/Revit_Core_Engine/Convert/Revit/Internal/ToSolid.cs
+++ b/Revit_Core_Engine/Convert/Revit/Internal/ToSolid.cs
@@ -97,7 +97,7 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
 
         [Description("Converts Revit bounding box to a Revit Solid.")]
-        [Input("scopeBox", "Revit bounding box to be converted.")]
+        [Input("bbox", "Revit bounding box to be converted.")]
         [Input("settings", "Revit adapter settings to be used while performing the convert.")]
         [Output("solid", "Revit Solid resulting from converting the input Revit scope box.")]
         public static Solid ToSolid(this BoundingBoxXYZ bbox, RevitSettings settings = null)

--- a/Revit_Core_Engine/Convert/Revit/Internal/ToSolid.cs
+++ b/Revit_Core_Engine/Convert/Revit/Internal/ToSolid.cs
@@ -95,6 +95,40 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        [Description("Converts Revit bounding box to a Revit Solid.")]
+        [Input("scopeBox", "Revit bounding box to be converted.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Output("solid", "Revit Solid resulting from converting the input Revit scope box.")]
+        public static Solid ToSolid(this BoundingBoxXYZ bbox, RevitSettings settings = null)
+        {
+            XYZ pt0 = new XYZ(bbox.Min.X, bbox.Min.Y, bbox.Min.Z);
+            XYZ pt1 = new XYZ(bbox.Max.X, bbox.Min.Y, bbox.Min.Z);
+            XYZ pt2 = new XYZ(bbox.Max.X, bbox.Max.Y, bbox.Min.Z);
+            XYZ pt3 = new XYZ(bbox.Min.X, bbox.Max.Y, bbox.Min.Z);
+
+            Line edge0 = Line.CreateBound(pt0, pt1);
+            Line edge1 = Line.CreateBound(pt1, pt2);
+            Line edge2 = Line.CreateBound(pt2, pt3);
+            Line edge3 = Line.CreateBound(pt3, pt0);
+
+            List<Curve> edges = new List<Curve>();
+            edges.Add(edge0);
+            edges.Add(edge1);
+            edges.Add(edge2);
+            edges.Add(edge3);
+
+            double height = bbox.Max.Z - bbox.Min.Z;
+
+            CurveLoop baseLoop = CurveLoop.Create(edges);
+
+            List<CurveLoop> loopList = new List<CurveLoop>();
+            loopList.Add(baseLoop);
+
+            Solid solid = GeometryCreationUtilities.CreateExtrusionGeometry(loopList, XYZ.BasisZ, height);
+            return SolidUtils.CreateTransformed(solid, bbox.Transform);
+        }
+
     }
 }
 

--- a/Revit_Core_Engine/Query/Bounds.cs
+++ b/Revit_Core_Engine/Query/Bounds.cs
@@ -55,13 +55,11 @@ namespace BH.Revit.Engine.Core
 
             foreach (Solid solid in solids)
             {
-                BoundingBoxXYZ solidBBox = new BoundingBoxXYZ();
-
                 Solid newSolid = solid;
                 if (transform != null)
                     newSolid = SolidUtils.CreateTransformed(solid, transform);
 
-                solidBBox = newSolid.GetBoundingBox();
+                BoundingBoxXYZ solidBBox = newSolid.GetBoundingBox();
 
                 XYZ solidMin = solidBBox.Min;
                 XYZ solidMax = solidBBox.Max;

--- a/Revit_Core_Engine/Query/Bounds.cs
+++ b/Revit_Core_Engine/Query/Bounds.cs
@@ -57,15 +57,11 @@ namespace BH.Revit.Engine.Core
             {
                 BoundingBoxXYZ solidBBox = new BoundingBoxXYZ();
 
+                Solid newSolid = solid;
                 if (transform != null)
-                {
-                    Solid transSolid = SolidUtils.CreateTransformed(solid, transform);
-                    solidBBox = transSolid.GetBoundingBox();
-                }
-                else
-                {
-                    solidBBox = solid.GetBoundingBox();
-                }
+                    newSolid = SolidUtils.CreateTransformed(solid, transform);
+
+                solidBBox = newSolid.GetBoundingBox();
 
                 XYZ solidMin = solidBBox.Min;
                 XYZ solidMax = solidBBox.Max;

--- a/Revit_Core_Engine/Query/Bounds.cs
+++ b/Revit_Core_Engine/Query/Bounds.cs
@@ -55,7 +55,18 @@ namespace BH.Revit.Engine.Core
 
             foreach (Solid solid in solids)
             {
-                BoundingBoxXYZ solidBBox = solid.GetBoundingBox();
+                BoundingBoxXYZ solidBBox = new BoundingBoxXYZ();
+
+                if (transform != null)
+                {
+                    Solid transSolid = SolidUtils.CreateTransformed(solid, transform);
+                    solidBBox = transSolid.GetBoundingBox();
+                }
+                else
+                {
+                    solidBBox = solid.GetBoundingBox();
+                }
+
                 XYZ solidMin = solidBBox.Min;
                 XYZ solidMax = solidBBox.Max;
                 XYZ solidOrigin = solidBBox.Transform.Origin;
@@ -71,12 +82,6 @@ namespace BH.Revit.Engine.Core
             BoundingBoxXYZ unionBbox = new BoundingBoxXYZ();
             unionBbox.Min = new XYZ(minX, minY, minZ);
             unionBbox.Max = new XYZ(maxX, maxY, maxZ);
-
-            if (transform != null)
-            {
-                Solid union = SolidUtils.CreateTransformed(unionBbox.ToSolid(), transform);
-                unionBbox = union.GetBoundingBox();
-            }
 
             return unionBbox;
         }

--- a/Revit_Core_Engine/Query/Bounds.cs
+++ b/Revit_Core_Engine/Query/Bounds.cs
@@ -73,7 +73,10 @@ namespace BH.Revit.Engine.Core
             unionBbox.Max = new XYZ(maxX, maxY, maxZ);
 
             if (transform != null)
-                unionBbox.Transform = transform;
+            {
+                Solid union = SolidUtils.CreateTransformed(unionBbox.ToSolid(), transform);
+                unionBbox = union.GetBoundingBox();
+            }
 
             return unionBbox;
         }

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -1,0 +1,176 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using Autodesk.Revit.DB;
+using BH.oM.Base.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Check if two elements intersect.")]
+        [Input("element1", "First element to check the intersection for.")]
+        [Input("element2", "Second element to check the intersection for.")]
+        [Output("bool", "Result of the intersect checking.")]
+        public static bool DoesIntersect(this Element element1, Element element2)
+        {
+            if (element1 == null || element2 == null)
+            {
+                return false;
+            }
+
+            Document doc1 = element1.Document;
+            Document doc2 = element2.Document;
+
+            //host vs host
+            if (!doc1.IsLinked && !doc2.IsLinked)
+            {
+                BoundingBoxXYZ bbox1 = element1.PhysicalBounds();
+                BoundingBoxXYZ bbox2 = element2.PhysicalBounds();
+
+                if (!bbox1.IsInRange(bbox2))
+                    return false;
+
+                ElementIntersectsElementFilter intersectFilter = new ElementIntersectsElementFilter(element2);
+                return intersectFilter.PassesFilter(element1);
+            }
+            //host vs link
+            else if (!doc1.IsLinked && doc2.IsLinked)
+            {
+                BoundingBoxXYZ bbox1 = element1.PhysicalBounds();
+                Transform transform2 = doc2.LinkTransform();
+                BoundingBoxXYZ bbox2 = element2.get_Geometry(new Options()).GetTransformed(transform2).GetBoundingBox();
+
+                if (!bbox1.IsInRange(bbox2))
+                    return false;
+
+                List<Solid> element2Solids = element2.Solids(new Options());
+                foreach (Solid elSolid in element2Solids)
+                {
+                    Solid transformedSolid = SolidUtils.CreateTransformed(elSolid, transform2);
+                    ElementIntersectsSolidFilter intersectFilter = new ElementIntersectsSolidFilter(transformedSolid);
+                    if (intersectFilter.PassesFilter(element1))
+                        return true;
+                }
+            }
+            //link vs host
+            else if (doc1.IsLinked && !doc2.IsLinked)
+            {
+                BoundingBoxXYZ bbox2 = element2.PhysicalBounds();
+                Transform transform1 = doc1.LinkTransform();
+                BoundingBoxXYZ bbox1 = element1.get_Geometry(new Options()).GetTransformed(transform1).GetBoundingBox();
+
+                if (!bbox1.IsInRange(bbox2))
+                    return false;
+
+                List<Solid> element1Solids = element1.Solids(new Options());
+                foreach (Solid elSolid in element1Solids)
+                {
+                    Solid transformedSolid = SolidUtils.CreateTransformed(elSolid, transform1);
+                    ElementIntersectsSolidFilter intersectFilter = new ElementIntersectsSolidFilter(transformedSolid);
+                    if (intersectFilter.PassesFilter(element1))
+                        return true;
+                }
+            }
+            //link vs link
+            else if (doc1.IsLinked && doc2.IsLinked)
+            {
+                Transform transform1 = doc1.LinkTransform();
+                Transform transform2 = doc2.LinkTransform();
+                BoundingBoxXYZ bbox1 = element1.get_Geometry(new Options()).GetTransformed(transform1).GetBoundingBox();
+                BoundingBoxXYZ bbox2 = element2.get_Geometry(new Options()).GetTransformed(transform2).GetBoundingBox();
+
+                if (!bbox1.IsInRange(bbox2))
+                    return false;
+
+                List<Solid> element1Solids = element1.Solids(new Options());
+                List<Solid> element2Solids = element2.Solids(new Options());
+                List<Solid> el1TransSolids = element1Solids.Select(x => SolidUtils.CreateTransformed(x, transform1)).ToList();
+                List<Solid> el2TransSolids = element2Solids.Select(x => SolidUtils.CreateTransformed(x, transform2)).ToList();
+
+                foreach (Solid el1Solid in el1TransSolids)
+                {
+                    foreach (Solid el2Solid in el2TransSolids)
+                    {
+                        Solid intersection = BooleanOperationsUtils.ExecuteBooleanOperation(el1Solid, el2Solid, BooleanOperationsType.Intersect);
+                        if (intersection.Volume != 0)
+                            return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /***************************************************/
+
+        [Description("Check if bounding box intersects with element.")]
+        [Input("bbox", "Bounding box to check the intersection for.")]
+        [Input("element", "Element to check the intersection for.")]
+        [Output("bool", "Result of the intersect checking.")]
+        public static bool DoesIntersect(this BoundingBoxXYZ bbox, Element element)
+        {
+            if (bbox == null || element == null)
+            {
+                return false;
+            }
+
+            Document doc = element.Document;
+
+            Outline outline = new Outline(bbox.Min, bbox.Max);
+            BoundingBoxIntersectsFilter bboxIntersect = new BoundingBoxIntersectsFilter(outline);
+            BoundingBoxIsInsideFilter bboxInside = new BoundingBoxIsInsideFilter(outline);
+            LogicalOrFilter bboxFilter = new LogicalOrFilter(new List<ElementFilter> { bboxIntersect, bboxInside });
+
+            //host vs host
+            if (!doc.IsLinked)
+            {
+                return bboxFilter.PassesFilter(element);
+            }
+            //host vs link
+            else
+            {
+                Transform transform = doc.LinkTransform();
+                BoundingBoxXYZ elBbox = element.get_Geometry(new Options()).GetTransformed(transform).GetBoundingBox();
+
+                if (!bbox.IsInRange(elBbox))
+                    return false;
+
+                Solid bboxSolid = bbox.ToSolid();
+                Solid transformedBBoxSolid = SolidUtils.CreateTransformed(bboxSolid, transform.Inverse);
+                ElementIntersectsSolidFilter intersectFilter = new ElementIntersectsSolidFilter(transformedBBoxSolid);
+                return intersectFilter.PassesFilter(element);
+            }
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -399,6 +399,7 @@
     <Compile Include="Query\ConvertMethod.cs" />
     <Compile Include="Query\CoordinateSystem.cs" />
     <Compile Include="Compute\OpenWorksetsPrefilter.cs" />
+    <Compile Include="Query\DoesIntersect.cs" />
     <Compile Include="Query\ElementIds\ElementIdsOfEverything.cs" />
     <Compile Include="Query\Insulation.cs" />
     <Compile Include="Query\ViewBox.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1223 

<!-- Add short description of what has been fixed -->
- Added `Does Intersect` method for checking the intersection between elements.
- Method `Bounds` for getting the bounding box of the element has been changed.
- Extend `ToSolid` method for bounding box elements.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Revit 2018 models](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%231224-DoesIntersect?csf=1&web=1&e=eJhNxD)
- `MEP Model` as a Host
- `Arch Model` as a Link
- `LinkVsLink` to check intersection between linked elements

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->