### PR TITLE
Revit_Core_Engine: Handle null exception on Nurbs curves in element boundaries

### DIFF
--- a/Revit_Core_Engine/Convert/FromRevit.cs
+++ b/Revit_Core_Engine/Convert/FromRevit.cs
@@ -161,8 +161,12 @@ namespace BH.Revit.Engine.Core
             if (converted is IBHoMObject)
                 result = new List<IBHoMObject> { ((IBHoMObject)converted).IPostprocess(transform, settings) };
             else if (converted is IEnumerable<IBHoMObject>)
-                result = new List<IBHoMObject>(((IEnumerable<IBHoMObject>)converted).Select(x => x.IPostprocess(transform, settings)));
-            
+            {
+                result = new List<IBHoMObject>(((IEnumerable<IBHoMObject>)converted)
+                    .Where(x => x != null)
+                    .Select(x => x.IPostprocess(transform, settings)));
+            }
+
             return result;
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1290 

<!-- Add short description of what has been fixed -->
Revit elements with nurbs curves in their boundaries will fail to pull with the message "Outline isn't closed" message. This PR handles another error this exception then triggers.

![image](https://user-images.githubusercontent.com/102604891/207306878-10ce69bb-4f74-400c-96f7-abb237b5fe61.png)


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/Revit_Core_Engine-%231290-NullException?csf=1&web=1&e=5EAe64)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Remove the irrelevant error message due to the same error thrown twice.
