### PR TITLE
Null geometry transformation bug on Pull fixed

### DIFF
--- a/Revit_Core_Adapter/CRUD/Read.cs
+++ b/Revit_Core_Adapter/CRUD/Read.cs
@@ -235,7 +235,7 @@ namespace BH.Revit.Adapter.Core
                     {
                         edges = element.Curves(geometryOptions, settings, true).FromRevit();
                         if (bHoMTransform != null)
-                            edges = edges.Select(x => x.ITransform(bHoMTransform)).ToList();
+                            edges = edges.Select(x => x?.ITransform(bHoMTransform)).ToList();
                     }
 
                     List<ISurface> surfaces = null;
@@ -243,7 +243,7 @@ namespace BH.Revit.Adapter.Core
                     {
                         surfaces = element.Faces(geometryOptions, settings).Select(x => x.IFromRevit()).ToList();
                         if (bHoMTransform != null)
-                            surfaces = surfaces.Select(x => x.ITransform(bHoMTransform)).ToList();
+                            surfaces = surfaces.Select(x => x?.ITransform(bHoMTransform)).ToList();
                     }
 
                     List<oM.Geometry.Mesh> meshes = null;
@@ -251,7 +251,7 @@ namespace BH.Revit.Adapter.Core
                     {
                         meshes = element.MeshedGeometry(meshOptions, settings);
                         if (bHoMTransform != null)
-                            meshes = meshes.Select(x => x.Transform(bHoMTransform)).ToList();
+                            meshes = meshes.Select(x => x?.Transform(bHoMTransform)).ToList();
                     }
 
                     if (geometryConfig.PullEdges || geometryConfig.PullSurfaces || geometryConfig.PullMeshes)
@@ -267,7 +267,7 @@ namespace BH.Revit.Adapter.Core
                     {
                         List<RenderMesh> renderMeshes = element.RenderMeshes(renderMeshOptions, settings);
                         if (bHoMTransform != null)
-                            renderMeshes = renderMeshes.Select(x => x.Transform(bHoMTransform)).ToList();
+                            renderMeshes = renderMeshes.Select(x => x?.Transform(bHoMTransform)).ToList();
 
                         RevitRepresentation representation = new RevitRepresentation(renderMeshes);
                         foreach (IBHoMObject iBHoMObject in iBHoMObjects)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1273

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FRevit%5FToolkit%2F%231273%2DPullFromLinkGeometryBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->