### PR TITLE
Family Instance on MEPCurve connectors fix

### DIFF
--- a/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
@@ -249,15 +249,17 @@ namespace BH.Revit.Engine.Core
             ConnectorSet newElConnSet = newElementMEPCurve.ConnectorManager.Connectors;
             Connector conn1 = null;
             Connector conn2 = null;
+            double minDistance = double.MaxValue;
             foreach (Connector hostConn in hostConnSet)
             {
                 foreach (Connector newElConn in newElConnSet)
                 {
-                    if (hostConn.Origin.IsAlmostEqualTo(newElConn.Origin))
+                    double dist = hostConn.Origin.DistanceTo(newElConn.Origin);
+                    if (dist < minDistance)
                     {
                         conn1 = hostConn;
                         conn2 = newElConn;
-                        break;
+                        minDistance = dist;
                     }
                 }
             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1267 

<!-- Add short description of what has been fixed -->
Placing family instance on MEPCurve doesn't work for specific cases (sloped pipes). This fix changes connector location check from `IsAlmostEqual` to `DistanceTo` to avoid null connector values.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->