### PR TITLE
Mechanism for filtering linked elements visible in the active view of host document added

### DIFF
--- a/Revit_Core_Engine/Objects/Active2dViewVisibilityContext.cs
+++ b/Revit_Core_Engine/Objects/Active2dViewVisibilityContext.cs
@@ -23,6 +23,7 @@
 using Autodesk.Revit.DB;
 using System.ComponentModel;
 
+#if (!REVIT2018 && !REVIT2019)
 namespace BH.Revit.Engine.Core
 {
     [Description("Class used to extract elements visible in the active view of the host document if that view is of 2d type. See " + nameof(Query.ElementIdsByVisibleInActiveView) + " for usage example.")]
@@ -105,3 +106,4 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
     }
 }
+#endif

--- a/Revit_Core_Engine/Objects/Active2dViewVisibilityContext.cs
+++ b/Revit_Core_Engine/Objects/Active2dViewVisibilityContext.cs
@@ -1,0 +1,107 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using System.ComponentModel;
+
+namespace BH.Revit.Engine.Core
+{
+    [Description("Class used to extract elements visible in the active view of the host document if that view is of 2d type. See " + nameof(Query.ElementIdsByVisibleInActiveView) + " for usage example.")]
+    public class Active2dViewVisibilityContext : ActiveViewVisibilityContext, IExportContext2D
+    {
+        /***************************************************/
+        /****                Constructor                ****/
+        /***************************************************/
+
+        [Description("hostDocument refers to the document that owns the active view. targetDocument can take three values:" +
+                     "\n- same as hostDocument - visible elements of the host document are then collected" +
+                     "\n- document linked in the host document - elements of that linked document visible in the active view of the host document are then collected" +
+                     "\n- null - all elements of all documents, host and links, are then collected")]
+        public Active2dViewVisibilityContext(Document hostDocument, Document targetDocument) : base(hostDocument, targetDocument)
+        {
+        }
+
+
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        public RenderNodeAction OnElementBegin2D(ElementNode node)
+        {
+            return base.OnElementBegin(node.ElementId);
+        }
+
+        /***************************************************/
+
+        public void OnElementEnd2D(ElementNode node)
+        {
+        }
+
+        /***************************************************/
+
+        public RenderNodeAction OnFaceEdge2D(FaceEdgeNode node)
+        {
+            return RenderNodeAction.Skip;
+        }
+
+        /***************************************************/
+
+        public RenderNodeAction OnFaceSilhouette2D(FaceSilhouetteNode node)
+        {
+            return RenderNodeAction.Skip;
+        }
+
+        /***************************************************/
+
+        public RenderNodeAction OnCurve(CurveNode node)
+        {
+            return RenderNodeAction.Skip;
+        }
+
+        /***************************************************/
+
+        public RenderNodeAction OnPolyline(PolylineNode node)
+        {
+            return RenderNodeAction.Skip;
+        }
+
+        /***************************************************/
+
+        public void OnLineSegment(LineSegment segment)
+        {
+        }
+
+        /***************************************************/
+
+        public void OnPolylineSegments(PolylineSegments segments)
+        {
+        }
+
+        /***************************************************/
+
+        public void OnText(TextNode node)
+        {
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Objects/ActiveViewVisibilityContext.cs
+++ b/Revit_Core_Engine/Objects/ActiveViewVisibilityContext.cs
@@ -1,0 +1,223 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    [Description("Class used to extract elements visible in the active view of the host document. See " + nameof(Query.ElementIdsByVisibleInActiveView) + " for usage example.")]
+    public class ActiveViewVisibilityContext : IExportContext
+    {
+        /***************************************************/
+        /****                Constructor                ****/
+        /***************************************************/
+
+        [Description("hostDocument refers to the document that owns the active view. targetDocument can take three values:" +
+                     "\n- same as hostDocument - visible elements of the host document are then collected" +
+                     "\n- document linked in the host document - elements of that linked document visible in the active view of the host document are then collected" +
+                     "\n- null - all elements of all documents, host and links, are then collected")]
+        public ActiveViewVisibilityContext(Document hostDocument, Document targetDocument)
+        {
+            m_Documents.Push(hostDocument);
+            m_documentLookup[hostDocument.PathName] = hostDocument;
+            m_targetDocument = targetDocument;
+            m_Elements.Add(hostDocument.PathName, new HashSet<ElementId>());
+        }
+
+
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Returns ids of all elements visible in the active view of the host document. The ids are grouped by document they belong to.")]
+        public Dictionary<Document, HashSet<ElementId>> GetAllElementsVisibleInActiveView()
+        {
+            if (m_targetDocument != null)
+            {
+                BH.Engine.Base.Compute.RecordError($"The context has been processed with a single target document. Please run again making sure that the target document parameter in the context constructor is null.");
+                return null;
+            }
+            else
+                return m_documentLookup.ToDictionary(x => x.Value, x => m_Elements[x.Key]);
+        }
+
+        /***************************************************/
+
+        [Description("Returns ids of given target document's elements visible in the active view of the host document.")]
+        public HashSet<ElementId> GetElementsVisibleInActiveView(Document targetDocument)
+        {
+            HashSet<ElementId> result = null;
+            if (!m_Elements.TryGetValue(targetDocument?.PathName, out result))
+                BH.Engine.Base.Compute.RecordError($"Document {targetDocument.Title} has not been processed in the context. Please run again making sure the document is passed as target document in the context constructor or the target document parameter is null.");
+
+            return result;
+        }
+
+        /***************************************************/
+
+        public void Finish()
+        {
+        }
+
+        /***************************************************/
+
+        public bool IsCanceled()
+        {
+            return false;
+        }
+
+        /***************************************************/
+
+        public RenderNodeAction OnElementBegin(ElementId elementId)
+        {
+            Document doc = m_Documents.Peek();
+            m_Elements[doc.PathName].Add(elementId);
+
+            Element element = doc.GetElement(elementId);
+            if (element is RevitLinkInstance)
+            {
+                RevitLinkInstance linkInstance = (RevitLinkInstance)element;
+                if (m_targetDocument == null || m_targetDocument.PathName == linkInstance.GetLinkDocument().PathName)
+                {
+                    m_documentLookup[linkInstance.Document.PathName] = linkInstance.Document;
+                    return RenderNodeAction.Proceed;
+                }
+            }
+
+            return RenderNodeAction.Skip;
+        }
+
+        /***************************************************/
+
+        public void OnElementEnd(ElementId elementId)
+        {
+        }
+
+        /***************************************************/
+
+        public RenderNodeAction OnFaceBegin(FaceNode node)
+        {
+            return RenderNodeAction.Skip;
+        }
+
+        /***************************************************/
+
+        public void OnFaceEnd(FaceNode node)
+        {
+        }
+
+        /***************************************************/
+
+        public RenderNodeAction OnInstanceBegin(InstanceNode node)
+        {
+            return RenderNodeAction.Skip;
+        }
+
+        /***************************************************/
+
+        public void OnInstanceEnd(InstanceNode node)
+        {
+        }
+
+        /***************************************************/
+
+        /***************************************************/
+
+        public void OnLight(LightNode node)
+        {
+        }
+
+        /***************************************************/
+
+        public RenderNodeAction OnLinkBegin(LinkNode node)
+        {
+            Document doc = node.GetDocument();
+            m_Documents.Push(doc);
+            if (!m_Elements.ContainsKey(doc.PathName))
+                m_Elements[doc.PathName] = new HashSet<ElementId>();
+
+            return RenderNodeAction.Proceed;
+        }
+
+        /***************************************************/
+
+        public void OnLinkEnd(LinkNode node)
+        {
+            m_Documents.Pop();
+        }
+
+        /***************************************************/
+
+        public void OnMaterial(MaterialNode node)
+        {
+        }
+
+        /***************************************************/
+
+        public void OnPolymesh(PolymeshTopology node)
+        {
+        }
+
+        /***************************************************/
+
+        /***************************************************/
+
+        public void OnRPC(RPCNode node)
+        {
+        }
+
+        /***************************************************/
+
+        public RenderNodeAction OnViewBegin(ViewNode node)
+        {
+            return RenderNodeAction.Proceed;
+        }
+
+        /***************************************************/
+
+        public void OnViewEnd(ElementId elementId)
+        {
+        }
+
+        /***************************************************/
+
+        public bool Start()
+        {
+            return true;
+        }
+
+
+        /***************************************************/
+        /****              Private fields               ****/
+        /***************************************************/
+
+        private Document m_targetDocument;
+        private Stack<Document> m_Documents = new Stack<Document>();
+        private Dictionary<string, Document> m_documentLookup = new Dictionary<string, Document>();
+        private Dictionary<string, HashSet<ElementId>> m_Elements = new Dictionary<string, HashSet<ElementId>>();
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Objects/ActiveViewVisibilityContext.cs
+++ b/Revit_Core_Engine/Objects/ActiveViewVisibilityContext.cs
@@ -27,7 +27,7 @@ using System.Linq;
 
 namespace BH.Revit.Engine.Core
 {
-    [Description("Class used to extract elements visible in the active view of the host document. See " + nameof(Query.ElementIdsByVisibleInActiveView) + " for usage example.")]
+    [Description("Class used to extract elements visible in the active view of the host document if that view is of 3d type. See " + nameof(Query.ElementIdsByVisibleInActiveView) + " for usage example.")]
     public class ActiveViewVisibilityContext : IExportContext
     {
         /***************************************************/
@@ -40,9 +40,10 @@ namespace BH.Revit.Engine.Core
                      "\n- null - all elements of all documents, host and links, are then collected")]
         public ActiveViewVisibilityContext(Document hostDocument, Document targetDocument)
         {
+            m_HostDocument = hostDocument;
+            m_TargetDocument = targetDocument;
             m_Documents.Push(hostDocument);
             m_DocumentLookup[hostDocument.PathName] = hostDocument;
-            m_TargetDocument = targetDocument;
             m_Elements.Add(hostDocument.PathName, new HashSet<ElementId>());
         }
 
@@ -143,8 +144,6 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        /***************************************************/
-
         public void OnLight(LightNode node)
         {
         }
@@ -182,8 +181,6 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        /***************************************************/
-
         public void OnRPC(RPCNode node)
         {
         }
@@ -192,7 +189,10 @@ namespace BH.Revit.Engine.Core
 
         public RenderNodeAction OnViewBegin(ViewNode node)
         {
-            return RenderNodeAction.Proceed;
+            if (node.ViewId == m_HostDocument.ActiveView.Id)
+                return RenderNodeAction.Proceed;
+            else
+                return RenderNodeAction.Skip;
         }
 
         /***************************************************/
@@ -213,6 +213,7 @@ namespace BH.Revit.Engine.Core
         /****              Private fields               ****/
         /***************************************************/
 
+        private Document m_HostDocument;
         private Document m_TargetDocument;
         private Stack<Document> m_Documents = new Stack<Document>();
         private Dictionary<string, Document> m_DocumentLookup = new Dictionary<string, Document>();

--- a/Revit_Core_Engine/Objects/ActiveViewVisibilityContext.cs
+++ b/Revit_Core_Engine/Objects/ActiveViewVisibilityContext.cs
@@ -41,8 +41,8 @@ namespace BH.Revit.Engine.Core
         public ActiveViewVisibilityContext(Document hostDocument, Document targetDocument)
         {
             m_Documents.Push(hostDocument);
-            m_documentLookup[hostDocument.PathName] = hostDocument;
-            m_targetDocument = targetDocument;
+            m_DocumentLookup[hostDocument.PathName] = hostDocument;
+            m_TargetDocument = targetDocument;
             m_Elements.Add(hostDocument.PathName, new HashSet<ElementId>());
         }
 
@@ -54,13 +54,13 @@ namespace BH.Revit.Engine.Core
         [Description("Returns ids of all elements visible in the active view of the host document. The ids are grouped by document they belong to.")]
         public Dictionary<Document, HashSet<ElementId>> GetAllElementsVisibleInActiveView()
         {
-            if (m_targetDocument != null)
+            if (m_TargetDocument != null)
             {
                 BH.Engine.Base.Compute.RecordError($"The context has been processed with a single target document. Please run again making sure that the target document parameter in the context constructor is null.");
                 return null;
             }
             else
-                return m_documentLookup.ToDictionary(x => x.Value, x => m_Elements[x.Key]);
+                return m_DocumentLookup.ToDictionary(x => x.Value, x => m_Elements[x.Key]);
         }
 
         /***************************************************/
@@ -99,9 +99,9 @@ namespace BH.Revit.Engine.Core
             if (element is RevitLinkInstance)
             {
                 RevitLinkInstance linkInstance = (RevitLinkInstance)element;
-                if (m_targetDocument == null || m_targetDocument.PathName == linkInstance.GetLinkDocument().PathName)
+                if (m_TargetDocument == null || m_TargetDocument.PathName == linkInstance.GetLinkDocument().PathName)
                 {
-                    m_documentLookup[linkInstance.Document.PathName] = linkInstance.Document;
+                    m_DocumentLookup[linkInstance.Document.PathName] = linkInstance.Document;
                     return RenderNodeAction.Proceed;
                 }
             }
@@ -213,9 +213,9 @@ namespace BH.Revit.Engine.Core
         /****              Private fields               ****/
         /***************************************************/
 
-        private Document m_targetDocument;
+        private Document m_TargetDocument;
         private Stack<Document> m_Documents = new Stack<Document>();
-        private Dictionary<string, Document> m_documentLookup = new Dictionary<string, Document>();
+        private Dictionary<string, Document> m_DocumentLookup = new Dictionary<string, Document>();
         private Dictionary<string, HashSet<ElementId>> m_Elements = new Dictionary<string, HashSet<ElementId>>();
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/ElementIds/ElementIds.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIds.cs
@@ -320,6 +320,20 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Finds the ElementIds of all elements within the Revit document that pass the filtering criteria set in the given FilterByVisibleInActiveView request.")]
+        [Input("request", "FilterByVisibleInActiveView request containing the filtering criteria, against which the elements in the Revit document are checked.")]
+        [Input("document", "Revit Document queried for the filtered elements.")]
+        [Input("discipline", "Engineering discipline based on the BHoM discipline classification.")]
+        [Input("settings", "Revit adapter settings to be used while evaluating the elements against the filtering criteria.")]
+        [Input("ids", "Optional, allows narrowing the search: if not null, the output will be an intersection of this collection and ElementIds filtered by the query.")]
+        [Output("elementIds", "Collection of filtered Revit ElementIds.")]
+        public static IEnumerable<ElementId> ElementIds(this FilterByVisibleInActiveView request, Document document, Discipline discipline = Discipline.Undefined, RevitSettings settings = null, IEnumerable<ElementId> ids = null)
+        {
+            return document.ElementIdsByVisibleInActiveView(ids);
+        }
+
+        /***************************************************/
+
         [Description("Finds the ElementIds of all elements within the Revit document that pass the filtering criteria set in the given FilterViewByName request.")]
         [Input("request", "FilterViewByName request containing the filtering criteria, against which the elements in the Revit document are checked.")]
         [Input("document", "Revit Document queried for the filtered elements.")]

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
@@ -44,9 +44,16 @@ namespace BH.Revit.Engine.Core
                 return null;
 
             Document hostDocument = document.IsLinked ? document.HostDocument() : document;
-            ActiveViewVisibilityContext context = new ActiveViewVisibilityContext(hostDocument, document);
+
+            ActiveViewVisibilityContext context;
+            if (hostDocument.ActiveView is View3D)
+                context = new ActiveViewVisibilityContext(hostDocument, document);
+            else
+                context = new Active2dViewVisibilityContext(hostDocument, document);
+
             CustomExporter exporter = new CustomExporter(hostDocument, context);
             exporter.IncludeGeometricObjects = false;
+            exporter.Export2DIncludingAnnotationObjects = true;
             exporter.ShouldStopOnError = false;
 
             try

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
@@ -53,10 +53,15 @@ namespace BH.Revit.Engine.Core
             {
                 exporter.Export(new List<ElementId> { hostDocument.ActiveView.Id });
             }
-            catch (Exception ex)
+            catch (Autodesk.Revit.Exceptions.ArgumentException ex)
             {
-                BH.Engine.Base.Compute.RecordError($"Visible elements could not be queried from the active view because views of type {hostDocument.ActiveView.ViewType} are not queryable in this version of Revit.");
-                return null;
+                if (ex.ParamName == "viewIds")
+                {
+                    BH.Engine.Base.Compute.RecordError($"Visible elements could not be queried from the active view because views of type {hostDocument.ActiveView.ViewType} are not queryable in this version of Revit.");
+                    return null;
+                }
+                else
+                    throw;
             }
 
             HashSet<ElementId> result = context.GetElementsVisibleInActiveView(document);

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Filters ElementIds of elements that are visible in active view of the host document. If the input document is a linked document, its elements visible in the active view of the host document will be returned.")]
+        [Input("document", "Revit document to be processed (can be a linked document).")]
+        [Input("ids", "Optional, allows narrowing the search: if not null, the output will be an intersection of this collection and ElementIds filtered by the query.")]
+        [Output("elementIds", "Collection of filtered ElementIds.")]
+        public static IEnumerable<ElementId> ElementIdsByVisibleInActiveView(this Document document, IEnumerable<ElementId> ids = null)
+        {
+            if (document == null)
+                return null;
+
+            Document hostDocument = document.IsLinked ? document.HostDocument() : document;
+            ActiveViewVisibilityContext context = new ActiveViewVisibilityContext(hostDocument, document);
+            CustomExporter exporter = new CustomExporter(hostDocument, context);
+            exporter.IncludeGeometricObjects = false;
+            exporter.ShouldStopOnError = false;
+
+            try
+            {
+                exporter.Export(hostDocument.ActiveView);
+            }
+            catch (Exception ex)
+            {
+                BH.Engine.Base.Compute.RecordError("Visible elements could not be queried from the active view because it is not queryable (it is drafting, template etc.).");
+                return null;
+            }
+
+            HashSet<ElementId> result = context.GetElementsVisibleInActiveView(document);
+            if (ids != null)
+                result.IntersectWith(ids);
+
+            return result;
+        }
+
+        /***************************************************/
+    }
+
+   
+}

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
@@ -51,7 +51,7 @@ namespace BH.Revit.Engine.Core
 
             try
             {
-                exporter.Export(hostDocument.ActiveView);
+                exporter.Export(new List<ElementId> { hostDocument.ActiveView.Id });
             }
             catch (Exception ex)
             {

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
@@ -22,7 +22,6 @@
 
 using Autodesk.Revit.DB;
 using BH.oM.Base.Attributes;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -49,12 +48,22 @@ namespace BH.Revit.Engine.Core
             if (hostDocument.ActiveView is View3D)
                 context = new ActiveViewVisibilityContext(hostDocument, document);
             else
+            {
+#if (REVIT2018 || REVIT2019)
+                BH.Engine.Base.Compute.RecordError($"Querying visible elements from the active view failed because only 3d views are supported in Revit 2019 or older. In later versions also 2d views can be queried.");
+                return null;
+#else
                 context = new Active2dViewVisibilityContext(hostDocument, document);
+#endif
+            }
 
             CustomExporter exporter = new CustomExporter(hostDocument, context);
             exporter.IncludeGeometricObjects = false;
-            exporter.Export2DIncludingAnnotationObjects = true;
             exporter.ShouldStopOnError = false;
+
+#if (!REVIT2018 && !REVIT2019)
+            exporter.Export2DIncludingAnnotationObjects = true;
+#endif
 
             try
             {
@@ -79,7 +88,5 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
-    }
-
-   
+    }   
 }

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInActiveView.cs
@@ -55,7 +55,7 @@ namespace BH.Revit.Engine.Core
             }
             catch (Exception ex)
             {
-                BH.Engine.Base.Compute.RecordError("Visible elements could not be queried from the active view because it is not queryable (it is drafting, template etc.).");
+                BH.Engine.Base.Compute.RecordError($"Visible elements could not be queried from the active view because views of type {hostDocument.ActiveView.ViewType} are not queryable in this version of Revit.");
                 return null;
             }
 

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInView.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByVisibleInView.cs
@@ -35,7 +35,7 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Filters ElementIds of elements that are visible in a view.")]
+        [Description("Filters ElementIds of elements that are visible in a view. Works only for querying the document that owns the view under the input viewId.")]
         [Input("document", "Revit document to be processed.")]
         [Input("viewId", "ElementId of the Revit view in which the filtered elements are visible.")]
         [Input("ids", "Optional, allows narrowing the search: if not null, the output will be an intersection of this collection and ElementIds filtered by the query.")]
@@ -68,4 +68,3 @@ namespace BH.Revit.Engine.Core
         /***************************************************/
     }
 }
-

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -423,6 +423,7 @@
     <Compile Include="Modify\SetProperty.cs" />
     <Compile Include="Modify\SetViewDetailLevel.cs" />
     <Compile Include="Modify\SetViewScale.cs" />
+    <Compile Include="Objects\ActiveViewVisibilityContext.cs" />
     <Compile Include="Objects\OutlineCache.cs" />
     <Compile Include="Objects\SpecTypeId.cs" />
     <Compile Include="Objects\SurfaceCache.cs" />
@@ -435,6 +436,7 @@
     <Compile Include="Query\CableTraySectionProfile.cs" />
     <Compile Include="Query\CableTraySectionProperty.cs" />
     <Compile Include="Query\CategoriesWithBoundParameters.cs" />
+    <Compile Include="Query\ElementIds\ElementIdsByVisibleInActiveView.cs" />
     <Compile Include="Query\IsBooleanParameter.cs" />
     <Compile Include="Query\IsOwnedByNone.cs" />
     <Compile Include="Query\IsOwnedByCurrentUser.cs" />

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -424,6 +424,7 @@
     <Compile Include="Modify\SetViewDetailLevel.cs" />
     <Compile Include="Modify\SetViewScale.cs" />
     <Compile Include="Objects\ActiveViewVisibilityContext.cs" />
+    <Compile Include="Objects\Active2dViewVisibilityContext.cs" />
     <Compile Include="Objects\OutlineCache.cs" />
     <Compile Include="Objects\SpecTypeId.cs" />
     <Compile Include="Objects\SurfaceCache.cs" />

--- a/Revit_oM/Requests/FilterByVisibleInActiveView.cs
+++ b/Revit_oM/Requests/FilterByVisibleInActiveView.cs
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Data.Requests;
+using System.ComponentModel;
+
+namespace BH.oM.Adapters.Revit.Requests
+{
+    [Description("IRequest that filters elements visible in active view of the host Revit document. Combine with " + nameof(FilterByLink) + " to query linked documents for elements visible in active view of the host document.")]
+    public class FilterByVisibleInActiveView : IRequest
+    {
+        /***************************************************/
+        /****                Properties                 ****/
+        /***************************************************/
+
+
+        /***************************************************/
+    }
+}
+
+

--- a/Revit_oM/Requests/FilterByVisibleInView.cs
+++ b/Revit_oM/Requests/FilterByVisibleInView.cs
@@ -25,7 +25,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapters.Revit.Requests
 {
-    [Description("IRequest that filters all elements visible in a given Revit view.")]
+    [Description("IRequest that filters all elements visible in a given Revit view. Works only for querying the host document (will not return valid results if combined with " + nameof(FilterByLink) + ").")]
     public class FilterByVisibleInView : IRequest
     {
         /***************************************************/

--- a/Revit_oM/Revit_oM.csproj
+++ b/Revit_oM/Revit_oM.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Parameters\RevitPulledParameters.cs" />
     <Compile Include="Requests\FilterByLink.cs" />
     <Compile Include="Requests\FilterByScopeBox.cs" />
+    <Compile Include="Requests\FilterByVisibleInActiveView.cs" />
     <Compile Include="Requests\FilterEverything.cs" />
     <Compile Include="Requests\FilterLinkInstance.cs" />
     <Compile Include="Requests\IParameterRequest.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1261

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231262%2DLinkedElementsFromActiveView&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - try hiding the elements to validate the behaviour.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
@vietle-bh @travispotterBH @michal-pekacki please have a look at `ActiveViewVisibilityContext` and its application in filtering the visible linked elements - can be helpful in other applications 👍 