### PR TITLE
Revit_Core_Engine: pull of windows from link fixed

### DIFF
--- a/Revit_Core_Engine/Query/GeometryPrimitives.cs
+++ b/Revit_Core_Engine/Query/GeometryPrimitives.cs
@@ -45,7 +45,8 @@ namespace BH.Revit.Engine.Core
             if (geometryElement == null)
                 return null;
 
-            List<GeometryObject> result = new List<GeometryObject>();
+            List<GeometryObject> geometry = new List<GeometryObject>();
+            List<GeometryObject> instanceGeometry = new List<GeometryObject>();
             foreach (GeometryObject geometryObject in geometryElement)
             {
                 if (geometryObject is GeometryInstance)
@@ -62,13 +63,16 @@ namespace BH.Revit.Engine.Core
 
                     List<GeometryObject> instanceGeometries = geomElement.GeometryPrimitives(null, settings);
                     if (instanceGeometries != null)
-                        result.AddRange(instanceGeometries);
+                        instanceGeometry.AddRange(instanceGeometries);
                 }
                 else
-                    result.Add(geometryObject);
+                    geometry.Add(geometryObject);
             }
 
-            return result;
+            instanceGeometry = instanceGeometry.Where(x => !(x is Solid && ((Solid)x).Faces.IsEmpty)).ToList();
+            geometry = geometry.Where(x => !(x is Solid && ((Solid)x).Faces.IsEmpty)).ToList();
+
+            return geometry.Any() ? geometry : instanceGeometry;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/LinkPanelFaces.cs
+++ b/Revit_Core_Engine/Query/LinkPanelFaces.cs
@@ -64,7 +64,7 @@ namespace BH.Revit.Engine.Core
             Plane p = Plane.CreateByNormalAndOrigin(normal, line.Origin);
 
             List<Solid> solids = wall.Solids(new Options());
-            List<Solid> halfSolids = solids.Select(x => BooleanOperationsUtils.CutWithHalfSpace(x, p)).ToList();
+            List<Solid> halfSolids = solids.Select(x => BooleanOperationsUtils.CutWithHalfSpace(x, p)).Where(x => x != null).ToList();
 
             List<Face> result = new List<Face>();
             foreach (Solid s in halfSolids)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1280

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/Revit_Toolkit/issues/1280


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
From the two issues raised in the original issue:
Null reference was an easy fix, occurred when the solid was entirely outside of the half space, which makes perfect sense.

Generating ids error originates from an edge case where the element had its geometry defined both as instance geometry and element geometry (from what I understand, instance geometry is the geometry created based on the family definition, while the element geometry is what it actually is in the model - see [Revit API docs](https://www.revitapidocs.com/2018.2/fe25b14f-5866-ca0f-a660-c157484c3a56.htm) for more details):
- usually walls have only element geometry, for some weird reason some of them also have instance one:
    ![image](https://user-images.githubusercontent.com/26874773/203859779-01ff888f-5e54-49d8-8f6d-b920a032ec35.png)
        ...from what I understand, instance geometry should be ignored in this case because it does not really exist in the model
- `FamilyInstance` _should_ only have instance geometry, but who knows what will Revit come up with...
- I have found elements that have both element and instance geometry (see railing below), but apparently the element geometry is invalid then
    ![image](https://user-images.githubusercontent.com/26874773/203860065-0c34eb2e-e4c3-45b6-bd21-f9b281825d45.png)
    
...so I drew a conclusion that the procedure should be as follows:
- if the element has a valid element geometry, return only this geometry
- otherwise return instance geometry

I made the above assumptions after longer investigation, but I cannot fully guarantee that it is valid for all cases. Therefore, I strongly recommend wider testing using the standard testing procedures before this gets merged @enarhi.