### PR TITLE
Revit => BHoM panel convert performance improved plus minor facade panel convert bug fixed

### DIFF
--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -204,9 +204,10 @@ namespace BH.Revit.Adapter.Core
             }
 
             Dictionary<string, List<IBHoMObject>> refObjects = new Dictionary<string, List<IBHoMObject>>();
-            
+
             // Extract panel geometry prior to running the converts (this is an optimisation aimed to reduce the number of view regenerations)
-            document.CachePanelGeometry(elementIds, discipline, refObjects, settings);
+            if (!document.IsLinked)
+                document.CachePanelGeometry(elementIds, discipline, settings, refObjects);
             
             List<IBHoMObject> result = new List<IBHoMObject>();
             foreach (ElementId id in elementIds)

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -204,6 +204,10 @@ namespace BH.Revit.Adapter.Core
             }
 
             Dictionary<string, List<IBHoMObject>> refObjects = new Dictionary<string, List<IBHoMObject>>();
+            
+            // Extract panel geometry prior to running the converts (this is an optimisation aimed to reduce the number of view regenerations)
+            document.CachePanelGeometry(elementIds, discipline, refObjects, settings);
+            
             List<IBHoMObject> result = new List<IBHoMObject>();
             foreach (ElementId id in elementIds)
             {

--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -205,7 +205,7 @@ namespace BH.Revit.Adapter.Core
 
             Dictionary<string, List<IBHoMObject>> refObjects = new Dictionary<string, List<IBHoMObject>>();
 
-            // Extract panel geometry prior to running the converts (this is an optimisation aimed to reduce the number of view regenerations)
+            // Extract panel geometry of walls, floors, slabs and roofs prior to running the converts (this is an optimisation aimed to reduce the number of view regenerations)
             if (!document.IsLinked)
                 document.CachePanelGeometry(elementIds, discipline, settings, refObjects);
             

--- a/Revit_Core_Engine/Compute/CachePanelGeometry.cs
+++ b/Revit_Core_Engine/Compute/CachePanelGeometry.cs
@@ -1,0 +1,79 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.oM.Adapters.Revit.Enums;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Geometry;
+using BH.Revit.Engine.Core.Objects;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        //[Description("Queries the WorksetId of the active workset in a given Revit document.")]
+        //[Input("document", "Revit document to be queried for the active workset.")]
+        //[Output("worksetId", "WorksetId of the active workset in the input Revit document.")]
+        public static void CachePanelGeometry(this Document document, List<ElementId> elementIds, Discipline discipline, Dictionary<string, List<IBHoMObject>> refObjects, RevitSettings settings)
+        {
+            List<HostObject> hostObjectsToExtractSurfaces = new List<HostObject>();
+            foreach (ElementId id in elementIds)
+            {
+                HostObject hostObject = document.GetElement(id) as HostObject;
+                if (hostObject == null)
+                    continue;
+
+                bool outlinesFound = false;
+                if (discipline == Discipline.Structural)
+                {
+                    List<ICurve> outlines = hostObject.AnalyticalOutlines(settings);
+                    if (outlines != null && outlines.Count != 0)
+                    {
+                        outlinesFound = true;
+                        OutlineCache cache = new OutlineCache { Outlines = outlines };
+                        refObjects.Add(id.OutlineCacheKey(), new List<IBHoMObject> { cache });
+                    }
+                }
+
+                if (!outlinesFound)
+                    hostObjectsToExtractSurfaces.Add(hostObject);
+            }
+
+            var surfacesToCache = hostObjectsToExtractSurfaces.PanelSurfaces(discipline, settings);
+            foreach (HostObject hostObject in hostObjectsToExtractSurfaces)
+            {
+                SurfaceCache cache = new SurfaceCache { Surfaces = surfacesToCache[hostObject.Id] };
+                refObjects.Add(hostObject.Id.SurfaceCacheKey(), new List<IBHoMObject> { cache });
+            }
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Compute/CachePanelGeometry.cs
+++ b/Revit_Core_Engine/Compute/CachePanelGeometry.cs
@@ -38,10 +38,15 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        //[Description("Queries the WorksetId of the active workset in a given Revit document.")]
-        //[Input("document", "Revit document to be queried for the active workset.")]
-        //[Output("worksetId", "WorksetId of the active workset in the input Revit document.")]
-        public static void CachePanelGeometry(this Document document, List<ElementId> elementIds, Discipline discipline, Dictionary<string, List<IBHoMObject>> refObjects, RevitSettings settings)
+        [Description("Extracts the panel geometry from Revit walls, floors, roofs etc. and caches it in refObjects in order to use it in panel converts downstream." +
+                     "\nIt is an optimisation meant to minimise the number of document regenerations on panel converts, which often become the major time consumer.")]
+        [Input("document", "Revit document hosting the panel elements with locations to be cached.")]
+        [Input("elementIds", "Ids of the panel elements with locations to be cached.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
+        [Input("refObjects", "Collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once." +
+               "\nExtracted location surfaces are stored here.")]
+        public static void CachePanelGeometry(this Document document, List<ElementId> elementIds, Discipline discipline, RevitSettings settings, Dictionary<string, List<IBHoMObject>> refObjects)
         {
             List<HostObject> hostObjectsToExtractSurfaces = new List<HostObject>();
             foreach (ElementId id in elementIds)

--- a/Revit_Core_Engine/Convert/Architecture/FromRevit/Ceiling.cs
+++ b/Revit_Core_Engine/Convert/Architecture/FromRevit/Ceiling.cs
@@ -29,6 +29,7 @@ using BH.oM.Base.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using BH.Revit.Engine.Core.Objects;
 
 namespace BH.Revit.Engine.Core
 {
@@ -57,7 +58,13 @@ namespace BH.Revit.Engine.Core
             oM.Physical.Constructions.Construction construction = (ceiling.Document.GetElement(ceiling.GetTypeId()) as HostObjAttributes).ConstructionFromRevit(null, settings, refObjects);
 
             ISurface location = null;
-            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces = ceiling.PanelSurfaces(null, settings);
+            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces;
+            SurfaceCache cache = refObjects.GetValue<SurfaceCache>(ceiling.Id.SurfaceCacheKey());
+            if (cache != null)
+                surfaces = cache.Surfaces;
+            else
+                surfaces = ceiling.PanelSurfaces(null, settings);
+
             if (surfaces != null && surfaces.Count != 0)
             {
                 List<ISurface> locations = new List<ISurface>();

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Panel.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Panel.cs
@@ -32,6 +32,7 @@ using BH.oM.Base.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
 using BH.Engine.Base;
+using BH.Revit.Engine.Core.Objects;
 
 namespace BH.Revit.Engine.Core
 {
@@ -117,7 +118,13 @@ namespace BH.Revit.Engine.Core
             if (panels != null && panels.Count != 0)
                 return panels;
 
-            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces = ceiling.PanelSurfaces(ceiling.FindInserts(true, true, true, true), settings);
+            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces;
+            SurfaceCache cache = refObjects.GetValue<SurfaceCache>(ceiling.Id.SurfaceCacheKey());
+            if (cache != null)
+                surfaces = cache.Surfaces;
+            else
+                surfaces = ceiling.PanelSurfaces(ceiling.FindInserts(true, true, true, true), settings);
+
             if (surfaces == null)
                 return panels;
 
@@ -185,7 +192,13 @@ namespace BH.Revit.Engine.Core
             if (panels != null && panels.Count != 0)
                 return panels;
 
-            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces = floor.PanelSurfaces(floor.FindInserts(true, true, true, true), settings);
+            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces;
+            SurfaceCache cache = refObjects.GetValue<SurfaceCache>(floor.Id.SurfaceCacheKey());
+            if (cache != null)
+                surfaces = cache.Surfaces;
+            else
+                surfaces = floor.PanelSurfaces(floor.FindInserts(true, true, true, true), settings);
+
             if (surfaces == null)
                 return panels;
 
@@ -253,8 +266,14 @@ namespace BH.Revit.Engine.Core
             List<oM.Environment.Elements.Panel> panels = refObjects.GetValues<oM.Environment.Elements.Panel>(roofBase.Id);
             if (panels != null && panels.Count > 0)
                 return panels;
-
-            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces = roofBase.PanelSurfaces(roofBase.FindInserts(true, true, true, true), settings);
+            
+            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces;
+            SurfaceCache cache = refObjects.GetValue<SurfaceCache>(roofBase.Id.SurfaceCacheKey());
+            if (cache != null)
+                surfaces = cache.Surfaces;
+            else
+                surfaces = roofBase.PanelSurfaces(roofBase.FindInserts(true, true, true, true), settings);
+            
             if (surfaces == null)
                 return panels;
             
@@ -325,7 +344,13 @@ namespace BH.Revit.Engine.Core
             if (wall.StackedWallOwnerId != null && wall.StackedWallOwnerId != ElementId.InvalidElementId)
                 return null;
 
-            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces = wall.PanelSurfaces(wall.FindInserts(true, true, true, true), settings);
+            Dictionary<PlanarSurface, List<PlanarSurface>> surfaces;
+            SurfaceCache cache = refObjects.GetValue<SurfaceCache>(wall.Id.SurfaceCacheKey());
+            if (cache != null)
+                surfaces = cache.Surfaces;
+            else
+                surfaces = wall.PanelSurfaces(wall.FindInserts(true, true, true, true), settings);
+
             if (surfaces == null)
                 return panels;
 

--- a/Revit_Core_Engine/Convert/Environment/FromRevit/Panel.cs
+++ b/Revit_Core_Engine/Convert/Environment/FromRevit/Panel.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using BH.Engine.Base;
 using BH.Revit.Engine.Core.Objects;
+using BH.oM.Adapters.Revit.Enums;
 
 namespace BH.Revit.Engine.Core
 {
@@ -123,7 +124,7 @@ namespace BH.Revit.Engine.Core
             if (cache != null)
                 surfaces = cache.Surfaces;
             else
-                surfaces = ceiling.PanelSurfaces(ceiling.FindInserts(true, true, true, true), settings);
+                surfaces = ceiling.PanelSurfaces(ceiling.InsertsToIgnore(Discipline.Environmental), settings);
 
             if (surfaces == null)
                 return panels;
@@ -197,7 +198,7 @@ namespace BH.Revit.Engine.Core
             if (cache != null)
                 surfaces = cache.Surfaces;
             else
-                surfaces = floor.PanelSurfaces(floor.FindInserts(true, true, true, true), settings);
+                surfaces = floor.PanelSurfaces(floor.InsertsToIgnore(Discipline.Environmental), settings);
 
             if (surfaces == null)
                 return panels;
@@ -272,7 +273,7 @@ namespace BH.Revit.Engine.Core
             if (cache != null)
                 surfaces = cache.Surfaces;
             else
-                surfaces = roofBase.PanelSurfaces(roofBase.FindInserts(true, true, true, true), settings);
+                surfaces = roofBase.PanelSurfaces(roofBase.InsertsToIgnore(Discipline.Environmental), settings);
             
             if (surfaces == null)
                 return panels;
@@ -349,7 +350,7 @@ namespace BH.Revit.Engine.Core
             if (cache != null)
                 surfaces = cache.Surfaces;
             else
-                surfaces = wall.PanelSurfaces(wall.FindInserts(true, true, true, true), settings);
+                surfaces = wall.PanelSurfaces(wall.InsertsToIgnore(Discipline.Environmental), settings);
 
             if (surfaces == null)
                 return panels;

--- a/Revit_Core_Engine/Convert/Facade/FromRevit/Panel.cs
+++ b/Revit_Core_Engine/Convert/Facade/FromRevit/Panel.cs
@@ -31,6 +31,7 @@ using BH.oM.Base.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using BH.Revit.Engine.Core.Objects;
 
 namespace BH.Revit.Engine.Core
 {
@@ -79,20 +80,18 @@ namespace BH.Revit.Engine.Core
             BoundingBoxXYZ bbox = wall.get_BoundingBox(null);
             if (bbox != null)
             {
-                BoundingBoxIntersectsFilter bbif = new BoundingBoxIntersectsFilter(new Outline(bbox.Min, bbox.Max));
-                IList<ElementId> insertIds = (wall as HostObject).FindInserts(true, true, true, true);
-                List<Element> inserts;
-                if (insertIds.Count == 0)
-                    inserts = new List<Element>();
+                IList<ElementId> insertIds = wall.InsertsToIgnore(oM.Adapters.Revit.Enums.Discipline.Physical);
+
+                SurfaceCache cache = refObjects.GetValue<SurfaceCache>(wall.Id.SurfaceCacheKey());
+                if (cache != null)
+                    surfaces = cache.Surfaces;
                 else
-                    inserts = new FilteredElementCollector(wall.Document, insertIds).WherePasses(bbif).ToList();
+                    surfaces = wall.PanelSurfaces(insertIds, settings);
 
-                List<FamilyInstance> windows = inserts.Where(x => x is FamilyInstance && x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Windows).Cast<FamilyInstance>().ToList();
-                List<FamilyInstance> doors = inserts.Where(x => x is FamilyInstance && x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Doors).Cast<FamilyInstance>().ToList();
-
-                surfaces = wall.PanelSurfaces(windows.Union(doors).Select(x => x.Id), settings);
                 if (surfaces != null)
                 {
+                    List<FamilyInstance> inserts = insertIds.Select(x => wall.Document.GetElement(x)).Cast<FamilyInstance>().ToList();
+
                     List<ISurface> locations = new List<ISurface>(surfaces.Keys);
                     if (locations.Count == 1)
                         location = locations[0];
@@ -114,14 +113,14 @@ namespace BH.Revit.Engine.Core
                         }
                     }
 
-                    foreach (FamilyInstance window in windows)
+                    foreach (FamilyInstance window in inserts.Where(x => x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Windows))
                     {
                         BH.oM.Facade.Elements.Opening bHoMWindow = window.FacadeOpeningFromRevit(wall, settings, refObjects);
                         if (bHoMWindow != null)
                             openings.Add(bHoMWindow);
                     }
 
-                    foreach (FamilyInstance door in doors)
+                    foreach (FamilyInstance door in inserts.Where(x => x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Doors))
                     {
                         BH.oM.Facade.Elements.Opening bHoMDoor = door.FacadeOpeningFromRevit(wall, settings, refObjects);
                         if (bHoMDoor != null)

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Door.cs
@@ -45,7 +45,7 @@ namespace BH.Revit.Engine.Core
         [Output("door", "BH.oM.Physical.Elements.Door resulting from converting the input Revit FamilyInstance.")]
         public static Door DoorFromRevit(this FamilyInstance familyInstance, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
-            return familyInstance.DoorFromRevit(null, settings, refObjects);
+            return familyInstance.DoorFromRevit(null as HostObject, settings, refObjects);
         }
 
         /***************************************************/
@@ -94,7 +94,32 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        [Description("Converts a Revit FamilyInstance to BH.oM.Physical.Elements.Door using the provided location.")]
+        [Input("familyInstance", "Revit FamilyInstance to be converted.")]
+        [Input("location", "Location to be applied to the returned object (the location is not queried from the object itself.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("door", "BH.oM.Physical.Elements.Door resulting from converting the input Revit FamilyInstance and applying the provided location.")]
+        public static Door DoorFromRevit(this FamilyInstance familyInstance, BH.oM.Geometry.ISurface location = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            if (familyInstance == null || location == null)
+                return null;
+
+            settings = settings.DefaultIfNull();
+
+            Door door = new Door { Location = location, Name = familyInstance.FamilyTypeFullName() };
+            FamilySymbol familySymbol = familyInstance.Document.GetElement(familyInstance.GetTypeId()) as FamilySymbol;
+            door.Construction = familySymbol?.ConstructionFromRevit(settings, refObjects);
+
+            //Set identifiers, parameters & custom data
+            door.SetIdentifiers(familyInstance);
+            door.CopyParameters(familyInstance, settings.MappingSettings);
+            door.SetProperties(familyInstance, settings.MappingSettings);
+
+            return door;
+        }
+
+        /***************************************************/
     }
 }
-
-

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Roof.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Roof.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using BH.Revit.Engine.Core.Objects;
 
 namespace BH.Revit.Engine.Core
 {
@@ -99,20 +100,18 @@ namespace BH.Revit.Engine.Core
             BoundingBoxXYZ bbox = roof.get_BoundingBox(null);
             if (bbox != null)
             {
-                BoundingBoxIntersectsFilter bbif = new BoundingBoxIntersectsFilter(new Outline(bbox.Min, bbox.Max));
-                IList<ElementId> insertIds = (roof as HostObject).FindInserts(true, true, true, true);
-                List<Element> inserts;
-                if (insertIds.Count == 0)
-                    inserts = new List<Element>();
+                IList<ElementId> insertIds = roof.InsertsToIgnore(oM.Adapters.Revit.Enums.Discipline.Physical);
+
+                SurfaceCache cache = refObjects.GetValue<SurfaceCache>(roof.Id.SurfaceCacheKey());
+                if (cache != null)
+                    surfaces = cache.Surfaces;
                 else
-                    inserts = new FilteredElementCollector(roof.Document, insertIds).WherePasses(bbif).ToList();
+                    surfaces = roof.PanelSurfaces(insertIds, settings);
 
-                List<FamilyInstance> windows = inserts.Where(x => x is FamilyInstance && x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Windows).Cast<FamilyInstance>().ToList();
-                List<FamilyInstance> doors = inserts.Where(x => x is FamilyInstance && x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Doors).Cast<FamilyInstance>().ToList();
-
-                surfaces = roof.PanelSurfaces(windows.Union(doors).Select(x => x.Id), settings);
                 if (surfaces != null)
                 {
+                    List<FamilyInstance> inserts = insertIds.Select(x => roof.Document.GetElement(x)).Cast<FamilyInstance>().ToList();
+
                     List<ISurface> locations = new List<ISurface>(surfaces.Keys);
                     if (locations.Count == 1)
                         location = locations[0];
@@ -124,14 +123,14 @@ namespace BH.Revit.Engine.Core
                         openings.AddRange(ps.Select(x => new BH.oM.Physical.Elements.Void { Location = x }));
                     }
 
-                    foreach (FamilyInstance window in windows)
+                    foreach (FamilyInstance window in inserts.Where(x => x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Windows))
                     {
                         BH.oM.Physical.Elements.Window bHoMWindow = window.WindowFromRevit(roof, settings, refObjects);
                         if (bHoMWindow != null)
                             openings.Add(bHoMWindow);
                     }
 
-                    foreach (FamilyInstance door in doors)
+                    foreach (FamilyInstance door in inserts.Where(x => x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Doors))
                     {
                         BH.oM.Physical.Elements.Door bHoMDoor = door.DoorFromRevit(roof, settings, refObjects);
                         if (bHoMDoor != null)

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Wall.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Wall.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using BH.Revit.Engine.Core.Objects;
 
 namespace BH.Revit.Engine.Core
 {
@@ -101,20 +102,18 @@ namespace BH.Revit.Engine.Core
             BoundingBoxXYZ bbox = wall.get_BoundingBox(null);
             if (bbox != null)
             {
-                BoundingBoxIntersectsFilter bbif = new BoundingBoxIntersectsFilter(new Outline(bbox.Min, bbox.Max));
-                IList<ElementId> insertIds = (wall as HostObject).FindInserts(true, true, true, true);
-                List<Element> inserts;
-                if (insertIds.Count == 0)
-                    inserts = new List<Element>();
+                IList<ElementId> insertIds = wall.InsertsToIgnore(oM.Adapters.Revit.Enums.Discipline.Physical);
+
+                SurfaceCache cache = refObjects.GetValue<SurfaceCache>(wall.Id.SurfaceCacheKey());
+                if (cache != null)
+                    surfaces = cache.Surfaces;
                 else
-                    inserts = new FilteredElementCollector(wall.Document, insertIds).WherePasses(bbif).ToList();
+                    surfaces = wall.PanelSurfaces(insertIds, settings);
 
-                List<FamilyInstance> windows = inserts.Where(x => x is FamilyInstance && x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Windows).Cast<FamilyInstance>().ToList();
-                List<FamilyInstance> doors = inserts.Where(x => x is FamilyInstance && x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Doors).Cast<FamilyInstance>().ToList();
-
-                surfaces = wall.PanelSurfaces(windows.Union(doors).Select(x => x.Id), settings);
                 if (surfaces != null)
                 {
+                    List<FamilyInstance> inserts = insertIds.Select(x => wall.Document.GetElement(x)).Cast<FamilyInstance>().ToList();
+
                     List<ISurface> locations = new List<ISurface>(surfaces.Keys);
                     if (locations.Count == 1)
                         location = locations[0];
@@ -126,14 +125,14 @@ namespace BH.Revit.Engine.Core
                         openings.AddRange(ps.Select(x => new BH.oM.Physical.Elements.Void { Location = x }));
                     }
 
-                    foreach (FamilyInstance window in windows)
+                    foreach (FamilyInstance window in inserts.Where(x => x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Windows))
                     {
                         BH.oM.Physical.Elements.Window bHoMWindow = window.WindowFromRevit(wall, settings, refObjects);
                         if (bHoMWindow != null)
                             openings.Add(bHoMWindow);
                     }
 
-                    foreach (FamilyInstance door in doors)
+                    foreach (FamilyInstance door in inserts.Where(x => x.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Doors))
                     {
                         BH.oM.Physical.Elements.Door bHoMDoor = door.DoorFromRevit(wall, settings, refObjects);
                         if (bHoMDoor != null)

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Window.cs
@@ -45,7 +45,7 @@ namespace BH.Revit.Engine.Core
         [Output("window", "BH.oM.Physical.Elements.Window resulting from converting the input Revit FamilyInstance.")]
         public static Window WindowFromRevit(this FamilyInstance familyInstance, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
-            return familyInstance.WindowFromRevit(null, settings, refObjects);
+            return familyInstance.WindowFromRevit(null as HostObject, settings, refObjects);
         }
 
         /***************************************************/
@@ -94,7 +94,32 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        [Description("Converts a Revit FamilyInstance to BH.oM.Physical.Elements.Window using the provided location.")]
+        [Input("familyInstance", "Revit FamilyInstance to be converted.")]
+        [Input("location", "Location to be applied to the returned object (the location is not queried from the object itself.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("window", "BH.oM.Physical.Elements.Window resulting from converting the input Revit FamilyInstance and applying the provided location.")]
+        public static Window WindowFromRevit(this FamilyInstance familyInstance, BH.oM.Geometry.ISurface location = null, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            if (familyInstance == null || location == null)
+                return null;
+
+            settings = settings.DefaultIfNull();
+
+            Window window = new Window { Location = location, Name = familyInstance.FamilyTypeFullName() };
+            FamilySymbol familySymbol = familyInstance.Document.GetElement(familyInstance.GetTypeId()) as FamilySymbol;
+            window.Construction = familySymbol?.ConstructionFromRevit(settings, refObjects);
+
+            //Set identifiers, parameters & custom data
+            window.SetIdentifiers(familyInstance);
+            window.CopyParameters(familyInstance, settings.MappingSettings);
+            window.SetProperties(familyInstance, settings.MappingSettings);
+
+            return window;
+        }
+
+        /***************************************************/
     }
 }
-
-

--- a/Revit_Core_Engine/Objects/OutlineCache.cs
+++ b/Revit_Core_Engine/Objects/OutlineCache.cs
@@ -1,0 +1,15 @@
+﻿using BH.oM.Base;
+using BH.oM.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Revit.Engine.Core.Objects
+{
+    internal class OutlineCache : BHoMObject
+    {
+        internal List<ICurve> Outlines { get; set; } = null;
+    }
+}

--- a/Revit_Core_Engine/Objects/OutlineCache.cs
+++ b/Revit_Core_Engine/Objects/OutlineCache.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core.Objects
 {
-    [Description("Cache object to store the outlines of structural panels for convert purposes.")]
+    [Description("Cache object to store the outlines of structural panels for conversion purposes.")]
     internal class OutlineCache : BHoMObject
     {
         /***************************************************/

--- a/Revit_Core_Engine/Objects/OutlineCache.cs
+++ b/Revit_Core_Engine/Objects/OutlineCache.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using BH.oM.Geometry;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Revit_Core_Engine/Objects/OutlineCache.cs
+++ b/Revit_Core_Engine/Objects/OutlineCache.cs
@@ -1,15 +1,20 @@
 ﻿using BH.oM.Base;
 using BH.oM.Geometry;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core.Objects
 {
+    [Description("Cache object to store the outlines of structural panels for convert purposes.")]
     internal class OutlineCache : BHoMObject
     {
+        /***************************************************/
+        /****                 Properties                ****/
+        /***************************************************/
+
+        [Description("Outlines of structural panels to be used in converts.")]
         internal List<ICurve> Outlines { get; set; } = null;
+
+        /***************************************************/
     }
 }

--- a/Revit_Core_Engine/Objects/SurfaceCache.cs
+++ b/Revit_Core_Engine/Objects/SurfaceCache.cs
@@ -12,7 +12,7 @@ namespace BH.Revit.Engine.Core.Objects
         /****                 Properties                ****/
         /***************************************************/
 
-        [Description("Surface locations of panels to be used in converts.")]
+        [Description("Surface locations of panels and their openings to be used in converts. Key is the location surface of a panel, value is the list of opening locations.")]
         internal Dictionary<PlanarSurface, List<PlanarSurface>> Surfaces { get; set; } = null;
 
         /***************************************************/

--- a/Revit_Core_Engine/Objects/SurfaceCache.cs
+++ b/Revit_Core_Engine/Objects/SurfaceCache.cs
@@ -1,15 +1,20 @@
 ﻿using BH.oM.Base;
 using BH.oM.Geometry;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core.Objects
 {
+    [Description("Cache object to store the surface locations of panels for convert purposes.")]
     internal class SurfaceCache : BHoMObject
     {
+        /***************************************************/
+        /****                 Properties                ****/
+        /***************************************************/
+
+        [Description("Surface locations of panels to be used in converts.")]
         internal Dictionary<PlanarSurface, List<PlanarSurface>> Surfaces { get; set; } = null;
+
+        /***************************************************/
     }
 }

--- a/Revit_Core_Engine/Objects/SurfaceCache.cs
+++ b/Revit_Core_Engine/Objects/SurfaceCache.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using BH.oM.Geometry;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Revit_Core_Engine/Objects/SurfaceCache.cs
+++ b/Revit_Core_Engine/Objects/SurfaceCache.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core.Objects
 {
-    [Description("Cache object to store the surface locations of panels for convert purposes.")]
+    [Description("Cache object to store the surface locations of panels for conversion purposes.")]
     internal class SurfaceCache : BHoMObject
     {
         /***************************************************/

--- a/Revit_Core_Engine/Objects/SurfaceCache.cs
+++ b/Revit_Core_Engine/Objects/SurfaceCache.cs
@@ -1,0 +1,15 @@
+﻿using BH.oM.Base;
+using BH.oM.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Revit.Engine.Core.Objects
+{
+    internal class SurfaceCache : BHoMObject
+    {
+        internal Dictionary<PlanarSurface, List<PlanarSurface>> Surfaces { get; set; } = null;
+    }
+}

--- a/Revit_Core_Engine/Query/CurtainPanels.cs
+++ b/Revit_Core_Engine/Query/CurtainPanels.cs
@@ -59,15 +59,22 @@ namespace BH.Revit.Engine.Core
             for (int i = 0; i < panels.Count; i++)
             {
                 FamilyInstance panel = panels[i] as FamilyInstance;
-                if (panel == null || panel.get_BoundingBox(null) == null)
+                if (panel == null)
                     continue;
+
+                if (panel.get_BoundingBox(null) == null)
+                {
+                    ElementId hostPanelId = (panel as Panel)?.FindHostPanel();
+                    if (hostPanelId == null || document.GetElement(hostPanelId)?.get_BoundingBox(null) == null)
+                        continue;
+                }
 
                 foreach (PolyCurve pc in cells[i].CurveLoops.FromRevit())
                 {
                     if (panel.Category.Id.IntegerValue == (int)Autodesk.Revit.DB.BuiltInCategory.OST_Doors)
-                        result.Add(panel.DoorFromRevit(settings, refObjects));
+                        result.Add(panel.DoorFromRevit(BH.Engine.Geometry.Create.PlanarSurface(pc), settings, refObjects));
                     else
-                        result.Add(panel.WindowFromRevit(settings, refObjects));
+                        result.Add(panel.WindowFromRevit(BH.Engine.Geometry.Create.PlanarSurface(pc), settings, refObjects));
                 }
             }
             

--- a/Revit_Core_Engine/Query/InsertsToIgnore.cs
+++ b/Revit_Core_Engine/Query/InsertsToIgnore.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.oM.Adapters.Revit.Enums;
+using BH.oM.Base.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        //[Description("Returns the workset Ids of all worksets in a given Revit document.")]
+        //[Input("document", "Revit document to be queried for worksets.")]
+        //[Output("ids", "Workset Ids of all worksets in the input Revit document.")]
+        public static IList<ElementId> InsertsToIgnore(this HostObject hostObject, Discipline discipline)
+        {
+            switch (discipline)
+            {
+                case Discipline.Environmental:
+                    return hostObject.FindInserts(true, true, true, true);
+                case Discipline.Structural:
+                    return null;
+                case Discipline.Facade:
+                case Discipline.Physical:
+                case Discipline.Architecture:
+                    {
+                        if (hostObject is Ceiling || hostObject.CurtainGrids().Count != 0)
+                            return null;
+
+                        BoundingBoxXYZ bbox = hostObject.get_BoundingBox(null);
+                        if (bbox == null)
+                            return null;
+
+                        IList<ElementId> insertIds = hostObject.FindInserts(true, true, true, true);
+                        List<Element> inserts = new List<Element>();
+                        if (insertIds.Count != 0)
+                        {
+                            BoundingBoxIntersectsFilter bbif = new BoundingBoxIntersectsFilter(new Outline(bbox.Min, bbox.Max));
+                            inserts = new FilteredElementCollector(hostObject.Document, insertIds).WherePasses(bbif).ToList();
+                        }
+
+                        return inserts.Where(x => x is FamilyInstance && (x.Category.Id.IntegerValue == (int)Autodesk.Revit.DB.BuiltInCategory.OST_Windows || x.Category.Id.IntegerValue == (int)Autodesk.Revit.DB.BuiltInCategory.OST_Windows)).Select(x => x.Id).ToList();
+                    }
+            }
+
+            return null;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Query/InsertsToIgnore.cs
+++ b/Revit_Core_Engine/Query/InsertsToIgnore.cs
@@ -66,7 +66,7 @@ namespace BH.Revit.Engine.Core
                             inserts = new FilteredElementCollector(hostObject.Document, insertIds).WherePasses(bbif).ToList();
                         }
 
-                        return inserts.Where(x => x is FamilyInstance && (x.Category.Id.IntegerValue == (int)Autodesk.Revit.DB.BuiltInCategory.OST_Windows || x.Category.Id.IntegerValue == (int)Autodesk.Revit.DB.BuiltInCategory.OST_Windows)).Select(x => x.Id).ToList();
+                        return inserts.Where(x => x is FamilyInstance && (x.Category.Id.IntegerValue == (int)Autodesk.Revit.DB.BuiltInCategory.OST_Windows || x.Category.Id.IntegerValue == (int)Autodesk.Revit.DB.BuiltInCategory.OST_Doors)).Select(x => x.Id).ToList();
                     }
             }
 

--- a/Revit_Core_Engine/Query/InsertsToIgnore.cs
+++ b/Revit_Core_Engine/Query/InsertsToIgnore.cs
@@ -35,9 +35,10 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        //[Description("Returns the workset Ids of all worksets in a given Revit document.")]
-        //[Input("document", "Revit document to be queried for worksets.")]
-        //[Output("ids", "Workset Ids of all worksets in the input Revit document.")]
+        [Description("Returns ElementIds of insert objects to be ignored in convert of a Revit panel element to given engineering discipline.")]
+        [Input("hostObject", "Revit HostObject (panel element) to find the inserts that should be ignored on convert.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Output("ids", "ElementIds of insert objects to be ignored in convert of a Revit panel element to the input engineering discipline.")]
         public static IList<ElementId> InsertsToIgnore(this HostObject hostObject, Discipline discipline)
         {
             switch (discipline)

--- a/Revit_Core_Engine/Query/IsSimilar.cs
+++ b/Revit_Core_Engine/Query/IsSimilar.cs
@@ -67,5 +67,28 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        [Description("Checks whether two Revit planes are similar within the tolerance specified in the settings.")]
+        [Input("plane1", "First Revit plane to compare.")]
+        [Input("plane2", "Second Revit plane to compare.")]
+        [Input("settings", "Revit adapter settings to be used while performing the comparison.")]
+        [Input("flippedIsEqual", "If true, flipped planes will be considered as similar, otherwise not.")]
+        [Output("similar", "True if the input Revit planes are similar within the tolerance, otherwise false.")]
+        public static bool IsSimilar(this Plane plane1, Plane plane2, RevitSettings settings, bool flippedIsEqual = false)
+        {
+            double dotProduct = plane1.Normal.DotProduct(plane2.Normal);
+            if (flippedIsEqual)
+                dotProduct = Math.Abs(dotProduct);
+
+            if (1 - dotProduct <= settings.AngleTolerance)
+                return true;
+
+            UV uv;
+            double distance;
+            plane1.Project(plane2.Origin, out uv, out distance);
+            return distance <= settings.DistanceTolerance;
+        }
+
+        /***************************************************/
     }
 }

--- a/Revit_Core_Engine/Query/OpeningSurface.cs
+++ b/Revit_Core_Engine/Query/OpeningSurface.cs
@@ -272,7 +272,7 @@ namespace BH.Revit.Engine.Core
                 {
                     HostObject h = hosts[i];
 
-                    List<Autodesk.Revit.DB.Plane> planes = h.IPanelPlanes();
+                    List<Autodesk.Revit.DB.Plane> planes = h.IPanelPlanes(settings);
                     if (planes.Count == 0)
                         continue;
 

--- a/Revit_Core_Engine/Query/OutlineCacheKey.cs
+++ b/Revit_Core_Engine/Query/OutlineCacheKey.cs
@@ -21,12 +21,7 @@
  */
 
 using Autodesk.Revit.DB;
-using BH.oM.Adapters.Revit.Enums;
-using BH.oM.Adapters.Revit.Settings;
-using BH.oM.Base;
 using BH.oM.Base.Attributes;
-using BH.oM.Geometry;
-using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core
@@ -37,9 +32,9 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        //[Description("Queries the WorksetId of the active workset in a given Revit document.")]
-        //[Input("document", "Revit document to be queried for the active workset.")]
-        //[Output("worksetId", "WorksetId of the active workset in the input Revit document.")]
+        [Description("Returns the refObjects key, under which the outlines of a given Revit structural panel element are stored.")]
+        [Input("elementId", "ElementId of the Revit structural panel for which the refObjects key is queried.")]
+        [Output("key", "RefObjects key, under which the outlines of the input Revit structural panel element are stored.")]
         public static string OutlineCacheKey(this ElementId elementId)
         {
             return $"AnalyticalOutlines_{elementId.IntegerValue}";

--- a/Revit_Core_Engine/Query/OutlineCacheKey.cs
+++ b/Revit_Core_Engine/Query/OutlineCacheKey.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.oM.Adapters.Revit.Enums;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Geometry;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        //[Description("Queries the WorksetId of the active workset in a given Revit document.")]
+        //[Input("document", "Revit document to be queried for the active workset.")]
+        //[Output("worksetId", "WorksetId of the active workset in the input Revit document.")]
+        public static string OutlineCacheKey(this ElementId elementId)
+        {
+            return $"AnalyticalOutlines_{elementId.IntegerValue}";
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Query/PanelPlanes.cs
+++ b/Revit_Core_Engine/Query/PanelPlanes.cs
@@ -21,10 +21,13 @@
  */
 
 using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base.Attributes;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace BH.Revit.Engine.Core
 {
@@ -36,8 +39,9 @@ namespace BH.Revit.Engine.Core
 
         [Description("Extracts the BHoM-representative (centre, top or bottom, depending on element category) planes from a given Revit host object.")]
         [Input("hostObject", "Revit host object to extract the BHoM-representative planes from.")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
         [Output("planes", "BHoM-representative planes extracted from the input Revit host object.")]
-        public static List<Plane> IPanelPlanes(this HostObject hostObject)
+        public static List<Plane> IPanelPlanes(this HostObject hostObject, RevitSettings settings)
         {
             return PanelPlanes(hostObject as dynamic);
         }
@@ -49,8 +53,9 @@ namespace BH.Revit.Engine.Core
 
         [Description("Extracts the BHoM-representative (centre) planes from a given Revit wall.")]
         [Input("wall", "Revit wall to extract the BHoM-representative planes from.")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
         [Output("planes", "BHoM-representative planes extracted from the input Revit wall.")]
-        public static List<Plane> PanelPlanes(this Wall wall)
+        public static List<Plane> PanelPlanes(this Wall wall, RevitSettings settings)
         {
             Line line = (wall.Location as LocationCurve)?.Curve as Line;
             if (line == null)
@@ -63,16 +68,23 @@ namespace BH.Revit.Engine.Core
 
         [Description("Extracts the BHoM-representative (top) planes from a given Revit floor.")]
         [Input("floor", "Revit floor to extract the BHoM-representative planes from.")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
         [Output("planes", "BHoM-representative planes extracted from the input Revit floor.")]
-        public static List<Plane> PanelPlanes(this Floor floor)
+        public static List<Plane> PanelPlanes(this Floor floor, RevitSettings settings)
         {
-            //TODO: leave unique only!!
+            settings = settings.DefaultIfNull();
+
             List<Plane> result = new List<Plane>();
             foreach (Reference reference in HostObjectUtils.GetTopFaces(floor))
             {
+
                 PlanarFace pf = floor.GetGeometryObjectFromReference(reference) as PlanarFace;
                 if (pf != null)
-                    result.Add(Plane.CreateByNormalAndOrigin(pf.FaceNormal, pf.Origin));
+                {
+                    Plane plane = Plane.CreateByNormalAndOrigin(pf.FaceNormal, pf.Origin);
+                    if (result.All(x => !x.IsSimilar(plane, settings, true)))
+                        result.Add(plane);
+                }
             }
 
             return result;
@@ -82,16 +94,22 @@ namespace BH.Revit.Engine.Core
 
         [Description("Extracts the BHoM-representative (top) planes from a given Revit roof.")]
         [Input("roof", "Revit floor to extract the BHoM-representative planes from.")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
         [Output("planes", "BHoM-representative planes extracted from the input Revit roof.")]
-        public static List<Plane> PanelPlanes(this RoofBase roof)
+        public static List<Plane> PanelPlanes(this RoofBase roof, RevitSettings settings)
         {
-            //TODO: leave unique only!!
+            settings = settings.DefaultIfNull();
+
             List<Plane> result = new List<Plane>();
             foreach (Reference reference in HostObjectUtils.GetTopFaces(roof))
             {
                 PlanarFace pf = roof.GetGeometryObjectFromReference(reference) as PlanarFace;
                 if (pf != null)
-                    result.Add(Plane.CreateByNormalAndOrigin(pf.FaceNormal, pf.Origin));
+                {
+                    Plane plane = Plane.CreateByNormalAndOrigin(pf.FaceNormal, pf.Origin);
+                    if (result.All(x => !x.IsSimilar(plane, settings, true)))
+                        result.Add(plane);
+                }
             }
 
             return result;
@@ -101,16 +119,22 @@ namespace BH.Revit.Engine.Core
 
         [Description("Extracts the BHoM-representative (bottom) planes from a given Revit ceiling.")]
         [Input("ceiling", "Revit ceiling to extract the BHoM-representative planes from.")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
         [Output("planes", "BHoM-representative planes extracted from the input Revit ceiling.")]
-        public static List<Plane> PanelPlanes(this Ceiling ceiling)
+        public static List<Plane> PanelPlanes(this Ceiling ceiling, RevitSettings settings)
         {
-            //TODO: leave unique only!!
+            settings = settings.DefaultIfNull();
+
             List<Plane> result = new List<Plane>();
             foreach (Reference reference in HostObjectUtils.GetBottomFaces(ceiling))
             {
                 PlanarFace pf = ceiling.GetGeometryObjectFromReference(reference) as PlanarFace;
                 if (pf != null)
-                    result.Add(Plane.CreateByNormalAndOrigin(pf.FaceNormal, pf.Origin));
+                {
+                    Plane plane = Plane.CreateByNormalAndOrigin(pf.FaceNormal, pf.Origin);
+                    if (result.All(x => !x.IsSimilar(plane, settings, true)))
+                        result.Add(plane);
+                }
             }
 
             return result;

--- a/Revit_Core_Engine/Query/PanelPlanes.cs
+++ b/Revit_Core_Engine/Query/PanelPlanes.cs
@@ -43,7 +43,7 @@ namespace BH.Revit.Engine.Core
         [Output("planes", "BHoM-representative planes extracted from the input Revit host object.")]
         public static List<Plane> IPanelPlanes(this HostObject hostObject, RevitSettings settings)
         {
-            return PanelPlanes(hostObject as dynamic);
+            return PanelPlanes(hostObject as dynamic, settings);
         }
 
 
@@ -145,7 +145,7 @@ namespace BH.Revit.Engine.Core
         /****             Fallback methods              ****/
         /***************************************************/
 
-        private static List<Plane> PanelPlanes(this HostObject hostObject)
+        private static List<Plane> PanelPlanes(this HostObject hostObject, RevitSettings settings)
         {
             BH.Engine.Base.Compute.RecordError(String.Format("Querying panel locations for Revit elements of type {0} is currently not supported.", hostObject.GetType().Name));
             return new List<Plane>();

--- a/Revit_Core_Engine/Query/PanelPlanes.cs
+++ b/Revit_Core_Engine/Query/PanelPlanes.cs
@@ -66,6 +66,7 @@ namespace BH.Revit.Engine.Core
         [Output("planes", "BHoM-representative planes extracted from the input Revit floor.")]
         public static List<Plane> PanelPlanes(this Floor floor)
         {
+            //TODO: leave unique only!!
             List<Plane> result = new List<Plane>();
             foreach (Reference reference in HostObjectUtils.GetTopFaces(floor))
             {
@@ -84,6 +85,7 @@ namespace BH.Revit.Engine.Core
         [Output("planes", "BHoM-representative planes extracted from the input Revit roof.")]
         public static List<Plane> PanelPlanes(this RoofBase roof)
         {
+            //TODO: leave unique only!!
             List<Plane> result = new List<Plane>();
             foreach (Reference reference in HostObjectUtils.GetTopFaces(roof))
             {
@@ -102,6 +104,7 @@ namespace BH.Revit.Engine.Core
         [Output("planes", "BHoM-representative planes extracted from the input Revit ceiling.")]
         public static List<Plane> PanelPlanes(this Ceiling ceiling)
         {
+            //TODO: leave unique only!!
             List<Plane> result = new List<Plane>();
             foreach (Reference reference in HostObjectUtils.GetBottomFaces(ceiling))
             {

--- a/Revit_Core_Engine/Query/PanelSurfaces.cs
+++ b/Revit_Core_Engine/Query/PanelSurfaces.cs
@@ -51,6 +51,8 @@ namespace BH.Revit.Engine.Core
             settings = settings.DefaultIfNull();
 
             var result = new Dictionary<ElementId, Dictionary<PlanarSurface, List<PlanarSurface>>>();
+            List<Document> inputDocs = hostObjects.Select(x => x.Document).ToList();
+            List<ElementId> inputIds = hostObjects.Select(x => x.Id).ToList();
 
             List<HostObject> linked = hostObjects.Where(x => x.Document.IsLinked).ToList();
             List<HostObject> curtains = hostObjects.Where(x => !x.Document.IsLinked && x.ICurtainGrids().Count != 0).ToList();
@@ -86,6 +88,12 @@ namespace BH.Revit.Engine.Core
                 {
                     result.Add(kvp.Key, kvp.Value);
                 }
+            }
+
+            // Recreate the input collection because some objects could have been invalidated due to the processing done in the temp transaction
+            for (int i = 0; i < hostObjects.Count; i++)
+            {
+                hostObjects[i] = inputDocs[i].GetElement(inputIds[i]) as HostObject;
             }
 
             return result;

--- a/Revit_Core_Engine/Query/PanelSurfaces.cs
+++ b/Revit_Core_Engine/Query/PanelSurfaces.cs
@@ -128,7 +128,7 @@ namespace BH.Revit.Engine.Core
             foreach ((ElementId, IEnumerable<ElementId>) tuple in hostsWithInsertsToIgnore)
             {
                 ElementId id = tuple.Item1;
-                List<Autodesk.Revit.DB.Plane> hostPlanes = (doc.GetElement(id) as HostObject)?.IPanelPlanes();
+                List<Autodesk.Revit.DB.Plane> hostPlanes = (doc.GetElement(id) as HostObject)?.IPanelPlanes(settings);
                 if (hostPlanes == null || hostPlanes.Count == 0)
                     result.Add(id, null);
                 else

--- a/Revit_Core_Engine/Query/PanelSurfaces.cs
+++ b/Revit_Core_Engine/Query/PanelSurfaces.cs
@@ -40,7 +40,7 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Extracts the BHoM-representative location surfaces from a given collection Revit host objects." +
+        [Description("Extracts the BHoM-representative location surfaces from a given collection of Revit host objects." +
                      "\nOptimised to regenerate the document only twice for all input elements, not twice per each.")]
         [Input("hostObjects", "Revit host objects to extract the location surfaces from.")]
         [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
@@ -50,13 +50,13 @@ namespace BH.Revit.Engine.Core
         {
             settings = settings.DefaultIfNull();
 
-            Dictionary<ElementId, Dictionary<PlanarSurface, List<PlanarSurface>>> result = new Dictionary<ElementId, Dictionary<PlanarSurface, List<PlanarSurface>>>();
+            var result = new Dictionary<ElementId, Dictionary<PlanarSurface, List<PlanarSurface>>>();
 
             List<HostObject> linked = hostObjects.Where(x => x.Document.IsLinked).ToList();
             List<HostObject> curtains = hostObjects.Where(x => !x.Document.IsLinked && x.ICurtainGrids().Count != 0).ToList();
             List<HostObject> solids = hostObjects.Except(linked.Union(curtains)).ToList();
 
-            // First process linked elements
+            // Process linked elements first
             foreach (HostObject hostObject in linked)
             {
                 if (hostObject.ICurtainGrids().Count != 0)
@@ -120,11 +120,11 @@ namespace BH.Revit.Engine.Core
 
         private static Dictionary<ElementId, Dictionary<PlanarSurface, List<PlanarSurface>>> PanelSurfaces_HostDocument(this Document doc, List<(ElementId, IEnumerable<ElementId>)> hostsWithInsertsToIgnore, RevitSettings settings = null)
         {
-            Dictionary<ElementId, Dictionary<PlanarSurface, List<PlanarSurface>>> result = new Dictionary<ElementId, Dictionary<PlanarSurface, List<PlanarSurface>>>();
+            var result = new Dictionary<ElementId, Dictionary<PlanarSurface, List<PlanarSurface>>>();
 
             // query panel surfaces from each of the panels and rule out the ones that do not have any
-            Dictionary<ElementId, List<Autodesk.Revit.DB.Plane>> planes = new Dictionary<ElementId, List<Autodesk.Revit.DB.Plane>>();
-            List<(ElementId, IEnumerable<ElementId>)> toProcess = new List<(ElementId, IEnumerable<ElementId>)>();
+            var planes = new Dictionary<ElementId, List<Autodesk.Revit.DB.Plane>>();
+            var toProcess = new List<(ElementId, IEnumerable<ElementId>)>();
             foreach ((ElementId, IEnumerable<ElementId>) tuple in hostsWithInsertsToIgnore)
             {
                 ElementId id = tuple.Item1;

--- a/Revit_Core_Engine/Query/SurfaceCacheKey.cs
+++ b/Revit_Core_Engine/Query/SurfaceCacheKey.cs
@@ -21,12 +21,7 @@
  */
 
 using Autodesk.Revit.DB;
-using BH.oM.Adapters.Revit.Enums;
-using BH.oM.Adapters.Revit.Settings;
-using BH.oM.Base;
 using BH.oM.Base.Attributes;
-using BH.oM.Geometry;
-using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core
@@ -37,9 +32,9 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        //[Description("Queries the WorksetId of the active workset in a given Revit document.")]
-        //[Input("document", "Revit document to be queried for the active workset.")]
-        //[Output("worksetId", "WorksetId of the active workset in the input Revit document.")]
+        [Description("Returns the refObjects key, under which the surface location of a given Revit panel element is stored.")]
+        [Input("elementId", "ElementId of the Revit panel for which the refObjects key is queried.")]
+        [Output("key", "RefObjects key, under which the surface location of the input Revit panel element is stored.")]
         public static string SurfaceCacheKey(this ElementId elementId)
         {
             return $"AnalyticalOutlines_{elementId.IntegerValue}";

--- a/Revit_Core_Engine/Query/SurfaceCacheKey.cs
+++ b/Revit_Core_Engine/Query/SurfaceCacheKey.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.oM.Adapters.Revit.Enums;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Geometry;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        //[Description("Queries the WorksetId of the active workset in a given Revit document.")]
+        //[Input("document", "Revit document to be queried for the active workset.")]
+        //[Output("worksetId", "WorksetId of the active workset in the input Revit document.")]
+        public static string SurfaceCacheKey(this ElementId elementId)
+        {
+            return $"AnalyticalOutlines_{elementId.IntegerValue}";
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -334,6 +334,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compute\Activate.cs" />
+    <Compile Include="Compute\CachePanelGeometry.cs" />
     <Compile Include="Compute\CheckFamilyMapUsage.cs" />
     <Compile Include="Compute\Errors.cs" />
     <Compile Include="Compute\GenerateProfile.cs" />
@@ -388,7 +389,9 @@
     <Compile Include="Modify\SetProperty.cs" />
     <Compile Include="Modify\SetViewDetailLevel.cs" />
     <Compile Include="Modify\SetViewScale.cs" />
+    <Compile Include="Objects\OutlineCache.cs" />
     <Compile Include="Objects\SpecTypeId.cs" />
+    <Compile Include="Objects\SurfaceCache.cs" />
     <Compile Include="Objects\UnitTypeId.cs" />
     <Compile Include="Query\AllConvertMethods.cs" />
     <Compile Include="Query\AllWorksetIds.cs" />
@@ -406,10 +409,13 @@
     <Compile Include="Compute\OpenWorksetsPrefilter.cs" />
     <Compile Include="Query\DoesIntersect.cs" />
     <Compile Include="Query\ElementIds\ElementIdsOfEverything.cs" />
+    <Compile Include="Query\InsertsToIgnore.cs" />
     <Compile Include="Query\Insulation.cs" />
     <Compile Include="Query\LinkedElementsInView.cs" />
     <Compile Include="Query\LinkName.cs" />
+    <Compile Include="Query\OutlineCacheKey.cs" />
     <Compile Include="Query\SpatialBoundCondition.cs" />
+    <Compile Include="Query\SurfaceCacheKey.cs" />
     <Compile Include="Query\Tessellate.cs" />
     <Compile Include="Query\ViewBox.cs" />
     <Compile Include="Query\FacadeCurtainPanels.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1236
Closes #1237

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231238%2DPanelConvertPerformance&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)
Worth testing the standard test procedure files too @vietle-bh 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Revit => BHoM panel convert performance improved
- facade panel convert bug fixed

### Additional comments
<!-- As required -->
The proposed performance improvement is quite complex in implementation, but I will try to explain it in a few points 🙈 

**Before:**
- each panel element converted individually
- temporary transaction and document regeneration done for each element separately

**After:**
- each panel element converted individually
- before any converts happen, the panel locations are being extracted and cached in `refObjects` to be used when the actual converts get called
- thanks to the above, all panel locations are queried in a single call, therefore only one temporary transaction is opened for all of them

In some cases this may cut down the execution time from hours to minutes.