### PR TITLE
Column style fixed on push of vertical columns + setting enum parameters re-enabled

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/ToRevit/FamilyInstance.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/FamilyInstance.cs
@@ -125,6 +125,9 @@ namespace BH.Revit.Engine.Core
             familyInstance.get_Parameter((BuiltInParameter.FAMILY_BASE_LEVEL_OFFSET_PARAM)).Set(-1e+3);
             familyInstance.get_Parameter((BuiltInParameter.FAMILY_TOP_LEVEL_OFFSET_PARAM)).Set(1e+3);
 
+            if (locationLine.IsVertical())
+                familyInstance.SetParameter(BuiltInParameter.SLANTED_COLUMN_TYPE_PARAM, 0);
+
             familyInstance.CopyParameters(framingElement, settings);
             familyInstance.SetLocation(framingElement, settings);
             

--- a/Revit_Core_Engine/Modify/SetParameter.cs
+++ b/Revit_Core_Engine/Modify/SetParameter.cs
@@ -324,7 +324,7 @@ namespace BH.Revit.Engine.Core
                                     return parameter.Set(boolValue ? 1 : 0);
                             }
 
-                            if (parameter.HasValue && parameter.Definition.GetDataType() == null)
+                            if (parameter.HasValue && parameter.Definition.ParameterType() == null)
                             {
                                 string val = parameter.AsValueString();
                                 if (val == valueString)

--- a/Revit_Core_Engine/Query/ParameterType.cs
+++ b/Revit_Core_Engine/Query/ParameterType.cs
@@ -46,7 +46,11 @@ namespace BH.Revit.Engine.Core
 #else
         public static ForgeTypeId ParameterType(this Definition definition)
         {
-            return definition.GetDataType();
+            ForgeTypeId result = definition?.GetDataType();
+            if (string.IsNullOrWhiteSpace(result?.TypeId))
+                result = null;
+
+            return null;
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1254
Closes #1255

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231257%2DPushVerticalColumn&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->