### PR TITLE
Naming of Framing elements on Push and Pull made behave more consistently

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Beam.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Beam.cs
@@ -53,7 +53,7 @@ namespace BH.Revit.Engine.Core
 
             oM.Geometry.ICurve locationCurve = familyInstance.LocationCurveFraming(settings);
             IFramingElementProperty property = familyInstance.FramingElementProperty(settings, refObjects);
-            beam = BH.Engine.Physical.Create.Beam(locationCurve, property, familyInstance.Name);
+            beam = BH.Engine.Physical.Create.Beam(locationCurve, property);
 
             //Set identifiers, parameters & custom data
             beam.SetIdentifiers(familyInstance);

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Bracing.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Bracing.cs
@@ -53,7 +53,7 @@ namespace BH.Revit.Engine.Core
 
             oM.Geometry.ICurve locationCurve = familyInstance.LocationCurveFraming(settings);
             IFramingElementProperty property = familyInstance.FramingElementProperty(settings, refObjects);
-            bracing = BH.Engine.Physical.Create.Bracing(locationCurve, property, familyInstance.Name);
+            bracing = BH.Engine.Physical.Create.Bracing(locationCurve, property);
 
             //Set identifiers, parameters & custom data
             bracing.SetIdentifiers(familyInstance);

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Column.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Column.cs
@@ -53,7 +53,7 @@ namespace BH.Revit.Engine.Core
 
             oM.Geometry.ICurve locationCurve = familyInstance.LocationCurveColumn(settings);
             IFramingElementProperty property = familyInstance.FramingElementProperty(settings, refObjects);
-            column = BH.Engine.Physical.Create.Column(locationCurve, property, familyInstance.Name);
+            column = BH.Engine.Physical.Create.Column(locationCurve, property);
 
             //Set identifiers, parameters & custom data
             column.SetIdentifiers(familyInstance);

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -307,10 +307,10 @@ namespace BH.Revit.Engine.Core
             {
                 elementType = bhomObject.ElementType(document, categories, settings);
                 if (elementType != null && differentNames)
-                    BH.Engine.Base.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {bhomObject.BHoM_Guid}");
+                    BH.Engine.Base.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and the name of its defining property are different. Revit element type has been set based on the former because no type has been found for the latter. BHoM_Guid: {bhomObject.BHoM_Guid}");
             }
             else if (differentNames)
-                BH.Engine.Base.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and its {nameof(BH.oM.Physical.Elements.ISurface.Construction)} name are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {bhomObject.BHoM_Guid}");
+                BH.Engine.Base.Compute.RecordWarning($"BHoM {bhomType.Name}'s name and the name of its defining property are different. Revit element type has been set based on the latter as it is meant to take precedence. BHoM_Guid: {bhomObject.BHoM_Guid}");
 
             return elementType;
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1239

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231240%2DNamingOfFramingElements&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->