### PR TITLE
Bug in push of slabs to Revit 2022/23 fixed

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
+++ b/Revit_Core_Engine/Convert/Physical/ToRevit/Floor.cs
@@ -82,6 +82,8 @@ namespace BH.Revit.Engine.Core
                     revitFloor = document.Create.NewFloor(curve.ToRevitCurveArray(), floorType, level, true);
 #else
                 revitFloor = Floor.Create(document, new List<CurveLoop> { curve.ToRevitCurveLoop() }, floorType.Id, level.Id);
+                revitFloor.SetParameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM, slabPlane.Origin.Z.FromSI(SpecTypeId.Length) - level.ProjectElevation, false);
+                document.Regenerate();
 #endif
             }
             else
@@ -102,6 +104,7 @@ namespace BH.Revit.Engine.Core
                 revitFloor = document.Create.NewSlab(curve.ToRevitCurveArray(), level, line, -tan, true);
 #else
                 revitFloor = Floor.Create(document, new List<CurveLoop> { curve.ToRevitCurveLoop() }, floorType.Id, level.Id, true, line, -tan);
+                revitFloor.SetParameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM, ln.Start.Z.FromSI(SpecTypeId.Length) - level.ProjectElevation, false);
 #endif
                 revitFloor.SetParameter(BuiltInParameter.ELEM_TYPE_PARAM, floorType.Id);
             }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1270

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231271%2DPushOfSlabsBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - open a new project in Revit 2022 or 2023, then do the push and check whether the floors are in correct location

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->