### PR TITLE
Revit_Core_Engine: Handle null exception on Nurbs curves in beams

### DIFF
--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
@@ -28,6 +28,7 @@ using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Base.Attributes;
+using BH.oM.Geometry;
 using BH.oM.Spatial.ShapeProfiles;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.MaterialFragments;
@@ -137,6 +138,12 @@ namespace BH.Revit.Engine.Core
             bars = new List<Bar>();
             if (locationCurve != null)
             {
+                if (locationCurve is NurbsCurve)
+                {
+                    BH.Engine.Base.Compute.RecordWarning("A the location curves is of the unsupported type: Nurbs. It has been simplified to a polyline.");
+                    locationCurve = new Polyline { ControlPoints = locationCurve.IControlPoints() };
+                }
+
                 //TODO: check category of familyInstance to recognize which rotation query to use
                 double rotation = familyInstance.OrientationAngle(settings);
                 foreach (BH.oM.Geometry.Line line in locationCurve.ICollapseToPolyline(Math.PI / 12).SubParts())


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1288 

<!-- Add short description of what has been fixed -->
While waiting for Bhom_Engine to add support for Nurbs, at least let's handle the exception on the Revit side by converting nurbs curves to polylines.

![image](https://user-images.githubusercontent.com/102604891/207280672-a26ed4e0-b2ae-484d-bbe3-9c0f7bf6a8ef.png)


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/Revit_Core_Engine-%231288-NullException?csf=1&web=1&e=giCgaQ)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Convert Nurbs curves to polylines to handle a null exception
