### PR TITLE
Irrelevant error on pull of MEPCurves removed

### DIFF
--- a/Revit_Core_Engine/Compute/CachePanelGeometry.cs
+++ b/Revit_Core_Engine/Compute/CachePanelGeometry.cs
@@ -52,7 +52,7 @@ namespace BH.Revit.Engine.Core
             foreach (ElementId id in elementIds)
             {
                 HostObject hostObject = document.GetElement(id) as HostObject;
-                if (hostObject == null || hostObject is MEPCurve)
+                if (hostObject == null || hostObject is MEPCurve || hostObject is CurtainGridLine || hostObject is CurtainSystemBase || hostObject is HostedSweep)
                     continue;
 
                 bool outlinesFound = false;

--- a/Revit_Core_Engine/Compute/CachePanelGeometry.cs
+++ b/Revit_Core_Engine/Compute/CachePanelGeometry.cs
@@ -52,7 +52,7 @@ namespace BH.Revit.Engine.Core
             foreach (ElementId id in elementIds)
             {
                 HostObject hostObject = document.GetElement(id) as HostObject;
-                if (hostObject == null)
+                if (hostObject == null || hostObject is MEPCurve)
                     continue;
 
                 bool outlinesFound = false;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1264

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231265%2DIrrelevantDuctError&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
@vietle-bh not sure how did this pass the Beta tests 🙈 