### PR TITLE
Revit_Engine: Improve error message when diffing with duplicate elementIds

### DIFF
--- a/Revit_Engine/Compute/RevitDiffing.cs
+++ b/Revit_Engine/Compute/RevitDiffing.cs
@@ -202,7 +202,7 @@ namespace BH.Engine.Adapters.Revit
                 return null;
             }
 
-            //Compute the diffing through DIffWIthCUstomIds making use of the ids extracted from the objects
+            //Compute the diffing through DiffWithCustomIds making use of the ids extracted from the objects
             Diff revitDiff = BH.Engine.Diffing.Compute.DiffWithCustomIds(pastObjects.ToList(), pastIds, followingObjects.ToList(), followingIds, diffConfigClone);
             return revitDiff;
         }

--- a/Revit_Engine/Compute/RevitDiffing.cs
+++ b/Revit_Engine/Compute/RevitDiffing.cs
@@ -191,7 +191,7 @@ namespace BH.Engine.Adapters.Revit
             {
                 List<string> messageSubjects = new List<string>();
                 if (dupsInPastIds) messageSubjects.Add(nameof(pastObjects));
-                if (dupsInFollIds) messageSubjects.Add(nameof(followingIds));
+                if (dupsInFollIds) messageSubjects.Add(nameof(followingObjects));
                 string message = $"Some of the {string.Join(" and ", messageSubjects)} contain duplicate {revitIdName}s. ";
 
                 if((dupsInPastIds && pastObjects.Any(x => x.GetType().Namespace.Contains("Structure"))) || 

--- a/Revit_Engine/Compute/RevitDiffing.cs
+++ b/Revit_Engine/Compute/RevitDiffing.cs
@@ -183,24 +183,20 @@ namespace BH.Engine.Adapters.Revit
                 followingIds = followingIdFragments.Select(x => x.PersistentId.ToString()).ToList();
             }
 
-            //Check for duplicate ids
-            if (pastIds.Count != pastIds.Distinct().Count())
+             //Check for duplicate ids
+            bool dupsInPastIds = pastIds.Count != pastIds.Distinct().Count();
+            bool dupsInFollIds = followingIds.Count != followingIds.Distinct().Count();
+
+            if (dupsInPastIds || dupsInFollIds)
             {
-                string message = $"Some of the {nameof(pastObjects)} contain duplicate {revitIdName}s.";
+                List<string> messageSubjects = new List<string>();
+                if (dupsInPastIds) messageSubjects.Add(nameof(pastObjects));
+                if (dupsInFollIds) messageSubjects.Add(nameof(followingIds));
+                string message = $"Some of the {string.Join(" and ", messageSubjects)} contain duplicate {revitIdName}s. ";
 
-                if(pastObjects.Any(x => x.GetType().Namespace.Contains("Structure")))
-                    message+= " If trying to diff structural objects, try pulling using the Phsyical discipline rather than Structural discipline, as models containing disjointed floors and walls and/or curved beams lead to one Revit element being converted into multiple structural BHoM elements.";
-
-                BH.Engine.Base.Compute.RecordError(message);
-                return null;
-            }
-
-            if (followingIds.Count != followingIds.Distinct().Count())
-            {
-                string message = $"Some of the {nameof(followingIds)} contain duplicate {revitIdName}s.";
-
-                if (pastObjects.Any(x => x.GetType().Namespace.Contains("Structure")))
-                    message += " If trying to diff structural objects, try pulling using the Phsyical discipline rather than Structural discipline, as models containing disjointed floors and walls and/or curved beams lead to one Revit element being converted into multiple structural BHoM elements.";
+                if((dupsInPastIds && pastObjects.Any(x => x.GetType().Namespace.Contains("Structure"))) || 
+                    (dupsInFollIds && followingObjects.Any(x => x.GetType().Namespace.Contains("Structure"))))
+                    message += "\nIf trying to diff structural objects, try pulling using the Phsyical discipline rather than Structural discipline, as models containing disjointed floors and walls and/or curved beams lead to one Revit element being converted into multiple structural BHoM elements.";
 
                 BH.Engine.Base.Compute.RecordError(message);
                 return null;

--- a/Revit_Engine/Compute/RevitDiffing.cs
+++ b/Revit_Engine/Compute/RevitDiffing.cs
@@ -154,7 +154,7 @@ namespace BH.Engine.Adapters.Revit
             }
             DiffingConfig diffConfigClone = GetRevitDiffingConfig(rcc);
 
-            // Check if input objects all have RevitIdentifiers assigned.
+            // Get the past and following RevitIdentifiers fragments.
             IEnumerable<RevitIdentifiers> pastIdFragments = pastObjects.OfType<IBHoMObject>().Select(obj => obj.GetRevitIdentifiers()).Where(x => x != null);
             IEnumerable<RevitIdentifiers> followingIdFragments = followingObjects.OfType<IBHoMObject>().Select(obj => obj.GetRevitIdentifiers()).Where(x => x != null);
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1246 

<!-- Add short description of what has been fixed -->

Improves the error message given when duplicate ids is detected. Gives further guidance to use physical elements rather than structural if structural elements are detected.

Changing the Diffing method called to one one step deeper as ids are already extracted.

### Test files
<!-- Link to test files to validate the proposed changes -->
(from @alelom) added a [test for this PR in DiffingTests_Prototypes](https://github.com/BHoM/DiffingTests_Prototypes/commit/4fd6beb6341649b0a350acec1f9fc8f29fd2d00a#diff-12ea9316c7af69edaf879938250d10c04a67762da06fdfc224959d42eb8e8c80). Run all tests in that solution to verify this PR.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->