### PR TITLE
Enum reflecting Revit categories added and category matching mechanism refactored

### DIFF
--- a/Revit_Core_Engine/Convert/Revit/ToRevit/Element.cs
+++ b/Revit_Core_Engine/Convert/Revit/ToRevit/Element.cs
@@ -63,7 +63,7 @@ namespace BH.Revit.Engine.Core
 
             settings = settings.DefaultIfNull();
 
-            BuiltInCategory builtInCategory = modelInstance.BuiltInCategory(document);
+            BuiltInCategory builtInCategory = modelInstance.BuiltInCategory();
 
             if (modelInstance.Location is ISurface || modelInstance.Location is ISolid)
             {

--- a/Revit_Core_Engine/Convert/Revit/ToRevit/ElementType.cs
+++ b/Revit_Core_Engine/Convert/Revit/ToRevit/ElementType.cs
@@ -52,7 +52,7 @@ namespace BH.Revit.Engine.Core
 
             settings = settings.DefaultIfNull();
 
-            elementType = instanceProperties.ElementType(document, new List<BuiltInCategory> { instanceProperties.BuiltInCategory(document) }, settings);
+            elementType = instanceProperties.ElementType(document, new List<BuiltInCategory> { instanceProperties.BuiltInCategory() }, settings);
             if (elementType == null)
                 return null;
 

--- a/Revit_Core_Engine/Convert/Revit/ToRevit/Family.cs
+++ b/Revit_Core_Engine/Convert/Revit/ToRevit/Family.cs
@@ -57,7 +57,7 @@ namespace BH.Revit.Engine.Core
                     instanceProperties.ToRevitElementType(document, settings, refObjects);
             }
 
-            HashSet<BuiltInCategory> categories = family.BuiltInCategories(document);
+            HashSet<BuiltInCategory> categories = family.BuiltInCategories();
 
             revitFamily = family.Family(document, categories, settings.FamilyLoadSettings);
 

--- a/Revit_Core_Engine/Convert/ToRevit.cs
+++ b/Revit_Core_Engine/Convert/ToRevit.cs
@@ -113,7 +113,7 @@ namespace BH.Revit.Engine.Core
         [Output("element", "Revit Element resulting from converting the input BH.oM.Adapters.Revit.Elements.ModelInstance.")]
         public static Element ToRevit(this ModelInstance modelInstance, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
         {
-            switch (modelInstance.BuiltInCategory(document))
+            switch (modelInstance.BuiltInCategory())
             {
                 case BuiltInCategory.OST_Lines:
                     return modelInstance.ToCurveElement(document, settings, refObjects);
@@ -132,7 +132,7 @@ namespace BH.Revit.Engine.Core
         [Output("element", "Revit Element resulting from converting the input BH.oM.Adapters.Revit.Elements.DraftingInstance.")]
         public static Element ToRevit(this DraftingInstance draftingInstance, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
         {
-            switch (draftingInstance.BuiltInCategory(document))
+            switch (draftingInstance.BuiltInCategory())
             {
                 case BuiltInCategory.OST_Lines:
                     return draftingInstance.ToCurveElement(document, settings, refObjects);

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -45,12 +45,12 @@ namespace BH.Revit.Engine.Core
         [Input("document", "Revit current document to be processed.")]
         [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
         [Output("builtInCategories", "Resulted collection of Revit BuiltInCategory.")]
-        public static HashSet<BuiltInCategory> BuiltInCategories(this oM.Adapters.Revit.Elements.Family family, Document document, bool caseSensitive = true)
+        public static HashSet<BuiltInCategory> BuiltInCategories(this oM.Adapters.Revit.Elements.Family family, bool caseSensitive = true)
         {
             if (family?.PropertiesList == null)
                 return null;
             
-            return new HashSet<BuiltInCategory>(family.PropertiesList.Select(x => x.BuiltInCategory(document, caseSensitive)));
+            return new HashSet<BuiltInCategory>(family.PropertiesList.Select(x => x.BuiltInCategory(caseSensitive)));
         }
 
         /***************************************************/
@@ -60,9 +60,9 @@ namespace BH.Revit.Engine.Core
         [Input("document", "Revit current document to be processed.")]
         [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
         [Output("builtInCategories", "Resulted collection of Revit BuiltInCategory.")]
-        public static HashSet<BuiltInCategory> BuiltInCategories(this IBHoMObject bHoMObject, Document document, bool caseSensitive = true)
+        public static HashSet<BuiltInCategory> BuiltInCategories(this IBHoMObject bHoMObject, bool caseSensitive = true)
         {
-            BuiltInCategory category = document.BuiltInCategory(bHoMObject.CategoryName(), caseSensitive);
+            BuiltInCategory category = BuiltInCategory(bHoMObject.CategoryName(), caseSensitive);
             if (category != Autodesk.Revit.DB.BuiltInCategory.INVALID)
                 return new HashSet<BuiltInCategory> { category };
 

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -40,6 +40,7 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
+        [PreviousVersion("6.1", "BH.Revit.Engine.Core.Query.BuiltInCategories(BH.oM.Adapters.Revit.Elements.Family, Autodesk.Revit.DB.Document, System.Boolean)")]
         [Description("Queries a BHoM Family for its Revit BuiltInCategory.")]
         [Input("family", "BHoM family to be queried.")]
         [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
@@ -54,6 +55,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [PreviousVersion("6.1", "BH.Revit.Engine.Core.Query.BuiltInCategories(BH.oM.Base.IBHoMObject, Autodesk.Revit.DB.Document, System.Boolean)")]
         [Description("Queries a BHoM IBHoMObject for its Revit BuiltInCategory.")]
         [Input("bHoMObject", "BHoM object to be queried.")]
         [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -42,7 +42,6 @@ namespace BH.Revit.Engine.Core
 
         [Description("Queries a BHoM Family for its Revit BuiltInCategory.")]
         [Input("family", "BHoM family to be queried.")]
-        [Input("document", "Revit current document to be processed.")]
         [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
         [Output("builtInCategories", "Resulted collection of Revit BuiltInCategory.")]
         public static HashSet<BuiltInCategory> BuiltInCategories(this oM.Adapters.Revit.Elements.Family family, bool caseSensitive = true)
@@ -57,7 +56,6 @@ namespace BH.Revit.Engine.Core
 
         [Description("Queries a BHoM IBHoMObject for its Revit BuiltInCategory.")]
         [Input("bHoMObject", "BHoM object to be queried.")]
-        [Input("document", "Revit current document to be processed.")]
         [Input("caseSensitive", "Optional, whether the lookup is case sensitive or not.")]
         [Output("builtInCategories", "Resulted collection of Revit BuiltInCategory.")]
         public static HashSet<BuiltInCategory> BuiltInCategories(this IBHoMObject bHoMObject, bool caseSensitive = true)

--- a/Revit_Core_Engine/Query/BuiltInCategory.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategory.cs
@@ -21,9 +21,11 @@
  */
 
 using Autodesk.Revit.DB;
+using BH.Engine.Base;
 using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Base.Attributes;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -36,21 +38,28 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Returns the Revit built-in category matching a given category name.")]
+        [Description("Returns the Revit built-in category matching a given category name." +
+                     "\nImportant! Only the categories contained in BH.oM.Revit.Enums.Category enum can be queried using this method.")]
         [Input("document", "Revit document to query the categories from.")]
         [Input("categoryName", "Name of the sought built-in Revit category.")]
         [Input("caseSensitive", "If true, the category name matching is case sensitive, otherwise not.")]
         [Output("Revit built-in category matching the input name.")]
         public static BuiltInCategory BuiltInCategory(this Document document, string categoryName, bool caseSensitive = true)
         {
-            if (string.IsNullOrEmpty(categoryName) || document?.Settings?.Categories == null)
-                return Autodesk.Revit.DB.BuiltInCategory.INVALID;
-
-            //TODO: use LabelUtils?
-            foreach (Category category in document.Settings.Categories)
+            Dictionary<string, BuiltInCategory> categoriesWithNames = CategoriesWithNames();
+            if (caseSensitive)
             {
-                if ((caseSensitive && category.Name == categoryName) || (!caseSensitive && category.Name.ToUpper() == categoryName.ToUpper()))
-                    return (BuiltInCategory)category.Id.IntegerValue;
+                if (categoriesWithNames.ContainsKey(categoryName))
+                    return categoriesWithNames[categoryName];
+            }
+            else
+            {
+                string lower = categoryName.ToLower();
+                foreach (var kvp in categoriesWithNames)
+                {
+                    if (kvp.Key.ToLower() == lower)
+                        return kvp.Value;
+                }
             }
 
             return Autodesk.Revit.DB.BuiltInCategory.INVALID;

--- a/Revit_Core_Engine/Query/BuiltInCategory.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategory.cs
@@ -44,7 +44,7 @@ namespace BH.Revit.Engine.Core
         [Input("categoryName", "Name of the sought built-in Revit category.")]
         [Input("caseSensitive", "If true, the category name matching is case sensitive, otherwise not.")]
         [Output("Revit built-in category matching the input name.")]
-        public static BuiltInCategory BuiltInCategory(this Document document, string categoryName, bool caseSensitive = true)
+        public static BuiltInCategory BuiltInCategory(this string categoryName, bool caseSensitive = true)
         {
             Dictionary<BuiltInCategory, string> categoriesWithNames = CategoriesWithNames();
             if (caseSensitive)
@@ -72,9 +72,9 @@ namespace BH.Revit.Engine.Core
         [Input("document", "Revit document to query the categories from.")]
         [Input("caseSensitive", "If true, the category name matching is case sensitive, otherwise not.")]
         [Output("Revit built-in category, to which the input BHoM IInstance belongs.")]
-        public static BuiltInCategory BuiltInCategory(this IInstance instance, Document document, bool caseSensitive = true)
+        public static BuiltInCategory BuiltInCategory(this IInstance instance, bool caseSensitive = true)
         {
-            return (instance?.Properties).BuiltInCategory(document, caseSensitive);
+            return (instance?.Properties).BuiltInCategory(caseSensitive);
         }
 
         /***************************************************/
@@ -84,9 +84,9 @@ namespace BH.Revit.Engine.Core
         [Input("document", "Revit document to query the categories from.")]
         [Input("caseSensitive", "If true, the category name matching is case sensitive, otherwise not.")]
         [Output("Revit built-in category, reference to which is stored in the input BHoM InstanceProperties.")]
-        public static BuiltInCategory BuiltInCategory(this InstanceProperties properties, Document document, bool caseSensitive = true)
+        public static BuiltInCategory BuiltInCategory(this InstanceProperties properties, bool caseSensitive = true)
         {
-            return document.BuiltInCategory(properties?.CategoryName, caseSensitive);
+            return BuiltInCategory(properties?.CategoryName, caseSensitive);
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/BuiltInCategory.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategory.cs
@@ -46,19 +46,19 @@ namespace BH.Revit.Engine.Core
         [Output("Revit built-in category matching the input name.")]
         public static BuiltInCategory BuiltInCategory(this Document document, string categoryName, bool caseSensitive = true)
         {
-            Dictionary<string, BuiltInCategory> categoriesWithNames = CategoriesWithNames();
+            Dictionary<BuiltInCategory, string> categoriesWithNames = CategoriesWithNames();
             if (caseSensitive)
             {
-                if (categoriesWithNames.ContainsKey(categoryName))
-                    return categoriesWithNames[categoryName];
+                if (categoriesWithNames.ContainsValue(categoryName))
+                    return categoriesWithNames.FirstOrDefault(x => x.Value == categoryName).Key;
             }
             else
             {
                 string lower = categoryName.ToLower();
                 foreach (var kvp in categoriesWithNames)
                 {
-                    if (kvp.Key.ToLower() == lower)
-                        return kvp.Value;
+                    if (kvp.Value.ToLower() == lower)
+                        return kvp.Key;
                 }
             }
 

--- a/Revit_Core_Engine/Query/BuiltInCategory.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategory.cs
@@ -38,6 +38,7 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
+        [PreviousVersion("6.1", "BH.Revit.Engine.Core.Query.BuiltInCategory(Autodesk.Revit.DB.Document, System.String, System.Boolean)")]
         [Description("Returns the Revit built-in category matching a given category name." +
                      "\nImportant! Only the categories contained in BH.oM.Revit.Enums.Category enum can be queried using this method.")]
         [Input("categoryName", "Name of the sought built-in Revit category.")]
@@ -66,6 +67,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [PreviousVersion("6.1", "BH.Revit.Engine.Core.Query.BuiltInCategory(BH.oM.Adapters.Revit.Elements.IInstance, Autodesk.Revit.DB.Document, System.Boolean)")]
         [Description("Returns Revit category, to which a given BHoM IInstance belongs.")]
         [Input("instance", "BHoM IInstance to extract the category information from.")]
         [Input("caseSensitive", "If true, the category name matching is case sensitive, otherwise not.")]
@@ -77,6 +79,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [PreviousVersion("6.1", "BH.Revit.Engine.Core.Query.BuiltInCategory(BH.oM.Adapters.Revit.Properties.InstanceProperties, Autodesk.Revit.DB.Document, System.Boolean)")]
         [Description("Returns Revit category, reference to which is stored in a given BHoM InstanceProperties.")]
         [Input("properties", "BHoM InstanceProperties to extract the category information from.")]
         [Input("caseSensitive", "If true, the category name matching is case sensitive, otherwise not.")]

--- a/Revit_Core_Engine/Query/BuiltInCategory.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategory.cs
@@ -40,7 +40,6 @@ namespace BH.Revit.Engine.Core
 
         [Description("Returns the Revit built-in category matching a given category name." +
                      "\nImportant! Only the categories contained in BH.oM.Revit.Enums.Category enum can be queried using this method.")]
-        [Input("document", "Revit document to query the categories from.")]
         [Input("categoryName", "Name of the sought built-in Revit category.")]
         [Input("caseSensitive", "If true, the category name matching is case sensitive, otherwise not.")]
         [Output("Revit built-in category matching the input name.")]
@@ -69,7 +68,6 @@ namespace BH.Revit.Engine.Core
 
         [Description("Returns Revit category, to which a given BHoM IInstance belongs.")]
         [Input("instance", "BHoM IInstance to extract the category information from.")]
-        [Input("document", "Revit document to query the categories from.")]
         [Input("caseSensitive", "If true, the category name matching is case sensitive, otherwise not.")]
         [Output("Revit built-in category, to which the input BHoM IInstance belongs.")]
         public static BuiltInCategory BuiltInCategory(this IInstance instance, bool caseSensitive = true)
@@ -81,7 +79,6 @@ namespace BH.Revit.Engine.Core
 
         [Description("Returns Revit category, reference to which is stored in a given BHoM InstanceProperties.")]
         [Input("properties", "BHoM InstanceProperties to extract the category information from.")]
-        [Input("document", "Revit document to query the categories from.")]
         [Input("caseSensitive", "If true, the category name matching is case sensitive, otherwise not.")]
         [Output("Revit built-in category, reference to which is stored in the input BHoM InstanceProperties.")]
         public static BuiltInCategory BuiltInCategory(this InstanceProperties properties, bool caseSensitive = true)

--- a/Revit_Core_Engine/Query/CategoriesWithNames.cs
+++ b/Revit_Core_Engine/Query/CategoriesWithNames.cs
@@ -52,7 +52,9 @@ namespace BH.Revit.Engine.Core
             m_CategoriesWithNames = new Dictionary<BuiltInCategory, string>();
             foreach (BH.oM.Revit.Enums.Category category in Enum.GetValues(typeof(BH.oM.Revit.Enums.Category)))
             {
-                m_CategoriesWithNames.Add(BH.Engine.Base.Compute.ParseEnum<BuiltInCategory>(category.ToString()), category.ToText());
+                BuiltInCategory builtInCategory = BH.Engine.Base.Compute.ParseEnum<BuiltInCategory>(category.ToString());
+                if (builtInCategory != default(BuiltInCategory))
+                    m_CategoriesWithNames.Add(builtInCategory, category.ToText());
             }
         }
 

--- a/Revit_Core_Engine/Query/CategoriesWithNames.cs
+++ b/Revit_Core_Engine/Query/CategoriesWithNames.cs
@@ -7,7 +7,7 @@ namespace BH.Revit.Engine.Core
 {
     public static partial class Query
     {
-        public static Dictionary<string, BuiltInCategory> CategoriesWithNames()
+        public static Dictionary<BuiltInCategory, string> CategoriesWithNames()
         {
             if (m_CategoriesWithNames == null)
                 CollectCategories();
@@ -22,10 +22,10 @@ namespace BH.Revit.Engine.Core
 
         private static void CollectCategories()
         {
-            m_CategoriesWithNames = new Dictionary<string, BuiltInCategory>();
+            m_CategoriesWithNames = new Dictionary<BuiltInCategory, string>();
             foreach (BH.oM.Revit.Enums.Category category in Enum.GetValues(typeof(BH.oM.Revit.Enums.Category)))
             {
-                m_CategoriesWithNames.Add(category.ToText(), (BuiltInCategory)((int)category));
+                m_CategoriesWithNames.Add((BuiltInCategory)((int)category), category.ToText());
             }
         }
 
@@ -34,7 +34,7 @@ namespace BH.Revit.Engine.Core
         /****              Private fields               ****/
         /***************************************************/
 
-        private static Dictionary<string, BuiltInCategory> m_CategoriesWithNames = null;
+        private static Dictionary<BuiltInCategory, string> m_CategoriesWithNames = null;
 
         /***************************************************/
     }

--- a/Revit_Core_Engine/Query/CategoriesWithNames.cs
+++ b/Revit_Core_Engine/Query/CategoriesWithNames.cs
@@ -25,7 +25,7 @@ namespace BH.Revit.Engine.Core
             m_CategoriesWithNames = new Dictionary<BuiltInCategory, string>();
             foreach (BH.oM.Revit.Enums.Category category in Enum.GetValues(typeof(BH.oM.Revit.Enums.Category)))
             {
-                m_CategoriesWithNames.Add((BuiltInCategory)((int)category), category.ToText());
+                m_CategoriesWithNames.Add(BH.Engine.Base.Compute.ParseEnum<BuiltInCategory>(category.ToString()), category.ToText());
             }
         }
 

--- a/Revit_Core_Engine/Query/CategoriesWithNames.cs
+++ b/Revit_Core_Engine/Query/CategoriesWithNames.cs
@@ -1,0 +1,41 @@
+﻿using Autodesk.Revit.DB;
+using BH.Engine.Base;
+using System;
+using System.Collections.Generic;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        public static Dictionary<string, BuiltInCategory> CategoriesWithNames()
+        {
+            if (m_CategoriesWithNames == null)
+                CollectCategories();
+
+            return m_CategoriesWithNames;
+        }
+
+
+        /***************************************************/
+        /****              Private methods              ****/
+        /***************************************************/
+
+        private static void CollectCategories()
+        {
+            m_CategoriesWithNames = new Dictionary<string, BuiltInCategory>();
+            foreach (BH.oM.Revit.Enums.Category category in Enum.GetValues(typeof(BH.oM.Revit.Enums.Category)))
+            {
+                m_CategoriesWithNames.Add(category.ToText(), (BuiltInCategory)((int)category));
+            }
+        }
+
+
+        /***************************************************/
+        /****              Private fields               ****/
+        /***************************************************/
+
+        private static Dictionary<string, BuiltInCategory> m_CategoriesWithNames = null;
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Query/CategoriesWithNames.cs
+++ b/Revit_Core_Engine/Query/CategoriesWithNames.cs
@@ -1,12 +1,39 @@
-﻿using Autodesk.Revit.DB;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
 using BH.Engine.Base;
+using BH.oM.Base.Attributes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core
 {
     public static partial class Query
     {
+        [Description("Returns a dictionary of BuiltInCategories supported by BHoM (UI, filtering by category) and their names." +
+                     "\nThe categories as well as  their names come from BH.oM.Revit.Enums.Category.")]
+        [Output("categories", "Dictionary of BuiltInCategories supported by BHoM and their names.")]
         public static Dictionary<BuiltInCategory, string> CategoriesWithNames()
         {
             if (m_CategoriesWithNames == null)

--- a/Revit_Core_Engine/Query/CategoryName.cs
+++ b/Revit_Core_Engine/Query/CategoryName.cs
@@ -37,7 +37,6 @@ namespace BH.Revit.Engine.Core
 
         [Description("Returns the name of a given Revit built-in category.")]
         [Input("builtInCategory", "Revit built-in category to get the name for.")]
-        [Input("document", "Revit document to parse for the category name.")]
         [Output("name", "Name of the input Revit category.")]
         public static string CategoryName(this BuiltInCategory builtInCategory)
         {

--- a/Revit_Core_Engine/Query/CategoryName.cs
+++ b/Revit_Core_Engine/Query/CategoryName.cs
@@ -35,6 +35,7 @@ namespace BH.Revit.Engine.Core
         /****              Public methods               ****/
         /***************************************************/
 
+        [PreviousVersion("6.1", "BH.Revit.Engine.Core.Query.CategoryName(Autodesk.Revit.DB.BuiltInCategory, Autodesk.Revit.DB.Document)")]
         [Description("Returns the name of a given Revit built-in category.")]
         [Input("builtInCategory", "Revit built-in category to get the name for.")]
         [Output("name", "Name of the input Revit category.")]

--- a/Revit_Core_Engine/Query/CategoryName.cs
+++ b/Revit_Core_Engine/Query/CategoryName.cs
@@ -41,12 +41,11 @@ namespace BH.Revit.Engine.Core
         [Output("name", "Name of the input Revit category.")]
         public static string CategoryName(this BuiltInCategory builtInCategory, Document document)
         {
-            if (document == null || document.Settings == null || document.Settings.Categories == null)
-                return null;
-
-            foreach (Category category in document.Settings.Categories)
-                if (category.Id.IntegerValue == (int)builtInCategory)
-                    return category.Name;
+            foreach (var kvp in CategoriesWithNames())
+            {
+                if (kvp.Value == builtInCategory)
+                    return kvp.Key;
+            }
 
             return null;
         }

--- a/Revit_Core_Engine/Query/CategoryName.cs
+++ b/Revit_Core_Engine/Query/CategoryName.cs
@@ -39,7 +39,7 @@ namespace BH.Revit.Engine.Core
         [Input("builtInCategory", "Revit built-in category to get the name for.")]
         [Input("document", "Revit document to parse for the category name.")]
         [Output("name", "Name of the input Revit category.")]
-        public static string CategoryName(this BuiltInCategory builtInCategory, Document document)
+        public static string CategoryName(this BuiltInCategory builtInCategory)
         {
             foreach (var kvp in CategoriesWithNames())
             {

--- a/Revit_Core_Engine/Query/CategoryName.cs
+++ b/Revit_Core_Engine/Query/CategoryName.cs
@@ -43,8 +43,8 @@ namespace BH.Revit.Engine.Core
         {
             foreach (var kvp in CategoriesWithNames())
             {
-                if (kvp.Value == builtInCategory)
-                    return kvp.Key;
+                if (kvp.Key == builtInCategory)
+                    return kvp.Value;
             }
 
             return null;

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByCategory.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByCategory.cs
@@ -46,7 +46,7 @@ namespace BH.Revit.Engine.Core
             if (document == null)
                 return null;
 
-            BuiltInCategory builtInCategory = document.BuiltInCategory(categoryName, caseSensitive);
+            BuiltInCategory builtInCategory = BuiltInCategory(categoryName, caseSensitive);
             if (builtInCategory == Autodesk.Revit.DB.BuiltInCategory.INVALID)
             {
                 BH.Engine.Base.Compute.RecordError("Couldn't find a Category named " + categoryName + ".");

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -61,7 +61,7 @@ namespace BH.Revit.Engine.Core
         [Output("framingType", "Revit element type to be used when converting the input BHoM object to Revit.")]
         public static FamilySymbol ElementType(this BH.oM.Physical.Elements.IFramingElement framingElement, Document document, RevitSettings settings = null)
         {
-            HashSet<BuiltInCategory> categories = framingElement.BuiltInCategories(document);
+            HashSet<BuiltInCategory> categories = framingElement.BuiltInCategories();
 
             // Adding StructuralFraming to be included for braces and others (non-columns) - most of families belong to this category.
             if (!(framingElement is BH.oM.Physical.Elements.Column))
@@ -84,7 +84,7 @@ namespace BH.Revit.Engine.Core
         [Output("elementType", "Revit element type to be used when converting the input BHoM object to Revit.")]
         public static ElementType ElementType(this BH.oM.Adapters.Revit.Elements.IInstance instance, Document document, RevitSettings settings = null)
         {
-            return instance.ElementTypeInclProperty(instance.Properties, document, new HashSet<BuiltInCategory> { instance.BuiltInCategory(document) }, settings);
+            return instance.ElementTypeInclProperty(instance.Properties, document, new HashSet<BuiltInCategory> { instance.BuiltInCategory() }, settings);
         }
 
         /***************************************************/
@@ -163,7 +163,7 @@ namespace BH.Revit.Engine.Core
         [Output("elementType", "Revit element type to be used when converting the input BHoM object to Revit.")]
         public static ElementType ElementType(this IBHoMObject bHoMObject, Document document, RevitSettings settings = null)
         {
-            return bHoMObject.ElementType(document, bHoMObject.BuiltInCategories(document), settings);
+            return bHoMObject.ElementType(document, bHoMObject.BuiltInCategories(), settings);
         }
 
         /***************************************************/
@@ -218,7 +218,7 @@ namespace BH.Revit.Engine.Core
                         if (builtInCategory == Autodesk.Revit.DB.BuiltInCategory.INVALID)
                             continue;
 
-                        FamilySymbol familySymbol = settings.FamilyLoadSettings.LoadFamilySymbol(document, builtInCategory.CategoryName(document), familyName, familyTypeName);
+                        FamilySymbol familySymbol = settings.FamilyLoadSettings.LoadFamilySymbol(document, builtInCategory.CategoryName(), familyName, familyTypeName);
                         if (familySymbol != null)
                             return familySymbol;
                     }

--- a/Revit_Core_Engine/Query/Family.cs
+++ b/Revit_Core_Engine/Query/Family.cs
@@ -65,7 +65,7 @@ namespace BH.Revit.Engine.Core
                         if (builtInCategory == Autodesk.Revit.DB.BuiltInCategory.INVALID)
                             continue;
 
-                        revitFamily = familyLoadSettings.LoadFamily(document, builtInCategory.CategoryName(document), family.Name);
+                        revitFamily = familyLoadSettings.LoadFamily(document, builtInCategory.CategoryName(), family.Name);
                         if (revitFamily != null)
                             return revitFamily;
                     }

--- a/Revit_oM/Enums/Category.cs
+++ b/Revit_oM/Enums/Category.cs
@@ -21,9 +21,11 @@
  */
 
 using BH.oM.Base.Attributes;
+using System.ComponentModel;
 
 namespace BH.oM.Revit.Enums
 {
+    [Description("A collection of Revit categories supported by BHoM (UI, filtering etc.).")]
     public enum Category
     {
         [DisplayText("Abutment Foundation Tags")]

--- a/Revit_oM/Enums/Category.cs
+++ b/Revit_oM/Enums/Category.cs
@@ -1,718 +1,712 @@
 ﻿using BH.oM.Base.Attributes;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BH.oM.Revit.Enums
 {
     public enum Category
     {
-        [DisplayText("Point Clouds")]
-        OST_PointClouds = -2010001,
-        [DisplayText("Analytical Links")]
-        OST_LinksAnalytical = -2009657,
-        [DisplayText("Analytical Slab Foundation Tags")]
-        OST_FoundationSlabAnalyticalTags = -2009656,
-        [DisplayText("Analytical Wall Foundation Tags")]
-        OST_WallFoundationAnalyticalTags = -2009655,
-        [DisplayText("Analytical Isolated Foundation Tags")]
-        OST_IsolatedFoundationAnalyticalTags = -2009654,
-        [DisplayText("Analytical Wall Tags")]
-        OST_WallAnalyticalTags = -2009653,
-        [DisplayText("Analytical Floor Tags")]
-        OST_FloorAnalyticalTags = -2009652,
-        [DisplayText("Analytical Column Tags")]
-        OST_ColumnAnalyticalTags = -2009651,
-        [DisplayText("Analytical Brace Tags")]
-        OST_BraceAnalyticalTags = -2009650,
-        [DisplayText("Analytical Beam Tags")]
-        OST_BeamAnalyticalTags = -2009649,
-        [DisplayText("Analytical Nodes")]
-        OST_AnalyticalNodes = -2009645,
-        [DisplayText("Analytical Foundation Slabs")]
-        OST_FoundationSlabAnalytical = -2009643,
-        [DisplayText("Analytical Wall Foundations")]
-        OST_WallFoundationAnalytical = -2009642,
-        [DisplayText("Analytical Isolated Foundations")]
-        OST_IsolatedFoundationAnalytical = -2009641,
-        [DisplayText("Analytical Walls")]
-        OST_WallAnalytical = -2009640,
-        [DisplayText("Analytical Floors")]
-        OST_FloorAnalytical = -2009639,
-        [DisplayText("Analytical Columns")]
-        OST_ColumnAnalytical = -2009636,
-        [DisplayText("Analytical Braces")]
-        OST_BraceAnalytical = -2009633,
-        [DisplayText("Analytical Beams")]
-        OST_BeamAnalytical = -2009630,
-        [DisplayText("Profile Tags")]
-        OST_StructConnectionProfilesTags = -2009064,
-        [DisplayText("Hole Tags")]
-        OST_StructConnectionHoleTags = -2009063,
-        [DisplayText("Structural Rebar Coupler Tags")]
-        OST_CouplerTags = -2009061,
-        [DisplayText("Structural Rebar Couplers")]
-        OST_Coupler = -2009060,
-        [DisplayText("Weld Tags")]
-        OST_StructConnectionWeldTags = -2009059,
-        [DisplayText("Shear Stud Tags")]
-        OST_StructConnectionShearStudTags = -2009058,
-        [DisplayText("Anchor Tags")]
-        OST_StructConnectionAnchorTags = -2009057,
-        [DisplayText("Bolt Tags")]
-        OST_StructConnectionBoltTags = -2009056,
-        [DisplayText("Plate Tags")]
-        OST_StructConnectionPlateTags = -2009055,
-        [DisplayText("Structural Connection Tags")]
-        OST_StructConnectionTags = -2009040,
-        [DisplayText("Structural Connections")]
-        OST_StructConnections = -2009030,
-        [DisplayText("Structural Fabric Reinforcement Symbols")]
-        OST_FabricReinSpanSymbol = -2009028,
-        [DisplayText("Rebar Set Toggle")]
-        OST_RebarSetToggle = -2009025,
-        [DisplayText("Structural Fabric Reinforcement Tags")]
-        OST_FabricReinforcementTags = -2009022,
-        [DisplayText("Structural Area Reinforcement Tags")]
-        OST_AreaReinTags = -2009021,
-        [DisplayText("Structural Rebar Tags")]
-        OST_RebarTags = -2009020,
-        [DisplayText("Structural Fabric Areas")]
-        OST_FabricAreas = -2009017,
-        [DisplayText("Structural Fabric Reinforcement")]
-        OST_FabricReinforcement = -2009016,
-        [DisplayText("Rebar Cover References")]
-        OST_RebarCover = -2009015,
-        [DisplayText("Rebar Shape")]
-        OST_RebarShape = -2009013,
-        [DisplayText("Structural Path Reinforcement Tags")]
-        OST_PathReinTags = -2009011,
-        [DisplayText("Structural Path Reinforcement Symbols")]
-        OST_PathReinSpanSymbol = -2009010,
-        [DisplayText("Structural Path Reinforcement")]
-        OST_PathRein = -2009009,
-        [DisplayText("Structural Area Reinforcement Symbols")]
-        OST_AreaReinSpanSymbol = -2009005,
-        [DisplayText("Structural Area Reinforcement")]
-        OST_AreaRein = -2009003,
-        [DisplayText("Structural Rebar")]
-        OST_Rebar = -2009000,
-        [DisplayText("MEP Fabrication Containment Tags")]
-        OST_FabricationContainmentTags = -2008213,
-        [DisplayText("MEP Fabrication Containment")]
-        OST_FabricationContainment = -2008212,
-        [DisplayText("MEP Fabrication Pipework Tags")]
-        OST_FabricationPipeworkTags = -2008209,
-        [DisplayText("MEP Fabrication Pipework")]
-        OST_FabricationPipework = -2008208,
-        [DisplayText("MEP Fabrication Hanger Tags")]
-        OST_FabricationHangerTags = -2008204,
-        [DisplayText("MEP Fabrication Hangers")]
-        OST_FabricationHangers = -2008203,
-        [DisplayText("MEP Fabrication Ductwork Tags")]
-        OST_FabricationDuctworkTags = -2008194,
-        [DisplayText("MEP Fabrication Ductwork")]
-        OST_FabricationDuctwork = -2008193,
-        [DisplayText("Analytical Surfaces")]
-        OST_AnalyticSurfaces = -2008186,
-        [DisplayText("Analytical Spaces")]
-        OST_AnalyticSpaces = -2008185,
-        [DisplayText("Pipe Segments")]
-        OST_PipeSegments = -2008163,
-        [DisplayText("Pipe Placeholders")]
-        OST_PlaceHolderPipes = -2008161,
-        [DisplayText("Duct Placeholders")]
-        OST_PlaceHolderDucts = -2008160,
-        [DisplayText("Pipe Insulation Tags")]
-        OST_PipeInsulationsTags = -2008155,
-        [DisplayText("Duct Lining Tags")]
-        OST_DuctLiningsTags = -2008154,
-        [DisplayText("Duct Insulation Tags")]
-        OST_DuctInsulationsTags = -2008153,
-        [DisplayText("Electrical Spare/Space Circuits")]
-        OST_ElectricalInternalCircuits = -2008152,
-        [DisplayText("Panel Schedule Graphics")]
-        OST_PanelScheduleGraphics = -2008151,
-        [DisplayText("Cable Tray Runs")]
-        OST_CableTrayRun = -2008150,
-        [DisplayText("Conduit Runs")]
-        OST_ConduitRun = -2008149,
-        [DisplayText("Conduit Tags")]
-        OST_ConduitTags = -2008133,
-        [DisplayText("Conduits")]
-        OST_Conduit = -2008132,
-        [DisplayText("Cable Tray Tags")]
-        OST_CableTrayTags = -2008131,
-        [DisplayText("Cable Trays")]
-        OST_CableTray = -2008130,
-        [DisplayText("Conduit Fitting Tags")]
-        OST_ConduitFittingTags = -2008129,
-        [DisplayText("Conduit Fittings")]
-        OST_ConduitFitting = -2008128,
-        [DisplayText("Cable Tray Fitting Tags")]
-        OST_CableTrayFittingTags = -2008127,
-        [DisplayText("Cable Tray Fittings")]
-        OST_CableTrayFitting = -2008126,
-        [DisplayText("Routing Preferences")]
-        OST_RoutingPreferences = -2008125,
-        [DisplayText("Duct Linings")]
-        OST_DuctLinings = -2008124,
-        [DisplayText("Duct Insulations")]
-        OST_DuctInsulations = -2008123,
-        [DisplayText("Pipe Insulations")]
-        OST_PipeInsulations = -2008122,
-        [DisplayText("Zone Tags")]
-        OST_ZoneTags = -2008115,
-        [DisplayText("HVAC Zones")]
-        OST_HVAC_Zones = -2008107,
-        [DisplayText("Switch System")]
-        OST_SwitchSystem = -2008101,
-        [DisplayText("Sprinkler Tags")]
-        OST_SprinklerTags = -2008100,
-        [DisplayText("Sprinklers")]
-        OST_Sprinklers = -2008099,
-        [DisplayText("Lighting Device Tags")]
-        OST_LightingDeviceTags = -2008088,
-        [DisplayText("Lighting Devices")]
-        OST_LightingDevices = -2008087,
-        [DisplayText("Fire Alarm Device Tags")]
-        OST_FireAlarmDeviceTags = -2008086,
-        [DisplayText("Fire Alarm Devices")]
-        OST_FireAlarmDevices = -2008085,
-        [DisplayText("Data Device Tags")]
-        OST_DataDeviceTags = -2008084,
-        [DisplayText("Data Devices")]
-        OST_DataDevices = -2008083,
-        [DisplayText("Communication Device Tags")]
-        OST_CommunicationDeviceTags = -2008082,
-        [DisplayText("Communication Devices")]
-        OST_CommunicationDevices = -2008081,
-        [DisplayText("Security Device Tags")]
-        OST_SecurityDeviceTags = -2008080,
-        [DisplayText("Security Devices")]
-        OST_SecurityDevices = -2008079,
-        [DisplayText("Nurse Call Device Tags")]
-        OST_NurseCallDeviceTags = -2008078,
-        [DisplayText("Nurse Call Devices")]
-        OST_NurseCallDevices = -2008077,
-        [DisplayText("Telephone Device Tags")]
-        OST_TelephoneDeviceTags = -2008076,
-        [DisplayText("Telephone Devices")]
-        OST_TelephoneDevices = -2008075,
-        [DisplayText("Duct Fitting Tags")]
-        OST_DuctFittingTags = -2008061,
-        [DisplayText("Pipe Fitting Tags")]
-        OST_PipeFittingTags = -2008060,
-        [DisplayText("Pipe Color Fill")]
-        OST_PipeColorFills = -2008059,
-        [DisplayText("Pipe Color Fill Legends")]
-        OST_PipeColorFillLegends = -2008058,
-        [DisplayText("Wire Tags")]
-        OST_WireTags = -2008057,
-        [DisplayText("Pipe Accessory Tags")]
-        OST_PipeAccessoryTags = -2008056,
-        [DisplayText("Pipe Accessories")]
-        OST_PipeAccessory = -2008055,
-        [DisplayText("Flex Pipes")]
-        OST_FlexPipeCurves = -2008050,
-        [DisplayText("Pipe Fittings")]
-        OST_PipeFitting = -2008049,
-        [DisplayText("Flex Pipe Tags")]
-        OST_FlexPipeTags = -2008048,
-        [DisplayText("Pipe Tags")]
-        OST_PipeTags = -2008047,
-        [DisplayText("Pipes")]
-        OST_PipeCurves = -2008044,
-        [DisplayText("Piping Systems")]
-        OST_PipingSystem = -2008043,
-        [DisplayText("Wires")]
-        OST_Wire = -2008039,
-        [DisplayText("Electrical Circuits")]
-        OST_ElectricalCircuit = -2008037,
-        [DisplayText("Flex Ducts")]
-        OST_FlexDuctCurves = -2008020,
-        [DisplayText("Duct Accessory Tags")]
-        OST_DuctAccessoryTags = -2008017,
-        [DisplayText("Duct Accessories")]
-        OST_DuctAccessory = -2008016,
-        [DisplayText("Duct Systems")]
-        OST_DuctSystem = -2008015,
-        [DisplayText("Air Terminal Tags")]
-        OST_DuctTerminalTags = -2008014,
-        [DisplayText("Air Terminals")]
-        OST_DuctTerminal = -2008013,
-        [DisplayText("Duct Fittings")]
-        OST_DuctFitting = -2008010,
-        [DisplayText("Duct Color Fill")]
-        OST_DuctColorFills = -2008005,
-        [DisplayText("Flex Duct Tags")]
-        OST_FlexDuctTags = -2008004,
-        [DisplayText("Duct Tags")]
-        OST_DuctTags = -2008003,
-        [DisplayText("Ducts")]
-        OST_DuctCurves = -2008000,
-        [DisplayText("Duct Color Fill Legends")]
-        OST_DuctColorFillLegends = -2007004,
-        [DisplayText("Structural Tendon Tags")]
-        OST_StructuralTendonTags = -2006276,
-        [DisplayText("Structural Tendons")]
-        OST_StructuralTendons = -2006274,
-        [DisplayText("Expansion Joint Tags")]
-        OST_ExpansionJointTags = -2006273,
-        [DisplayText("Expansion Joints")]
-        OST_ExpansionJoints = -2006271,
-        [DisplayText("Vibration Isolator Tags")]
-        OST_VibrationIsolatorTags = -2006266,
-        [DisplayText("Vibration Damper Tags")]
-        OST_VibrationDamperTags = -2006264,
-        [DisplayText("Vibration Management")]
-        OST_VibrationManagement = -2006261,
-        [DisplayText("Bridge Framing Tags")]
-        OST_BridgeFramingTags = -2006243,
-        [DisplayText("Bridge Framing")]
-        OST_BridgeFraming = -2006241,
-        [DisplayText("Pier Wall Tags")]
-        OST_PierWallTags = -2006230,
-        [DisplayText("Pier Pile Tags")]
-        OST_PierPileTags = -2006226,
-        [DisplayText("Pier Column Tags")]
-        OST_PierColumnTags = -2006222,
-        [DisplayText("Pier Cap Tags")]
-        OST_PierCapTags = -2006220,
-        [DisplayText("Approach Slab Tags")]
-        OST_ApproachSlabTags = -2006211,
-        [DisplayText("Abutment Wall Tags")]
-        OST_AbutmentWallTags = -2006210,
-        [DisplayText("Abutment Pile Tags")]
-        OST_AbutmentPileTags = -2006209,
         [DisplayText("Abutment Foundation Tags")]
-        OST_AbutmentFoundationTags = -2006208,
-        [DisplayText("Bearing Tags")]
-        OST_BridgeBearingTags = -2006178,
-        [DisplayText("Pier Foundation Tags")]
-        OST_BridgeFoundationTags = -2006176,
-        [DisplayText("Bridge Deck Tags")]
-        OST_BridgeDeckTags = -2006175,
-        [DisplayText("Bridge Cable Tags")]
-        OST_BridgeCableTags = -2006173,
-        [DisplayText("Pier Tower Tags")]
-        OST_BridgeTowerTags = -2006172,
-        [DisplayText("Pier Tags")]
-        OST_BridgePierTags = -2006171,
+        OST_AbutmentFoundationTags,
+        [DisplayText("Abutment Pile Tags")]
+        OST_AbutmentPileTags,
         [DisplayText("Abutment Tags")]
-        OST_BridgeAbutmentTags = -2006170,
-        [DisplayText("Bearings")]
-        OST_BridgeBearings = -2006138,
-        [DisplayText("Bridge Decks")]
-        OST_BridgeDecks = -2006135,
-        [DisplayText("Bridge Cables")]
-        OST_BridgeCables = -2006133,
-        [DisplayText("Piers")]
-        OST_BridgePiers = -2006131,
+        OST_BridgeAbutmentTags,
+        [DisplayText("Abutment Wall Tags")]
+        OST_AbutmentWallTags,
         [DisplayText("Abutments")]
-        OST_BridgeAbutments = -2006130,
-        [DisplayText("Brace in Plan View Symbols")]
-        OST_StructuralBracePlanReps = -2006110,
-        [DisplayText("Connection Symbols")]
-        OST_StructConnectionSymbols = -2006100,
-        [DisplayText("Structural Annotations")]
-        OST_StructuralAnnotations = -2006090,
-        [DisplayText("Revision Cloud Tags")]
-        OST_RevisionCloudTags = -2006080,
-        [DisplayText("Revision")]
-        OST_Revisions = -2006070,
-        [DisplayText("Revision Clouds")]
-        OST_RevisionClouds = -2006060,
-        [DisplayText("Elevation Marks")]
-        OST_ElevationMarks = -2006045,
-        [DisplayText("Grid Heads")]
-        OST_GridHeads = -2006040,
-        [DisplayText("Level Heads")]
-        OST_LevelHeads = -2006020,
-        [DisplayText("Scope Boxes")]
-        OST_VolumeOfInterest = -2006000,
-        [DisplayText("Boundary Conditions")]
-        OST_BoundaryConditions = -2005301,
-        [DisplayText("Internal Area Load Tags")]
-        OST_InternalAreaLoadTags = -2005255,
-        [DisplayText("Internal Line Load Tags")]
-        OST_InternalLineLoadTags = -2005254,
-        [DisplayText("Internal Point Load Tags")]
-        OST_InternalPointLoadTags = -2005253,
-        [DisplayText("Area Load Tags")]
-        OST_AreaLoadTags = -2005252,
-        [DisplayText("Line Load Tags")]
-        OST_LineLoadTags = -2005251,
-        [DisplayText("Point Load Tags")]
-        OST_PointLoadTags = -2005250,
-        [DisplayText("Structural Load Cases")]
-        OST_LoadCases = -2005210,
-        [DisplayText("Structural Internal Loads")]
-        OST_InternalLoads = -2005204,
-        [DisplayText("Structural Loads")]
-        OST_Loads = -2005200,
-        [DisplayText("Structural Beam System Tags")]
-        OST_BeamSystemTags = -2005130,
-        [DisplayText("Foundation Span Direction Symbol")]
-        OST_FootingSpanDirectionSymbol = -2005111,
-        [DisplayText("Span Direction Symbol")]
-        OST_SpanDirectionSymbol = -2005110,
-        [DisplayText("Spot Elevation Symbols")]
-        OST_SpotElevSymbols = -2005100,
-        [DisplayText("Multi Leader Tag")]
-        OST_MultiLeaderTag = -2005033,
-        [DisplayText("Curtain Wall Mullion Tags")]
-        OST_CurtainWallMullionTags = -2005032,
-        [DisplayText("Structural Truss Tags")]
-        OST_TrussTags = -2005030,
-        [DisplayText("Keynote Tags")]
-        OST_KeynoteTags = -2005029,
-        [DisplayText("Detail Item Tags")]
-        OST_DetailComponentTags = -2005028,
-        [DisplayText("Material Tags")]
-        OST_MaterialTags = -2005027,
-        [DisplayText("Floor Tags")]
-        OST_FloorTags = -2005026,
-        [DisplayText("Curtain System Tags")]
-        OST_CurtaSystemTags = -2005025,
-        [DisplayText("Stair Tags")]
-        OST_StairsTags = -2005023,
-        [DisplayText("Multi-Category Tags")]
-        OST_MultiCategoryTags = -2005022,
-        [DisplayText("Planting Tags")]
-        OST_PlantingTags = -2005021,
-        [DisplayText("Area Tags")]
-        OST_AreaTags = -2005020,
-        [DisplayText("Structural Foundation Tags")]
-        OST_StructuralFoundationTags = -2005019,
-        [DisplayText("Structural Column Tags")]
-        OST_StructuralColumnTags = -2005018,
-        [DisplayText("Parking Tags")]
-        OST_ParkingTags = -2005017,
-        [DisplayText("Site Tags")]
-        OST_SiteTags = -2005016,
-        [DisplayText("Structural Framing Tags")]
-        OST_StructuralFramingTags = -2005015,
-        [DisplayText("Specialty Equipment Tags")]
-        OST_SpecialityEquipmentTags = -2005014,
-        [DisplayText("Generic Model Tags")]
-        OST_GenericModelTags = -2005013,
-        [DisplayText("Curtain Panel Tags")]
-        OST_CurtainWallPanelTags = -2005012,
-        [DisplayText("Wall Tags")]
-        OST_WallTags = -2005011,
-        [DisplayText("Plumbing Fixture Tags")]
-        OST_PlumbingFixtureTags = -2005010,
-        [DisplayText("Mechanical Equipment Tags")]
-        OST_MechanicalEquipmentTags = -2005009,
-        [DisplayText("Lighting Fixture Tags")]
-        OST_LightingFixtureTags = -2005008,
-        [DisplayText("Furniture System Tags")]
-        OST_FurnitureSystemTags = -2005007,
-        [DisplayText("Furniture Tags")]
-        OST_FurnitureTags = -2005006,
-        [DisplayText("Electrical Fixture Tags")]
-        OST_ElectricalFixtureTags = -2005004,
-        [DisplayText("Electrical Equipment Tags")]
-        OST_ElectricalEquipmentTags = -2005003,
-        [DisplayText("Ceiling Tags")]
-        OST_CeilingTags = -2005002,
-        [DisplayText("Casework Tags")]
-        OST_CaseworkTags = -2005001,
-        [DisplayText("Spaces")]
-        OST_MEPSpaces = -2003600,
-        [DisplayText("Mass Floor Tags")]
-        OST_MassAreaFaceTags = -2003410,
-        [DisplayText("Mass Tags")]
-        OST_MassTags = -2003405,
-        [DisplayText("Mass")]
-        OST_Mass = -2003400,
-        [DisplayText("Areas")]
-        OST_Areas = -2003200,
-        [DisplayText("Project Information")]
-        OST_ProjectInformation = -2003101,
-        [DisplayText("Sheets")]
-        OST_Sheets = -2003100,
-        [DisplayText("Detail Items")]
-        OST_DetailComponents = -2002000,
-        [DisplayText("Entourage")]
-        OST_Entourage = -2001370,
-        [DisplayText("Planting")]
-        OST_Planting = -2001360,
-        [DisplayText("Structural Stiffener Tags")]
-        OST_StructuralStiffenerTags = -2001355,
-        [DisplayText("Structural Stiffeners")]
-        OST_StructuralStiffener = -2001354,
-        [DisplayText("RVT Links")]
-        OST_RvtLinks = -2001352,
-        [DisplayText("Specialty Equipment")]
-        OST_SpecialityEquipment = -2001350,
-        [DisplayText("Topography")]
-        OST_Topography = -2001340,
-        [DisplayText("Structural Trusses")]
-        OST_StructuralTruss = -2001336,
-        [DisplayText("Structural Columns")]
-        OST_StructuralColumns = -2001330,
-        [DisplayText("Structural Beam Systems")]
-        OST_StructuralFramingSystem = -2001327,
-        [DisplayText("Structural Framing")]
-        OST_StructuralFraming = -2001320,
-        [DisplayText("Structural Foundations")]
-        OST_StructuralFoundation = -2001300,
-        [DisplayText("Property Line Segment Tags")]
-        OST_SitePropertyLineSegmentTags = -2001269,
-        [DisplayText("Property Tags")]
-        OST_SitePropertyTags = -2001267,
-        [DisplayText("Site")]
-        OST_Site = -2001260,
-        [DisplayText("Road Tags")]
-        OST_RoadTags = -2001221,
-        [DisplayText("Roads")]
-        OST_Roads = -2001220,
-        [DisplayText("Parking")]
-        OST_Parking = -2001180,
-        [DisplayText("Plumbing Fixtures")]
-        OST_PlumbingFixtures = -2001160,
-        [DisplayText("Mechanical Equipment")]
-        OST_MechanicalEquipment = -2001140,
-        [DisplayText("Lighting Fixtures")]
-        OST_LightingFixtures = -2001120,
-        [DisplayText("Furniture Systems")]
-        OST_FurnitureSystems = -2001100,
-        [DisplayText("Signage Tags")]
-        OST_SignageTags = -2001061,
-        [DisplayText("Electrical Fixtures")]
-        OST_ElectricalFixtures = -2001060,
-        [DisplayText("Signage")]
-        OST_Signage = -2001058,
-        [DisplayText("Audio Visual Device Tags")]
-        OST_AudioVisualDeviceTags = -2001057,
-        [DisplayText("Audio Visual Devices")]
-        OST_AudioVisualDevices = -2001055,
-        [DisplayText("Vertical Circulation Tags")]
-        OST_VerticalCirculationTags = -2001054,
-        [DisplayText("Vertical Circulation")]
-        OST_VerticalCirculation = -2001052,
-        [DisplayText("Fire Protection Tags")]
-        OST_FireProtectionTags = -2001051,
-        [DisplayText("Fire Protection")]
-        OST_FireProtection = -2001049,
-        [DisplayText("Medical Equipment Tags")]
-        OST_MedicalEquipmentTags = -2001048,
-        [DisplayText("Medical Equipment")]
-        OST_MedicalEquipment = -2001046,
-        [DisplayText("Food Service Equipment Tags")]
-        OST_FoodServiceEquipmentTags = -2001045,
-        [DisplayText("Food Service Equipment")]
-        OST_FoodServiceEquipment = -2001043,
-        [DisplayText("Temporary Structure Tags")]
-        OST_TemporaryStructureTags = -2001042,
-        [DisplayText("Electrical Equipment")]
-        OST_ElectricalEquipment = -2001040,
-        [DisplayText("Temporary Structures")]
-        OST_TemporaryStructure = -2001039,
-        [DisplayText("Hardscape Tags")]
-        OST_HardscapeTags = -2001038,
-        [DisplayText("Hardscape")]
-        OST_Hardscape = -2001036,
-        [DisplayText("Alignment Station Labels")]
-        OST_AlignmentStationLabels = -2001017,
-        [DisplayText("Alignment Station Label Sets")]
-        OST_AlignmentStationLabelSets = -2001016,
-        [DisplayText("Alignment Tags")]
-        OST_AlignmentsTags = -2001015,
-        [DisplayText("Alignments")]
-        OST_Alignments = -2001012,
-        [DisplayText("Zone Equipment")]
-        OST_ZoneEquipment = -2001010,
-        [DisplayText("Water Loops")]
-        OST_MEPAnalyticalWaterLoop = -2001009,
-        [DisplayText("Air Systems")]
-        OST_MEPAnalyticalAirLoop = -2001008,
-        [DisplayText("System-Zone Tags")]
-        OST_MEPSystemZoneTags = -2001007,
-        [DisplayText("System-Zones")]
-        OST_MEPSystemZone = -2001001,
-        [DisplayText("Casework")]
-        OST_Casework = -2001000,
-        [DisplayText("Shaft Openings")]
-        OST_ShaftOpening = -2000996,
-        [DisplayText("Mechanical Equipment Set Boundary Lines")]
-        OST_MechanicalEquipmentSetBoundaryLines = -2000987,
-        [DisplayText("Mechanical Equipment Set Tags")]
-        OST_MechanicalEquipmentSetTags = -2000986,
-        [DisplayText("Mechanical Equipment Sets")]
-        OST_MechanicalEquipmentSet = -2000985,
-        [DisplayText("Analytical Pipe Connections")]
-        OST_AnalyticalPipeConnections = -2000983,
-        [DisplayText("Coordination Model")]
-        OST_Coordination_Model = -2000982,
-        [DisplayText("Multi-Rebar Annotations")]
-        OST_MultiReferenceAnnotations = -2000970,
-        [DisplayText("Analytical Node Tags")]
-        OST_NodeAnalyticalTags = -2000956,
-        [DisplayText("Analytical Link Tags")]
-        OST_LinkAnalyticalTags = -2000955,
-        [DisplayText("Stair Tread/Riser Numbers")]
-        OST_StairsTriserNumbers = -2000944,
-        [DisplayText("Stair Support Tags")]
-        OST_StairsSupportTags = -2000942,
-        [DisplayText("Stair Landing Tags")]
-        OST_StairsLandingTags = -2000941,
-        [DisplayText("Stair Run Tags")]
-        OST_StairsRunTags = -2000940,
-        [DisplayText("Stair Paths")]
-        OST_StairsPaths = -2000938,
+        OST_BridgeAbutments,
         [DisplayText("Adaptive Points")]
-        OST_AdaptivePoints = -2000900,
-        [DisplayText("Path of Travel Tags")]
-        OST_PathOfTravelTags = -2000834,
-        [DisplayText("Reference Points")]
-        OST_ReferencePoints = -2000710,
-        [DisplayText("Materials")]
-        OST_Materials = -2000700,
-        [DisplayText("Schedules")]
-        OST_Schedules = -2000573,
-        [DisplayText("Schedule Graphics")]
-        OST_ScheduleGraphics = -2000570,
-        [DisplayText("Raster Images")]
-        OST_RasterImages = -2000560,
-        [DisplayText("Color Fill Legends")]
-        OST_ColorFillLegends = -2000550,
-        [DisplayText("Annotation Crop Boundary")]
-        OST_AnnotationCrop = -2000547,
-        [DisplayText("Callout Boundary")]
-        OST_CalloutBoundary = -2000539,
-        [DisplayText("Callout Heads")]
-        OST_CalloutHeads = -2000538,
-        [DisplayText("Callouts")]
-        OST_Callouts = -2000537,
-        [DisplayText("Crop Boundaries")]
-        OST_CropBoundary = -2000536,
-        [DisplayText("Elevations")]
-        OST_Elev = -2000535,
-        [DisplayText("Reference Planes")]
-        OST_CLines = -2000530,
-        [DisplayText("View Titles")]
-        OST_ViewportLabel = -2000515,
-        [DisplayText("Viewports")]
-        OST_Viewports = -2000510,
-        [DisplayText("Cameras")]
-        OST_Camera_Lines = -2000501,
-        [DisplayText("Space Tags")]
-        OST_MEPSpaceTags = -2000485,
-        [DisplayText("Room Tags")]
-        OST_RoomTags = -2000480,
-        [DisplayText("Door Tags")]
-        OST_DoorTags = -2000460,
-        [DisplayText("Window Tags")]
-        OST_WindowTags = -2000450,
-        [DisplayText("Section Marks")]
-        OST_SectionHeads = -2000400,
-        [DisplayText("Contour Labels")]
-        OST_ContourLabels = -2000350,
-        [DisplayText("Curtain Systems")]
-        OST_CurtaSystem = -2000340,
+        OST_AdaptivePoints,
+        [DisplayText("Air Systems")]
+        OST_MEPAnalyticalAirLoop,
+        [DisplayText("Air Terminal Tags")]
+        OST_DuctTerminalTags,
+        [DisplayText("Air Terminals")]
+        OST_DuctTerminal,
+        [DisplayText("Alignment Station Label Sets")]
+        OST_AlignmentStationLabelSets,
+        [DisplayText("Alignment Station Labels")]
+        OST_AlignmentStationLabels,
+        [DisplayText("Alignment Tags")]
+        OST_AlignmentsTags,
+        [DisplayText("Alignments")]
+        OST_Alignments,
         [DisplayText("Analysis Display Style")]
-        OST_AnalysisDisplayStyle = -2000304,
+        OST_AnalysisDisplayStyle,
         [DisplayText("Analysis Results")]
-        OST_AnalysisResults = -2000303,
-        [DisplayText("Render Regions")]
-        OST_RenderRegions = -2000302,
-        [DisplayText("Section Boxes")]
-        OST_SectionBox = -2000301,
-        [DisplayText("Text Notes")]
-        OST_TextNotes = -2000300,
-        [DisplayText("Title Blocks")]
-        OST_TitleBlocks = -2000280,
-        [DisplayText("Views")]
-        OST_Views = -2000279,
-        [DisplayText("Part Tags")]
-        OST_PartTags = -2000270,
-        [DisplayText("Parts")]
-        OST_Parts = -2000269,
-        [DisplayText("Assembly Tags")]
-        OST_AssemblyTags = -2000268,
+        OST_AnalysisResults,
+        [DisplayText("Analytical Beam Tags")]
+        OST_BeamAnalyticalTags,
+        [DisplayText("Analytical Beams")]
+        OST_BeamAnalytical,
+        [DisplayText("Analytical Brace Tags")]
+        OST_BraceAnalyticalTags,
+        [DisplayText("Analytical Braces")]
+        OST_BraceAnalytical,
+        [DisplayText("Analytical Column Tags")]
+        OST_ColumnAnalyticalTags,
+        [DisplayText("Analytical Columns")]
+        OST_ColumnAnalytical,
+        [DisplayText("Analytical Floor Tags")]
+        OST_FloorAnalyticalTags,
+        [DisplayText("Analytical Floors")]
+        OST_FloorAnalytical,
+        [DisplayText("Analytical Foundation Slabs")]
+        OST_FoundationSlabAnalytical,
+        [DisplayText("Analytical Isolated Foundation Tags")]
+        OST_IsolatedFoundationAnalyticalTags,
+        [DisplayText("Analytical Isolated Foundations")]
+        OST_IsolatedFoundationAnalytical,
+        [DisplayText("Analytical Link Tags")]
+        OST_LinkAnalyticalTags,
+        [DisplayText("Analytical Links")]
+        OST_LinksAnalytical,
+        [DisplayText("Analytical Node Tags")]
+        OST_NodeAnalyticalTags,
+        [DisplayText("Analytical Nodes")]
+        OST_AnalyticalNodes,
+        [DisplayText("Analytical Pipe Connections")]
+        OST_AnalyticalPipeConnections,
+        [DisplayText("Analytical Slab Foundation Tags")]
+        OST_FoundationSlabAnalyticalTags,
+        [DisplayText("Analytical Spaces")]
+        OST_AnalyticSpaces,
+        [DisplayText("Analytical Surfaces")]
+        OST_AnalyticSurfaces,
+        [DisplayText("Analytical Wall Foundation Tags")]
+        OST_WallFoundationAnalyticalTags,
+        [DisplayText("Analytical Wall Foundations")]
+        OST_WallFoundationAnalytical,
+        [DisplayText("Analytical Wall Tags")]
+        OST_WallAnalyticalTags,
+        [DisplayText("Analytical Walls")]
+        OST_WallAnalytical,
+        [DisplayText("Anchor Tags")]
+        OST_StructConnectionAnchorTags,
+        [DisplayText("Annotation Crop Boundary")]
+        OST_AnnotationCrop,
+        [DisplayText("Approach Slab Tags")]
+        OST_ApproachSlabTags,
+        [DisplayText("Area Load Tags")]
+        OST_AreaLoadTags,
+        [DisplayText("Area Tags")]
+        OST_AreaTags,
+        [DisplayText("Areas")]
+        OST_Areas,
         [DisplayText("Assemblies")]
-        OST_Assemblies = -2000267,
-        [DisplayText("Roof Tags")]
-        OST_RoofTags = -2000266,
-        [DisplayText("Spot Slopes")]
-        OST_SpotSlopes = -2000265,
-        [DisplayText("Spot Coordinates")]
-        OST_SpotCoordinates = -2000264,
-        [DisplayText("Spot Elevations")]
-        OST_SpotElevations = -2000263,
-        [DisplayText("Dimensions")]
-        OST_Dimensions = -2000260,
-        [DisplayText("Levels")]
-        OST_Levels = -2000240,
-        [DisplayText("Displacement Path")]
-        OST_DisplacementPath = -2000223,
-        [DisplayText("Grids")]
-        OST_Grids = -2000220,
-        [DisplayText("Section Line")]
-        OST_SectionLine = -2000201,
-        [DisplayText("Sections")]
-        OST_Sections = -2000200,
-        [DisplayText("View Reference")]
-        OST_ReferenceViewerSymbol = -2000197,
-        [DisplayText("Imports in Families")]
-        OST_ImportObjectStyles = -2000196,
-        [DisplayText("Masking Region")]
-        OST_MaskingRegion = -2000194,
-        [DisplayText("Matchline")]
-        OST_Matchline = -2000193,
-        [DisplayText("Plan Region")]
-        OST_PlanRegion = -2000191,
-        [DisplayText("Filled region")]
-        OST_FilledRegion = -2000190,
-        [DisplayText("Ramps")]
-        OST_Ramps = -2000180,
-        [DisplayText("Curtain Grids")]
-        OST_CurtainGrids = -2000173,
-        [DisplayText("Curtain Wall Mullions")]
-        OST_CurtainWallMullions = -2000171,
-        [DisplayText("Curtain Panels")]
-        OST_CurtainWallPanels = -2000170,
-        [DisplayText("Rooms")]
-        OST_Rooms = -2000160,
-        [DisplayText("Generic Models")]
-        OST_GenericModel = -2000151,
-        [DisplayText("Generic Annotations")]
-        OST_GenericAnnotation = -2000150,
-        [DisplayText("Railing Tags")]
-        OST_StairsRailingTags = -2000133,
-        [DisplayText("Railings")]
-        OST_StairsRailing = -2000126,
-        [DisplayText("Stairs")]
-        OST_Stairs = -2000120,
-        [DisplayText("Guide Grid")]
-        OST_GuideGrid = -2000107,
-        [DisplayText("Columns")]
-        OST_Columns = -2000100,
-        [DisplayText("Model Groups")]
-        OST_IOSModelGroups = -2000095,
-        [DisplayText("Reference Lines")]
-        OST_ReferenceLines = -2000083,
-        [DisplayText("Furniture")]
-        OST_Furniture = -2000080,
-        [DisplayText("Lines")]
-        OST_Lines = -2000051,
+        OST_Assemblies,
+        [DisplayText("Assembly Tags")]
+        OST_AssemblyTags,
+        [DisplayText("Audio Visual Device Tags")]
+        OST_AudioVisualDeviceTags,
+        [DisplayText("Audio Visual Devices")]
+        OST_AudioVisualDevices,
+        [DisplayText("Bearing Tags")]
+        OST_BridgeBearingTags,
+        [DisplayText("Bearings")]
+        OST_BridgeBearings,
+        [DisplayText("Bolt Tags")]
+        OST_StructConnectionBoltTags,
+        [DisplayText("Boundary Conditions")]
+        OST_BoundaryConditions,
+        [DisplayText("Brace in Plan View Symbols")]
+        OST_StructuralBracePlanReps,
+        [DisplayText("Bridge Cable Tags")]
+        OST_BridgeCableTags,
+        [DisplayText("Bridge Cables")]
+        OST_BridgeCables,
+        [DisplayText("Bridge Deck Tags")]
+        OST_BridgeDeckTags,
+        [DisplayText("Bridge Decks")]
+        OST_BridgeDecks,
+        [DisplayText("Bridge Framing")]
+        OST_BridgeFraming,
+        [DisplayText("Bridge Framing Tags")]
+        OST_BridgeFramingTags,
+        [DisplayText("Cable Tray Fitting Tags")]
+        OST_CableTrayFittingTags,
+        [DisplayText("Cable Tray Fittings")]
+        OST_CableTrayFitting,
+        [DisplayText("Cable Tray Runs")]
+        OST_CableTrayRun,
+        [DisplayText("Cable Tray Tags")]
+        OST_CableTrayTags,
+        [DisplayText("Cable Trays")]
+        OST_CableTray,
+        [DisplayText("Callout Boundary")]
+        OST_CalloutBoundary,
+        [DisplayText("Callout Heads")]
+        OST_CalloutHeads,
+        [DisplayText("Callouts")]
+        OST_Callouts,
+        [DisplayText("Cameras")]
+        OST_Camera_Lines,
+        [DisplayText("Casework")]
+        OST_Casework,
+        [DisplayText("Casework Tags")]
+        OST_CaseworkTags,
+        [DisplayText("Ceiling Tags")]
+        OST_CeilingTags,
         [DisplayText("Ceilings")]
-        OST_Ceilings = -2000038,
-        [DisplayText("Roofs")]
-        OST_Roofs = -2000035,
-        [DisplayText("Floors")]
-        OST_Floors = -2000032,
+        OST_Ceilings,
+        [DisplayText("Color Fill Legends")]
+        OST_ColorFillLegends,
+        [DisplayText("Columns")]
+        OST_Columns,
+        [DisplayText("Communication Device Tags")]
+        OST_CommunicationDeviceTags,
+        [DisplayText("Communication Devices")]
+        OST_CommunicationDevices,
+        [DisplayText("Conduit Fitting Tags")]
+        OST_ConduitFittingTags,
+        [DisplayText("Conduit Fittings")]
+        OST_ConduitFitting,
+        [DisplayText("Conduit Runs")]
+        OST_ConduitRun,
+        [DisplayText("Conduit Tags")]
+        OST_ConduitTags,
+        [DisplayText("Conduits")]
+        OST_Conduit,
+        [DisplayText("Connection Symbols")]
+        OST_StructConnectionSymbols,
+        [DisplayText("Contour Labels")]
+        OST_ContourLabels,
+        [DisplayText("Coordination Model")]
+        OST_Coordination_Model,
+        [DisplayText("Crop Boundaries")]
+        OST_CropBoundary,
+        [DisplayText("Curtain Grids")]
+        OST_CurtainGrids,
+        [DisplayText("Curtain Panel Tags")]
+        OST_CurtainWallPanelTags,
+        [DisplayText("Curtain Panels")]
+        OST_CurtainWallPanels,
+        [DisplayText("Curtain System Tags")]
+        OST_CurtaSystemTags,
+        [DisplayText("Curtain Systems")]
+        OST_CurtaSystem,
+        [DisplayText("Curtain Wall Mullion Tags")]
+        OST_CurtainWallMullionTags,
+        [DisplayText("Curtain Wall Mullions")]
+        OST_CurtainWallMullions,
+        [DisplayText("Data Device Tags")]
+        OST_DataDeviceTags,
+        [DisplayText("Data Devices")]
+        OST_DataDevices,
+        [DisplayText("Detail Item Tags")]
+        OST_DetailComponentTags,
+        [DisplayText("Detail Items")]
+        OST_DetailComponents,
+        [DisplayText("Dimensions")]
+        OST_Dimensions,
+        [DisplayText("Displacement Path")]
+        OST_DisplacementPath,
+        [DisplayText("Door Tags")]
+        OST_DoorTags,
         [DisplayText("Doors")]
-        OST_Doors = -2000023,
-        [DisplayText("Windows")]
-        OST_Windows = -2000014,
+        OST_Doors,
+        [DisplayText("Duct Accessories")]
+        OST_DuctAccessory,
+        [DisplayText("Duct Accessory Tags")]
+        OST_DuctAccessoryTags,
+        [DisplayText("Duct Color Fill")]
+        OST_DuctColorFills,
+        [DisplayText("Duct Color Fill Legends")]
+        OST_DuctColorFillLegends,
+        [DisplayText("Duct Fitting Tags")]
+        OST_DuctFittingTags,
+        [DisplayText("Duct Fittings")]
+        OST_DuctFitting,
+        [DisplayText("Duct Insulation Tags")]
+        OST_DuctInsulationsTags,
+        [DisplayText("Duct Insulations")]
+        OST_DuctInsulations,
+        [DisplayText("Duct Lining Tags")]
+        OST_DuctLiningsTags,
+        [DisplayText("Duct Linings")]
+        OST_DuctLinings,
+        [DisplayText("Duct Placeholders")]
+        OST_PlaceHolderDucts,
+        [DisplayText("Duct Systems")]
+        OST_DuctSystem,
+        [DisplayText("Duct Tags")]
+        OST_DuctTags,
+        [DisplayText("Ducts")]
+        OST_DuctCurves,
+        [DisplayText("Electrical Circuits")]
+        OST_ElectricalCircuit,
+        [DisplayText("Electrical Equipment")]
+        OST_ElectricalEquipment,
+        [DisplayText("Electrical Equipment Tags")]
+        OST_ElectricalEquipmentTags,
+        [DisplayText("Electrical Fixture Tags")]
+        OST_ElectricalFixtureTags,
+        [DisplayText("Electrical Fixtures")]
+        OST_ElectricalFixtures,
+        [DisplayText("Electrical Spare/Space Circuits")]
+        OST_ElectricalInternalCircuits,
+        [DisplayText("Elevation Marks")]
+        OST_ElevationMarks,
+        [DisplayText("Elevations")]
+        OST_Elev,
+        [DisplayText("Entourage")]
+        OST_Entourage,
+        [DisplayText("Expansion Joint Tags")]
+        OST_ExpansionJointTags,
+        [DisplayText("Expansion Joints")]
+        OST_ExpansionJoints,
+        [DisplayText("Filled region")]
+        OST_FilledRegion,
+        [DisplayText("Fire Alarm Device Tags")]
+        OST_FireAlarmDeviceTags,
+        [DisplayText("Fire Alarm Devices")]
+        OST_FireAlarmDevices,
+        [DisplayText("Fire Protection")]
+        OST_FireProtection,
+        [DisplayText("Fire Protection Tags")]
+        OST_FireProtectionTags,
+        [DisplayText("Flex Duct Tags")]
+        OST_FlexDuctTags,
+        [DisplayText("Flex Ducts")]
+        OST_FlexDuctCurves,
+        [DisplayText("Flex Pipe Tags")]
+        OST_FlexPipeTags,
+        [DisplayText("Flex Pipes")]
+        OST_FlexPipeCurves,
+        [DisplayText("Floor Tags")]
+        OST_FloorTags,
+        [DisplayText("Floors")]
+        OST_Floors,
+        [DisplayText("Food Service Equipment")]
+        OST_FoodServiceEquipment,
+        [DisplayText("Food Service Equipment Tags")]
+        OST_FoodServiceEquipmentTags,
+        [DisplayText("Foundation Span Direction Symbol")]
+        OST_FootingSpanDirectionSymbol,
+        [DisplayText("Furniture")]
+        OST_Furniture,
+        [DisplayText("Furniture System Tags")]
+        OST_FurnitureSystemTags,
+        [DisplayText("Furniture Systems")]
+        OST_FurnitureSystems,
+        [DisplayText("Furniture Tags")]
+        OST_FurnitureTags,
+        [DisplayText("Generic Annotations")]
+        OST_GenericAnnotation,
+        [DisplayText("Generic Model Tags")]
+        OST_GenericModelTags,
+        [DisplayText("Generic Models")]
+        OST_GenericModel,
+        [DisplayText("Grid Heads")]
+        OST_GridHeads,
+        [DisplayText("Grids")]
+        OST_Grids,
+        [DisplayText("Guide Grid")]
+        OST_GuideGrid,
+        [DisplayText("Hardscape")]
+        OST_Hardscape,
+        [DisplayText("Hardscape Tags")]
+        OST_HardscapeTags,
+        [DisplayText("Hole Tags")]
+        OST_StructConnectionHoleTags,
+        [DisplayText("HVAC Zones")]
+        OST_HVAC_Zones,
+        [DisplayText("Imports in Families")]
+        OST_ImportObjectStyles,
+        [DisplayText("Internal Area Load Tags")]
+        OST_InternalAreaLoadTags,
+        [DisplayText("Internal Line Load Tags")]
+        OST_InternalLineLoadTags,
+        [DisplayText("Internal Point Load Tags")]
+        OST_InternalPointLoadTags,
+        [DisplayText("Keynote Tags")]
+        OST_KeynoteTags,
+        [DisplayText("Level Heads")]
+        OST_LevelHeads,
+        [DisplayText("Levels")]
+        OST_Levels,
+        [DisplayText("Lighting Device Tags")]
+        OST_LightingDeviceTags,
+        [DisplayText("Lighting Devices")]
+        OST_LightingDevices,
+        [DisplayText("Lighting Fixture Tags")]
+        OST_LightingFixtureTags,
+        [DisplayText("Lighting Fixtures")]
+        OST_LightingFixtures,
+        [DisplayText("Line Load Tags")]
+        OST_LineLoadTags,
+        [DisplayText("Lines")]
+        OST_Lines,
+        [DisplayText("Masking Region")]
+        OST_MaskingRegion,
+        [DisplayText("Mass")]
+        OST_Mass,
+        [DisplayText("Mass Floor Tags")]
+        OST_MassAreaFaceTags,
+        [DisplayText("Mass Tags")]
+        OST_MassTags,
+        [DisplayText("Matchline")]
+        OST_Matchline,
+        [DisplayText("Material Tags")]
+        OST_MaterialTags,
+        [DisplayText("Materials")]
+        OST_Materials,
+        [DisplayText("Mechanical Equipment")]
+        OST_MechanicalEquipment,
+        [DisplayText("Mechanical Equipment Set Boundary Lines")]
+        OST_MechanicalEquipmentSetBoundaryLines,
+        [DisplayText("Mechanical Equipment Set Tags")]
+        OST_MechanicalEquipmentSetTags,
+        [DisplayText("Mechanical Equipment Sets")]
+        OST_MechanicalEquipmentSet,
+        [DisplayText("Mechanical Equipment Tags")]
+        OST_MechanicalEquipmentTags,
+        [DisplayText("Medical Equipment")]
+        OST_MedicalEquipment,
+        [DisplayText("Medical Equipment Tags")]
+        OST_MedicalEquipmentTags,
+        [DisplayText("MEP Fabrication Containment")]
+        OST_FabricationContainment,
+        [DisplayText("MEP Fabrication Containment Tags")]
+        OST_FabricationContainmentTags,
+        [DisplayText("MEP Fabrication Ductwork")]
+        OST_FabricationDuctwork,
+        [DisplayText("MEP Fabrication Ductwork Tags")]
+        OST_FabricationDuctworkTags,
+        [DisplayText("MEP Fabrication Hanger Tags")]
+        OST_FabricationHangerTags,
+        [DisplayText("MEP Fabrication Hangers")]
+        OST_FabricationHangers,
+        [DisplayText("MEP Fabrication Pipework")]
+        OST_FabricationPipework,
+        [DisplayText("MEP Fabrication Pipework Tags")]
+        OST_FabricationPipeworkTags,
+        [DisplayText("Model Groups")]
+        OST_IOSModelGroups,
+        [DisplayText("Multi Leader Tag")]
+        OST_MultiLeaderTag,
+        [DisplayText("Multi-Category Tags")]
+        OST_MultiCategoryTags,
+        [DisplayText("Multi-Rebar Annotations")]
+        OST_MultiReferenceAnnotations,
+        [DisplayText("Nurse Call Device Tags")]
+        OST_NurseCallDeviceTags,
+        [DisplayText("Nurse Call Devices")]
+        OST_NurseCallDevices,
+        [DisplayText("Panel Schedule Graphics")]
+        OST_PanelScheduleGraphics,
+        [DisplayText("Parking")]
+        OST_Parking,
+        [DisplayText("Parking Tags")]
+        OST_ParkingTags,
+        [DisplayText("Part Tags")]
+        OST_PartTags,
+        [DisplayText("Parts")]
+        OST_Parts,
+        [DisplayText("Path of Travel Tags")]
+        OST_PathOfTravelTags,
+        [DisplayText("Pier Cap Tags")]
+        OST_PierCapTags,
+        [DisplayText("Pier Column Tags")]
+        OST_PierColumnTags,
+        [DisplayText("Pier Foundation Tags")]
+        OST_BridgeFoundationTags,
+        [DisplayText("Pier Pile Tags")]
+        OST_PierPileTags,
+        [DisplayText("Pier Tags")]
+        OST_BridgePierTags,
+        [DisplayText("Pier Tower Tags")]
+        OST_BridgeTowerTags,
+        [DisplayText("Pier Wall Tags")]
+        OST_PierWallTags,
+        [DisplayText("Piers")]
+        OST_BridgePiers,
+        [DisplayText("Pipe Accessories")]
+        OST_PipeAccessory,
+        [DisplayText("Pipe Accessory Tags")]
+        OST_PipeAccessoryTags,
+        [DisplayText("Pipe Color Fill")]
+        OST_PipeColorFills,
+        [DisplayText("Pipe Color Fill Legends")]
+        OST_PipeColorFillLegends,
+        [DisplayText("Pipe Fitting Tags")]
+        OST_PipeFittingTags,
+        [DisplayText("Pipe Fittings")]
+        OST_PipeFitting,
+        [DisplayText("Pipe Insulation Tags")]
+        OST_PipeInsulationsTags,
+        [DisplayText("Pipe Insulations")]
+        OST_PipeInsulations,
+        [DisplayText("Pipe Placeholders")]
+        OST_PlaceHolderPipes,
+        [DisplayText("Pipe Segments")]
+        OST_PipeSegments,
+        [DisplayText("Pipe Tags")]
+        OST_PipeTags,
+        [DisplayText("Pipes")]
+        OST_PipeCurves,
+        [DisplayText("Piping Systems")]
+        OST_PipingSystem,
+        [DisplayText("Plan Region")]
+        OST_PlanRegion,
+        [DisplayText("Planting")]
+        OST_Planting,
+        [DisplayText("Planting Tags")]
+        OST_PlantingTags,
+        [DisplayText("Plate Tags")]
+        OST_StructConnectionPlateTags,
+        [DisplayText("Plumbing Fixture Tags")]
+        OST_PlumbingFixtureTags,
+        [DisplayText("Plumbing Fixtures")]
+        OST_PlumbingFixtures,
+        [DisplayText("Point Clouds")]
+        OST_PointClouds,
+        [DisplayText("Point Load Tags")]
+        OST_PointLoadTags,
+        [DisplayText("Profile Tags")]
+        OST_StructConnectionProfilesTags,
+        [DisplayText("Project Information")]
+        OST_ProjectInformation,
+        [DisplayText("Property Line Segment Tags")]
+        OST_SitePropertyLineSegmentTags,
+        [DisplayText("Property Tags")]
+        OST_SitePropertyTags,
+        [DisplayText("Railing Tags")]
+        OST_StairsRailingTags,
+        [DisplayText("Railings")]
+        OST_StairsRailing,
+        [DisplayText("Ramps")]
+        OST_Ramps,
+        [DisplayText("Raster Images")]
+        OST_RasterImages,
+        [DisplayText("Rebar Cover References")]
+        OST_RebarCover,
+        [DisplayText("Rebar Set Toggle")]
+        OST_RebarSetToggle,
+        [DisplayText("Rebar Shape")]
+        OST_RebarShape,
+        [DisplayText("Reference Lines")]
+        OST_ReferenceLines,
+        [DisplayText("Reference Planes")]
+        OST_CLines,
+        [DisplayText("Reference Points")]
+        OST_ReferencePoints,
+        [DisplayText("Render Regions")]
+        OST_RenderRegions,
+        [DisplayText("Revision")]
+        OST_Revisions,
+        [DisplayText("Revision Cloud Tags")]
+        OST_RevisionCloudTags,
+        [DisplayText("Revision Clouds")]
+        OST_RevisionClouds,
+        [DisplayText("Road Tags")]
+        OST_RoadTags,
+        [DisplayText("Roads")]
+        OST_Roads,
+        [DisplayText("Roof Tags")]
+        OST_RoofTags,
+        [DisplayText("Roofs")]
+        OST_Roofs,
+        [DisplayText("Room Tags")]
+        OST_RoomTags,
+        [DisplayText("Rooms")]
+        OST_Rooms,
+        [DisplayText("Routing Preferences")]
+        OST_RoutingPreferences,
+        [DisplayText("RVT Links")]
+        OST_RvtLinks,
+        [DisplayText("Schedule Graphics")]
+        OST_ScheduleGraphics,
+        [DisplayText("Schedules")]
+        OST_Schedules,
+        [DisplayText("Scope Boxes")]
+        OST_VolumeOfInterest,
+        [DisplayText("Section Boxes")]
+        OST_SectionBox,
+        [DisplayText("Section Line")]
+        OST_SectionLine,
+        [DisplayText("Section Marks")]
+        OST_SectionHeads,
+        [DisplayText("Sections")]
+        OST_Sections,
+        [DisplayText("Security Device Tags")]
+        OST_SecurityDeviceTags,
+        [DisplayText("Security Devices")]
+        OST_SecurityDevices,
+        [DisplayText("Shaft Openings")]
+        OST_ShaftOpening,
+        [DisplayText("Shear Stud Tags")]
+        OST_StructConnectionShearStudTags,
+        [DisplayText("Sheets")]
+        OST_Sheets,
+        [DisplayText("Signage")]
+        OST_Signage,
+        [DisplayText("Signage Tags")]
+        OST_SignageTags,
+        [DisplayText("Site")]
+        OST_Site,
+        [DisplayText("Site Tags")]
+        OST_SiteTags,
+        [DisplayText("Space Tags")]
+        OST_MEPSpaceTags,
+        [DisplayText("Spaces")]
+        OST_MEPSpaces,
+        [DisplayText("Span Direction Symbol")]
+        OST_SpanDirectionSymbol,
+        [DisplayText("Specialty Equipment")]
+        OST_SpecialityEquipment,
+        [DisplayText("Specialty Equipment Tags")]
+        OST_SpecialityEquipmentTags,
+        [DisplayText("Spot Coordinates")]
+        OST_SpotCoordinates,
+        [DisplayText("Spot Elevation Symbols")]
+        OST_SpotElevSymbols,
+        [DisplayText("Spot Elevations")]
+        OST_SpotElevations,
+        [DisplayText("Spot Slopes")]
+        OST_SpotSlopes,
+        [DisplayText("Sprinkler Tags")]
+        OST_SprinklerTags,
+        [DisplayText("Sprinklers")]
+        OST_Sprinklers,
+        [DisplayText("Stair Landing Tags")]
+        OST_StairsLandingTags,
+        [DisplayText("Stair Paths")]
+        OST_StairsPaths,
+        [DisplayText("Stair Run Tags")]
+        OST_StairsRunTags,
+        [DisplayText("Stair Support Tags")]
+        OST_StairsSupportTags,
+        [DisplayText("Stair Tags")]
+        OST_StairsTags,
+        [DisplayText("Stair Tread/Riser Numbers")]
+        OST_StairsTriserNumbers,
+        [DisplayText("Stairs")]
+        OST_Stairs,
+        [DisplayText("Structural Annotations")]
+        OST_StructuralAnnotations,
+        [DisplayText("Structural Area Reinforcement")]
+        OST_AreaRein,
+        [DisplayText("Structural Area Reinforcement Symbols")]
+        OST_AreaReinSpanSymbol,
+        [DisplayText("Structural Area Reinforcement Tags")]
+        OST_AreaReinTags,
+        [DisplayText("Structural Beam System Tags")]
+        OST_BeamSystemTags,
+        [DisplayText("Structural Beam Systems")]
+        OST_StructuralFramingSystem,
+        [DisplayText("Structural Column Tags")]
+        OST_StructuralColumnTags,
+        [DisplayText("Structural Columns")]
+        OST_StructuralColumns,
+        [DisplayText("Structural Connection Tags")]
+        OST_StructConnectionTags,
+        [DisplayText("Structural Connections")]
+        OST_StructConnections,
+        [DisplayText("Structural Fabric Areas")]
+        OST_FabricAreas,
+        [DisplayText("Structural Fabric Reinforcement")]
+        OST_FabricReinforcement,
+        [DisplayText("Structural Fabric Reinforcement Symbols")]
+        OST_FabricReinSpanSymbol,
+        [DisplayText("Structural Fabric Reinforcement Tags")]
+        OST_FabricReinforcementTags,
+        [DisplayText("Structural Foundation Tags")]
+        OST_StructuralFoundationTags,
+        [DisplayText("Structural Foundations")]
+        OST_StructuralFoundation,
+        [DisplayText("Structural Framing")]
+        OST_StructuralFraming,
+        [DisplayText("Structural Framing Tags")]
+        OST_StructuralFramingTags,
+        [DisplayText("Structural Internal Loads")]
+        OST_InternalLoads,
+        [DisplayText("Structural Load Cases")]
+        OST_LoadCases,
+        [DisplayText("Structural Loads")]
+        OST_Loads,
+        [DisplayText("Structural Path Reinforcement")]
+        OST_PathRein,
+        [DisplayText("Structural Path Reinforcement Symbols")]
+        OST_PathReinSpanSymbol,
+        [DisplayText("Structural Path Reinforcement Tags")]
+        OST_PathReinTags,
+        [DisplayText("Structural Rebar")]
+        OST_Rebar,
+        [DisplayText("Structural Rebar Coupler Tags")]
+        OST_CouplerTags,
+        [DisplayText("Structural Rebar Couplers")]
+        OST_Coupler,
+        [DisplayText("Structural Rebar Tags")]
+        OST_RebarTags,
+        [DisplayText("Structural Stiffener Tags")]
+        OST_StructuralStiffenerTags,
+        [DisplayText("Structural Stiffeners")]
+        OST_StructuralStiffener,
+        [DisplayText("Structural Tendon Tags")]
+        OST_StructuralTendonTags,
+        [DisplayText("Structural Tendons")]
+        OST_StructuralTendons,
+        [DisplayText("Structural Truss Tags")]
+        OST_TrussTags,
+        [DisplayText("Structural Trusses")]
+        OST_StructuralTruss,
+        [DisplayText("Switch System")]
+        OST_SwitchSystem,
+        [DisplayText("System-Zone Tags")]
+        OST_MEPSystemZoneTags,
+        [DisplayText("System-Zones")]
+        OST_MEPSystemZone,
+        [DisplayText("Telephone Device Tags")]
+        OST_TelephoneDeviceTags,
+        [DisplayText("Telephone Devices")]
+        OST_TelephoneDevices,
+        [DisplayText("Temporary Structure Tags")]
+        OST_TemporaryStructureTags,
+        [DisplayText("Temporary Structures")]
+        OST_TemporaryStructure,
+        [DisplayText("Text Notes")]
+        OST_TextNotes,
+        [DisplayText("Title Blocks")]
+        OST_TitleBlocks,
+        [DisplayText("Topography")]
+        OST_Topography,
+        [DisplayText("Vertical Circulation")]
+        OST_VerticalCirculation,
+        [DisplayText("Vertical Circulation Tags")]
+        OST_VerticalCirculationTags,
+        [DisplayText("Vibration Damper Tags")]
+        OST_VibrationDamperTags,
+        [DisplayText("Vibration Isolator Tags")]
+        OST_VibrationIsolatorTags,
+        [DisplayText("Vibration Management")]
+        OST_VibrationManagement,
+        [DisplayText("View Reference")]
+        OST_ReferenceViewerSymbol,
+        [DisplayText("View Titles")]
+        OST_ViewportLabel,
+        [DisplayText("Viewports")]
+        OST_Viewports,
+        [DisplayText("Views")]
+        OST_Views,
+        [DisplayText("Wall Tags")]
+        OST_WallTags,
         [DisplayText("Walls")]
-        OST_Walls = -2000011,
+        OST_Walls,
+        [DisplayText("Water Loops")]
+        OST_MEPAnalyticalWaterLoop,
+        [DisplayText("Weld Tags")]
+        OST_StructConnectionWeldTags,
+        [DisplayText("Window Tags")]
+        OST_WindowTags,
+        [DisplayText("Windows")]
+        OST_Windows,
+        [DisplayText("Wire Tags")]
+        OST_WireTags,
+        [DisplayText("Wires")]
+        OST_Wire,
+        [DisplayText("Zone Equipment")]
+        OST_ZoneEquipment,
+        [DisplayText("Zone Tags")]
+        OST_ZoneTags,
     }
 }

--- a/Revit_oM/Enums/Category.cs
+++ b/Revit_oM/Enums/Category.cs
@@ -1,0 +1,718 @@
+﻿using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Revit.Enums
+{
+    public enum Category
+    {
+        [DisplayText("Point Clouds")]
+        OST_PointClouds = -2010001,
+        [DisplayText("Analytical Links")]
+        OST_LinksAnalytical = -2009657,
+        [DisplayText("Analytical Slab Foundation Tags")]
+        OST_FoundationSlabAnalyticalTags = -2009656,
+        [DisplayText("Analytical Wall Foundation Tags")]
+        OST_WallFoundationAnalyticalTags = -2009655,
+        [DisplayText("Analytical Isolated Foundation Tags")]
+        OST_IsolatedFoundationAnalyticalTags = -2009654,
+        [DisplayText("Analytical Wall Tags")]
+        OST_WallAnalyticalTags = -2009653,
+        [DisplayText("Analytical Floor Tags")]
+        OST_FloorAnalyticalTags = -2009652,
+        [DisplayText("Analytical Column Tags")]
+        OST_ColumnAnalyticalTags = -2009651,
+        [DisplayText("Analytical Brace Tags")]
+        OST_BraceAnalyticalTags = -2009650,
+        [DisplayText("Analytical Beam Tags")]
+        OST_BeamAnalyticalTags = -2009649,
+        [DisplayText("Analytical Nodes")]
+        OST_AnalyticalNodes = -2009645,
+        [DisplayText("Analytical Foundation Slabs")]
+        OST_FoundationSlabAnalytical = -2009643,
+        [DisplayText("Analytical Wall Foundations")]
+        OST_WallFoundationAnalytical = -2009642,
+        [DisplayText("Analytical Isolated Foundations")]
+        OST_IsolatedFoundationAnalytical = -2009641,
+        [DisplayText("Analytical Walls")]
+        OST_WallAnalytical = -2009640,
+        [DisplayText("Analytical Floors")]
+        OST_FloorAnalytical = -2009639,
+        [DisplayText("Analytical Columns")]
+        OST_ColumnAnalytical = -2009636,
+        [DisplayText("Analytical Braces")]
+        OST_BraceAnalytical = -2009633,
+        [DisplayText("Analytical Beams")]
+        OST_BeamAnalytical = -2009630,
+        [DisplayText("Profile Tags")]
+        OST_StructConnectionProfilesTags = -2009064,
+        [DisplayText("Hole Tags")]
+        OST_StructConnectionHoleTags = -2009063,
+        [DisplayText("Structural Rebar Coupler Tags")]
+        OST_CouplerTags = -2009061,
+        [DisplayText("Structural Rebar Couplers")]
+        OST_Coupler = -2009060,
+        [DisplayText("Weld Tags")]
+        OST_StructConnectionWeldTags = -2009059,
+        [DisplayText("Shear Stud Tags")]
+        OST_StructConnectionShearStudTags = -2009058,
+        [DisplayText("Anchor Tags")]
+        OST_StructConnectionAnchorTags = -2009057,
+        [DisplayText("Bolt Tags")]
+        OST_StructConnectionBoltTags = -2009056,
+        [DisplayText("Plate Tags")]
+        OST_StructConnectionPlateTags = -2009055,
+        [DisplayText("Structural Connection Tags")]
+        OST_StructConnectionTags = -2009040,
+        [DisplayText("Structural Connections")]
+        OST_StructConnections = -2009030,
+        [DisplayText("Structural Fabric Reinforcement Symbols")]
+        OST_FabricReinSpanSymbol = -2009028,
+        [DisplayText("Rebar Set Toggle")]
+        OST_RebarSetToggle = -2009025,
+        [DisplayText("Structural Fabric Reinforcement Tags")]
+        OST_FabricReinforcementTags = -2009022,
+        [DisplayText("Structural Area Reinforcement Tags")]
+        OST_AreaReinTags = -2009021,
+        [DisplayText("Structural Rebar Tags")]
+        OST_RebarTags = -2009020,
+        [DisplayText("Structural Fabric Areas")]
+        OST_FabricAreas = -2009017,
+        [DisplayText("Structural Fabric Reinforcement")]
+        OST_FabricReinforcement = -2009016,
+        [DisplayText("Rebar Cover References")]
+        OST_RebarCover = -2009015,
+        [DisplayText("Rebar Shape")]
+        OST_RebarShape = -2009013,
+        [DisplayText("Structural Path Reinforcement Tags")]
+        OST_PathReinTags = -2009011,
+        [DisplayText("Structural Path Reinforcement Symbols")]
+        OST_PathReinSpanSymbol = -2009010,
+        [DisplayText("Structural Path Reinforcement")]
+        OST_PathRein = -2009009,
+        [DisplayText("Structural Area Reinforcement Symbols")]
+        OST_AreaReinSpanSymbol = -2009005,
+        [DisplayText("Structural Area Reinforcement")]
+        OST_AreaRein = -2009003,
+        [DisplayText("Structural Rebar")]
+        OST_Rebar = -2009000,
+        [DisplayText("MEP Fabrication Containment Tags")]
+        OST_FabricationContainmentTags = -2008213,
+        [DisplayText("MEP Fabrication Containment")]
+        OST_FabricationContainment = -2008212,
+        [DisplayText("MEP Fabrication Pipework Tags")]
+        OST_FabricationPipeworkTags = -2008209,
+        [DisplayText("MEP Fabrication Pipework")]
+        OST_FabricationPipework = -2008208,
+        [DisplayText("MEP Fabrication Hanger Tags")]
+        OST_FabricationHangerTags = -2008204,
+        [DisplayText("MEP Fabrication Hangers")]
+        OST_FabricationHangers = -2008203,
+        [DisplayText("MEP Fabrication Ductwork Tags")]
+        OST_FabricationDuctworkTags = -2008194,
+        [DisplayText("MEP Fabrication Ductwork")]
+        OST_FabricationDuctwork = -2008193,
+        [DisplayText("Analytical Surfaces")]
+        OST_AnalyticSurfaces = -2008186,
+        [DisplayText("Analytical Spaces")]
+        OST_AnalyticSpaces = -2008185,
+        [DisplayText("Pipe Segments")]
+        OST_PipeSegments = -2008163,
+        [DisplayText("Pipe Placeholders")]
+        OST_PlaceHolderPipes = -2008161,
+        [DisplayText("Duct Placeholders")]
+        OST_PlaceHolderDucts = -2008160,
+        [DisplayText("Pipe Insulation Tags")]
+        OST_PipeInsulationsTags = -2008155,
+        [DisplayText("Duct Lining Tags")]
+        OST_DuctLiningsTags = -2008154,
+        [DisplayText("Duct Insulation Tags")]
+        OST_DuctInsulationsTags = -2008153,
+        [DisplayText("Electrical Spare/Space Circuits")]
+        OST_ElectricalInternalCircuits = -2008152,
+        [DisplayText("Panel Schedule Graphics")]
+        OST_PanelScheduleGraphics = -2008151,
+        [DisplayText("Cable Tray Runs")]
+        OST_CableTrayRun = -2008150,
+        [DisplayText("Conduit Runs")]
+        OST_ConduitRun = -2008149,
+        [DisplayText("Conduit Tags")]
+        OST_ConduitTags = -2008133,
+        [DisplayText("Conduits")]
+        OST_Conduit = -2008132,
+        [DisplayText("Cable Tray Tags")]
+        OST_CableTrayTags = -2008131,
+        [DisplayText("Cable Trays")]
+        OST_CableTray = -2008130,
+        [DisplayText("Conduit Fitting Tags")]
+        OST_ConduitFittingTags = -2008129,
+        [DisplayText("Conduit Fittings")]
+        OST_ConduitFitting = -2008128,
+        [DisplayText("Cable Tray Fitting Tags")]
+        OST_CableTrayFittingTags = -2008127,
+        [DisplayText("Cable Tray Fittings")]
+        OST_CableTrayFitting = -2008126,
+        [DisplayText("Routing Preferences")]
+        OST_RoutingPreferences = -2008125,
+        [DisplayText("Duct Linings")]
+        OST_DuctLinings = -2008124,
+        [DisplayText("Duct Insulations")]
+        OST_DuctInsulations = -2008123,
+        [DisplayText("Pipe Insulations")]
+        OST_PipeInsulations = -2008122,
+        [DisplayText("Zone Tags")]
+        OST_ZoneTags = -2008115,
+        [DisplayText("HVAC Zones")]
+        OST_HVAC_Zones = -2008107,
+        [DisplayText("Switch System")]
+        OST_SwitchSystem = -2008101,
+        [DisplayText("Sprinkler Tags")]
+        OST_SprinklerTags = -2008100,
+        [DisplayText("Sprinklers")]
+        OST_Sprinklers = -2008099,
+        [DisplayText("Lighting Device Tags")]
+        OST_LightingDeviceTags = -2008088,
+        [DisplayText("Lighting Devices")]
+        OST_LightingDevices = -2008087,
+        [DisplayText("Fire Alarm Device Tags")]
+        OST_FireAlarmDeviceTags = -2008086,
+        [DisplayText("Fire Alarm Devices")]
+        OST_FireAlarmDevices = -2008085,
+        [DisplayText("Data Device Tags")]
+        OST_DataDeviceTags = -2008084,
+        [DisplayText("Data Devices")]
+        OST_DataDevices = -2008083,
+        [DisplayText("Communication Device Tags")]
+        OST_CommunicationDeviceTags = -2008082,
+        [DisplayText("Communication Devices")]
+        OST_CommunicationDevices = -2008081,
+        [DisplayText("Security Device Tags")]
+        OST_SecurityDeviceTags = -2008080,
+        [DisplayText("Security Devices")]
+        OST_SecurityDevices = -2008079,
+        [DisplayText("Nurse Call Device Tags")]
+        OST_NurseCallDeviceTags = -2008078,
+        [DisplayText("Nurse Call Devices")]
+        OST_NurseCallDevices = -2008077,
+        [DisplayText("Telephone Device Tags")]
+        OST_TelephoneDeviceTags = -2008076,
+        [DisplayText("Telephone Devices")]
+        OST_TelephoneDevices = -2008075,
+        [DisplayText("Duct Fitting Tags")]
+        OST_DuctFittingTags = -2008061,
+        [DisplayText("Pipe Fitting Tags")]
+        OST_PipeFittingTags = -2008060,
+        [DisplayText("Pipe Color Fill")]
+        OST_PipeColorFills = -2008059,
+        [DisplayText("Pipe Color Fill Legends")]
+        OST_PipeColorFillLegends = -2008058,
+        [DisplayText("Wire Tags")]
+        OST_WireTags = -2008057,
+        [DisplayText("Pipe Accessory Tags")]
+        OST_PipeAccessoryTags = -2008056,
+        [DisplayText("Pipe Accessories")]
+        OST_PipeAccessory = -2008055,
+        [DisplayText("Flex Pipes")]
+        OST_FlexPipeCurves = -2008050,
+        [DisplayText("Pipe Fittings")]
+        OST_PipeFitting = -2008049,
+        [DisplayText("Flex Pipe Tags")]
+        OST_FlexPipeTags = -2008048,
+        [DisplayText("Pipe Tags")]
+        OST_PipeTags = -2008047,
+        [DisplayText("Pipes")]
+        OST_PipeCurves = -2008044,
+        [DisplayText("Piping Systems")]
+        OST_PipingSystem = -2008043,
+        [DisplayText("Wires")]
+        OST_Wire = -2008039,
+        [DisplayText("Electrical Circuits")]
+        OST_ElectricalCircuit = -2008037,
+        [DisplayText("Flex Ducts")]
+        OST_FlexDuctCurves = -2008020,
+        [DisplayText("Duct Accessory Tags")]
+        OST_DuctAccessoryTags = -2008017,
+        [DisplayText("Duct Accessories")]
+        OST_DuctAccessory = -2008016,
+        [DisplayText("Duct Systems")]
+        OST_DuctSystem = -2008015,
+        [DisplayText("Air Terminal Tags")]
+        OST_DuctTerminalTags = -2008014,
+        [DisplayText("Air Terminals")]
+        OST_DuctTerminal = -2008013,
+        [DisplayText("Duct Fittings")]
+        OST_DuctFitting = -2008010,
+        [DisplayText("Duct Color Fill")]
+        OST_DuctColorFills = -2008005,
+        [DisplayText("Flex Duct Tags")]
+        OST_FlexDuctTags = -2008004,
+        [DisplayText("Duct Tags")]
+        OST_DuctTags = -2008003,
+        [DisplayText("Ducts")]
+        OST_DuctCurves = -2008000,
+        [DisplayText("Duct Color Fill Legends")]
+        OST_DuctColorFillLegends = -2007004,
+        [DisplayText("Structural Tendon Tags")]
+        OST_StructuralTendonTags = -2006276,
+        [DisplayText("Structural Tendons")]
+        OST_StructuralTendons = -2006274,
+        [DisplayText("Expansion Joint Tags")]
+        OST_ExpansionJointTags = -2006273,
+        [DisplayText("Expansion Joints")]
+        OST_ExpansionJoints = -2006271,
+        [DisplayText("Vibration Isolator Tags")]
+        OST_VibrationIsolatorTags = -2006266,
+        [DisplayText("Vibration Damper Tags")]
+        OST_VibrationDamperTags = -2006264,
+        [DisplayText("Vibration Management")]
+        OST_VibrationManagement = -2006261,
+        [DisplayText("Bridge Framing Tags")]
+        OST_BridgeFramingTags = -2006243,
+        [DisplayText("Bridge Framing")]
+        OST_BridgeFraming = -2006241,
+        [DisplayText("Pier Wall Tags")]
+        OST_PierWallTags = -2006230,
+        [DisplayText("Pier Pile Tags")]
+        OST_PierPileTags = -2006226,
+        [DisplayText("Pier Column Tags")]
+        OST_PierColumnTags = -2006222,
+        [DisplayText("Pier Cap Tags")]
+        OST_PierCapTags = -2006220,
+        [DisplayText("Approach Slab Tags")]
+        OST_ApproachSlabTags = -2006211,
+        [DisplayText("Abutment Wall Tags")]
+        OST_AbutmentWallTags = -2006210,
+        [DisplayText("Abutment Pile Tags")]
+        OST_AbutmentPileTags = -2006209,
+        [DisplayText("Abutment Foundation Tags")]
+        OST_AbutmentFoundationTags = -2006208,
+        [DisplayText("Bearing Tags")]
+        OST_BridgeBearingTags = -2006178,
+        [DisplayText("Pier Foundation Tags")]
+        OST_BridgeFoundationTags = -2006176,
+        [DisplayText("Bridge Deck Tags")]
+        OST_BridgeDeckTags = -2006175,
+        [DisplayText("Bridge Cable Tags")]
+        OST_BridgeCableTags = -2006173,
+        [DisplayText("Pier Tower Tags")]
+        OST_BridgeTowerTags = -2006172,
+        [DisplayText("Pier Tags")]
+        OST_BridgePierTags = -2006171,
+        [DisplayText("Abutment Tags")]
+        OST_BridgeAbutmentTags = -2006170,
+        [DisplayText("Bearings")]
+        OST_BridgeBearings = -2006138,
+        [DisplayText("Bridge Decks")]
+        OST_BridgeDecks = -2006135,
+        [DisplayText("Bridge Cables")]
+        OST_BridgeCables = -2006133,
+        [DisplayText("Piers")]
+        OST_BridgePiers = -2006131,
+        [DisplayText("Abutments")]
+        OST_BridgeAbutments = -2006130,
+        [DisplayText("Brace in Plan View Symbols")]
+        OST_StructuralBracePlanReps = -2006110,
+        [DisplayText("Connection Symbols")]
+        OST_StructConnectionSymbols = -2006100,
+        [DisplayText("Structural Annotations")]
+        OST_StructuralAnnotations = -2006090,
+        [DisplayText("Revision Cloud Tags")]
+        OST_RevisionCloudTags = -2006080,
+        [DisplayText("Revision")]
+        OST_Revisions = -2006070,
+        [DisplayText("Revision Clouds")]
+        OST_RevisionClouds = -2006060,
+        [DisplayText("Elevation Marks")]
+        OST_ElevationMarks = -2006045,
+        [DisplayText("Grid Heads")]
+        OST_GridHeads = -2006040,
+        [DisplayText("Level Heads")]
+        OST_LevelHeads = -2006020,
+        [DisplayText("Scope Boxes")]
+        OST_VolumeOfInterest = -2006000,
+        [DisplayText("Boundary Conditions")]
+        OST_BoundaryConditions = -2005301,
+        [DisplayText("Internal Area Load Tags")]
+        OST_InternalAreaLoadTags = -2005255,
+        [DisplayText("Internal Line Load Tags")]
+        OST_InternalLineLoadTags = -2005254,
+        [DisplayText("Internal Point Load Tags")]
+        OST_InternalPointLoadTags = -2005253,
+        [DisplayText("Area Load Tags")]
+        OST_AreaLoadTags = -2005252,
+        [DisplayText("Line Load Tags")]
+        OST_LineLoadTags = -2005251,
+        [DisplayText("Point Load Tags")]
+        OST_PointLoadTags = -2005250,
+        [DisplayText("Structural Load Cases")]
+        OST_LoadCases = -2005210,
+        [DisplayText("Structural Internal Loads")]
+        OST_InternalLoads = -2005204,
+        [DisplayText("Structural Loads")]
+        OST_Loads = -2005200,
+        [DisplayText("Structural Beam System Tags")]
+        OST_BeamSystemTags = -2005130,
+        [DisplayText("Foundation Span Direction Symbol")]
+        OST_FootingSpanDirectionSymbol = -2005111,
+        [DisplayText("Span Direction Symbol")]
+        OST_SpanDirectionSymbol = -2005110,
+        [DisplayText("Spot Elevation Symbols")]
+        OST_SpotElevSymbols = -2005100,
+        [DisplayText("Multi Leader Tag")]
+        OST_MultiLeaderTag = -2005033,
+        [DisplayText("Curtain Wall Mullion Tags")]
+        OST_CurtainWallMullionTags = -2005032,
+        [DisplayText("Structural Truss Tags")]
+        OST_TrussTags = -2005030,
+        [DisplayText("Keynote Tags")]
+        OST_KeynoteTags = -2005029,
+        [DisplayText("Detail Item Tags")]
+        OST_DetailComponentTags = -2005028,
+        [DisplayText("Material Tags")]
+        OST_MaterialTags = -2005027,
+        [DisplayText("Floor Tags")]
+        OST_FloorTags = -2005026,
+        [DisplayText("Curtain System Tags")]
+        OST_CurtaSystemTags = -2005025,
+        [DisplayText("Stair Tags")]
+        OST_StairsTags = -2005023,
+        [DisplayText("Multi-Category Tags")]
+        OST_MultiCategoryTags = -2005022,
+        [DisplayText("Planting Tags")]
+        OST_PlantingTags = -2005021,
+        [DisplayText("Area Tags")]
+        OST_AreaTags = -2005020,
+        [DisplayText("Structural Foundation Tags")]
+        OST_StructuralFoundationTags = -2005019,
+        [DisplayText("Structural Column Tags")]
+        OST_StructuralColumnTags = -2005018,
+        [DisplayText("Parking Tags")]
+        OST_ParkingTags = -2005017,
+        [DisplayText("Site Tags")]
+        OST_SiteTags = -2005016,
+        [DisplayText("Structural Framing Tags")]
+        OST_StructuralFramingTags = -2005015,
+        [DisplayText("Specialty Equipment Tags")]
+        OST_SpecialityEquipmentTags = -2005014,
+        [DisplayText("Generic Model Tags")]
+        OST_GenericModelTags = -2005013,
+        [DisplayText("Curtain Panel Tags")]
+        OST_CurtainWallPanelTags = -2005012,
+        [DisplayText("Wall Tags")]
+        OST_WallTags = -2005011,
+        [DisplayText("Plumbing Fixture Tags")]
+        OST_PlumbingFixtureTags = -2005010,
+        [DisplayText("Mechanical Equipment Tags")]
+        OST_MechanicalEquipmentTags = -2005009,
+        [DisplayText("Lighting Fixture Tags")]
+        OST_LightingFixtureTags = -2005008,
+        [DisplayText("Furniture System Tags")]
+        OST_FurnitureSystemTags = -2005007,
+        [DisplayText("Furniture Tags")]
+        OST_FurnitureTags = -2005006,
+        [DisplayText("Electrical Fixture Tags")]
+        OST_ElectricalFixtureTags = -2005004,
+        [DisplayText("Electrical Equipment Tags")]
+        OST_ElectricalEquipmentTags = -2005003,
+        [DisplayText("Ceiling Tags")]
+        OST_CeilingTags = -2005002,
+        [DisplayText("Casework Tags")]
+        OST_CaseworkTags = -2005001,
+        [DisplayText("Spaces")]
+        OST_MEPSpaces = -2003600,
+        [DisplayText("Mass Floor Tags")]
+        OST_MassAreaFaceTags = -2003410,
+        [DisplayText("Mass Tags")]
+        OST_MassTags = -2003405,
+        [DisplayText("Mass")]
+        OST_Mass = -2003400,
+        [DisplayText("Areas")]
+        OST_Areas = -2003200,
+        [DisplayText("Project Information")]
+        OST_ProjectInformation = -2003101,
+        [DisplayText("Sheets")]
+        OST_Sheets = -2003100,
+        [DisplayText("Detail Items")]
+        OST_DetailComponents = -2002000,
+        [DisplayText("Entourage")]
+        OST_Entourage = -2001370,
+        [DisplayText("Planting")]
+        OST_Planting = -2001360,
+        [DisplayText("Structural Stiffener Tags")]
+        OST_StructuralStiffenerTags = -2001355,
+        [DisplayText("Structural Stiffeners")]
+        OST_StructuralStiffener = -2001354,
+        [DisplayText("RVT Links")]
+        OST_RvtLinks = -2001352,
+        [DisplayText("Specialty Equipment")]
+        OST_SpecialityEquipment = -2001350,
+        [DisplayText("Topography")]
+        OST_Topography = -2001340,
+        [DisplayText("Structural Trusses")]
+        OST_StructuralTruss = -2001336,
+        [DisplayText("Structural Columns")]
+        OST_StructuralColumns = -2001330,
+        [DisplayText("Structural Beam Systems")]
+        OST_StructuralFramingSystem = -2001327,
+        [DisplayText("Structural Framing")]
+        OST_StructuralFraming = -2001320,
+        [DisplayText("Structural Foundations")]
+        OST_StructuralFoundation = -2001300,
+        [DisplayText("Property Line Segment Tags")]
+        OST_SitePropertyLineSegmentTags = -2001269,
+        [DisplayText("Property Tags")]
+        OST_SitePropertyTags = -2001267,
+        [DisplayText("Site")]
+        OST_Site = -2001260,
+        [DisplayText("Road Tags")]
+        OST_RoadTags = -2001221,
+        [DisplayText("Roads")]
+        OST_Roads = -2001220,
+        [DisplayText("Parking")]
+        OST_Parking = -2001180,
+        [DisplayText("Plumbing Fixtures")]
+        OST_PlumbingFixtures = -2001160,
+        [DisplayText("Mechanical Equipment")]
+        OST_MechanicalEquipment = -2001140,
+        [DisplayText("Lighting Fixtures")]
+        OST_LightingFixtures = -2001120,
+        [DisplayText("Furniture Systems")]
+        OST_FurnitureSystems = -2001100,
+        [DisplayText("Signage Tags")]
+        OST_SignageTags = -2001061,
+        [DisplayText("Electrical Fixtures")]
+        OST_ElectricalFixtures = -2001060,
+        [DisplayText("Signage")]
+        OST_Signage = -2001058,
+        [DisplayText("Audio Visual Device Tags")]
+        OST_AudioVisualDeviceTags = -2001057,
+        [DisplayText("Audio Visual Devices")]
+        OST_AudioVisualDevices = -2001055,
+        [DisplayText("Vertical Circulation Tags")]
+        OST_VerticalCirculationTags = -2001054,
+        [DisplayText("Vertical Circulation")]
+        OST_VerticalCirculation = -2001052,
+        [DisplayText("Fire Protection Tags")]
+        OST_FireProtectionTags = -2001051,
+        [DisplayText("Fire Protection")]
+        OST_FireProtection = -2001049,
+        [DisplayText("Medical Equipment Tags")]
+        OST_MedicalEquipmentTags = -2001048,
+        [DisplayText("Medical Equipment")]
+        OST_MedicalEquipment = -2001046,
+        [DisplayText("Food Service Equipment Tags")]
+        OST_FoodServiceEquipmentTags = -2001045,
+        [DisplayText("Food Service Equipment")]
+        OST_FoodServiceEquipment = -2001043,
+        [DisplayText("Temporary Structure Tags")]
+        OST_TemporaryStructureTags = -2001042,
+        [DisplayText("Electrical Equipment")]
+        OST_ElectricalEquipment = -2001040,
+        [DisplayText("Temporary Structures")]
+        OST_TemporaryStructure = -2001039,
+        [DisplayText("Hardscape Tags")]
+        OST_HardscapeTags = -2001038,
+        [DisplayText("Hardscape")]
+        OST_Hardscape = -2001036,
+        [DisplayText("Alignment Station Labels")]
+        OST_AlignmentStationLabels = -2001017,
+        [DisplayText("Alignment Station Label Sets")]
+        OST_AlignmentStationLabelSets = -2001016,
+        [DisplayText("Alignment Tags")]
+        OST_AlignmentsTags = -2001015,
+        [DisplayText("Alignments")]
+        OST_Alignments = -2001012,
+        [DisplayText("Zone Equipment")]
+        OST_ZoneEquipment = -2001010,
+        [DisplayText("Water Loops")]
+        OST_MEPAnalyticalWaterLoop = -2001009,
+        [DisplayText("Air Systems")]
+        OST_MEPAnalyticalAirLoop = -2001008,
+        [DisplayText("System-Zone Tags")]
+        OST_MEPSystemZoneTags = -2001007,
+        [DisplayText("System-Zones")]
+        OST_MEPSystemZone = -2001001,
+        [DisplayText("Casework")]
+        OST_Casework = -2001000,
+        [DisplayText("Shaft Openings")]
+        OST_ShaftOpening = -2000996,
+        [DisplayText("Mechanical Equipment Set Boundary Lines")]
+        OST_MechanicalEquipmentSetBoundaryLines = -2000987,
+        [DisplayText("Mechanical Equipment Set Tags")]
+        OST_MechanicalEquipmentSetTags = -2000986,
+        [DisplayText("Mechanical Equipment Sets")]
+        OST_MechanicalEquipmentSet = -2000985,
+        [DisplayText("Analytical Pipe Connections")]
+        OST_AnalyticalPipeConnections = -2000983,
+        [DisplayText("Coordination Model")]
+        OST_Coordination_Model = -2000982,
+        [DisplayText("Multi-Rebar Annotations")]
+        OST_MultiReferenceAnnotations = -2000970,
+        [DisplayText("Analytical Node Tags")]
+        OST_NodeAnalyticalTags = -2000956,
+        [DisplayText("Analytical Link Tags")]
+        OST_LinkAnalyticalTags = -2000955,
+        [DisplayText("Stair Tread/Riser Numbers")]
+        OST_StairsTriserNumbers = -2000944,
+        [DisplayText("Stair Support Tags")]
+        OST_StairsSupportTags = -2000942,
+        [DisplayText("Stair Landing Tags")]
+        OST_StairsLandingTags = -2000941,
+        [DisplayText("Stair Run Tags")]
+        OST_StairsRunTags = -2000940,
+        [DisplayText("Stair Paths")]
+        OST_StairsPaths = -2000938,
+        [DisplayText("Adaptive Points")]
+        OST_AdaptivePoints = -2000900,
+        [DisplayText("Path of Travel Tags")]
+        OST_PathOfTravelTags = -2000834,
+        [DisplayText("Reference Points")]
+        OST_ReferencePoints = -2000710,
+        [DisplayText("Materials")]
+        OST_Materials = -2000700,
+        [DisplayText("Schedules")]
+        OST_Schedules = -2000573,
+        [DisplayText("Schedule Graphics")]
+        OST_ScheduleGraphics = -2000570,
+        [DisplayText("Raster Images")]
+        OST_RasterImages = -2000560,
+        [DisplayText("Color Fill Legends")]
+        OST_ColorFillLegends = -2000550,
+        [DisplayText("Annotation Crop Boundary")]
+        OST_AnnotationCrop = -2000547,
+        [DisplayText("Callout Boundary")]
+        OST_CalloutBoundary = -2000539,
+        [DisplayText("Callout Heads")]
+        OST_CalloutHeads = -2000538,
+        [DisplayText("Callouts")]
+        OST_Callouts = -2000537,
+        [DisplayText("Crop Boundaries")]
+        OST_CropBoundary = -2000536,
+        [DisplayText("Elevations")]
+        OST_Elev = -2000535,
+        [DisplayText("Reference Planes")]
+        OST_CLines = -2000530,
+        [DisplayText("View Titles")]
+        OST_ViewportLabel = -2000515,
+        [DisplayText("Viewports")]
+        OST_Viewports = -2000510,
+        [DisplayText("Cameras")]
+        OST_Camera_Lines = -2000501,
+        [DisplayText("Space Tags")]
+        OST_MEPSpaceTags = -2000485,
+        [DisplayText("Room Tags")]
+        OST_RoomTags = -2000480,
+        [DisplayText("Door Tags")]
+        OST_DoorTags = -2000460,
+        [DisplayText("Window Tags")]
+        OST_WindowTags = -2000450,
+        [DisplayText("Section Marks")]
+        OST_SectionHeads = -2000400,
+        [DisplayText("Contour Labels")]
+        OST_ContourLabels = -2000350,
+        [DisplayText("Curtain Systems")]
+        OST_CurtaSystem = -2000340,
+        [DisplayText("Analysis Display Style")]
+        OST_AnalysisDisplayStyle = -2000304,
+        [DisplayText("Analysis Results")]
+        OST_AnalysisResults = -2000303,
+        [DisplayText("Render Regions")]
+        OST_RenderRegions = -2000302,
+        [DisplayText("Section Boxes")]
+        OST_SectionBox = -2000301,
+        [DisplayText("Text Notes")]
+        OST_TextNotes = -2000300,
+        [DisplayText("Title Blocks")]
+        OST_TitleBlocks = -2000280,
+        [DisplayText("Views")]
+        OST_Views = -2000279,
+        [DisplayText("Part Tags")]
+        OST_PartTags = -2000270,
+        [DisplayText("Parts")]
+        OST_Parts = -2000269,
+        [DisplayText("Assembly Tags")]
+        OST_AssemblyTags = -2000268,
+        [DisplayText("Assemblies")]
+        OST_Assemblies = -2000267,
+        [DisplayText("Roof Tags")]
+        OST_RoofTags = -2000266,
+        [DisplayText("Spot Slopes")]
+        OST_SpotSlopes = -2000265,
+        [DisplayText("Spot Coordinates")]
+        OST_SpotCoordinates = -2000264,
+        [DisplayText("Spot Elevations")]
+        OST_SpotElevations = -2000263,
+        [DisplayText("Dimensions")]
+        OST_Dimensions = -2000260,
+        [DisplayText("Levels")]
+        OST_Levels = -2000240,
+        [DisplayText("Displacement Path")]
+        OST_DisplacementPath = -2000223,
+        [DisplayText("Grids")]
+        OST_Grids = -2000220,
+        [DisplayText("Section Line")]
+        OST_SectionLine = -2000201,
+        [DisplayText("Sections")]
+        OST_Sections = -2000200,
+        [DisplayText("View Reference")]
+        OST_ReferenceViewerSymbol = -2000197,
+        [DisplayText("Imports in Families")]
+        OST_ImportObjectStyles = -2000196,
+        [DisplayText("Masking Region")]
+        OST_MaskingRegion = -2000194,
+        [DisplayText("Matchline")]
+        OST_Matchline = -2000193,
+        [DisplayText("Plan Region")]
+        OST_PlanRegion = -2000191,
+        [DisplayText("Filled region")]
+        OST_FilledRegion = -2000190,
+        [DisplayText("Ramps")]
+        OST_Ramps = -2000180,
+        [DisplayText("Curtain Grids")]
+        OST_CurtainGrids = -2000173,
+        [DisplayText("Curtain Wall Mullions")]
+        OST_CurtainWallMullions = -2000171,
+        [DisplayText("Curtain Panels")]
+        OST_CurtainWallPanels = -2000170,
+        [DisplayText("Rooms")]
+        OST_Rooms = -2000160,
+        [DisplayText("Generic Models")]
+        OST_GenericModel = -2000151,
+        [DisplayText("Generic Annotations")]
+        OST_GenericAnnotation = -2000150,
+        [DisplayText("Railing Tags")]
+        OST_StairsRailingTags = -2000133,
+        [DisplayText("Railings")]
+        OST_StairsRailing = -2000126,
+        [DisplayText("Stairs")]
+        OST_Stairs = -2000120,
+        [DisplayText("Guide Grid")]
+        OST_GuideGrid = -2000107,
+        [DisplayText("Columns")]
+        OST_Columns = -2000100,
+        [DisplayText("Model Groups")]
+        OST_IOSModelGroups = -2000095,
+        [DisplayText("Reference Lines")]
+        OST_ReferenceLines = -2000083,
+        [DisplayText("Furniture")]
+        OST_Furniture = -2000080,
+        [DisplayText("Lines")]
+        OST_Lines = -2000051,
+        [DisplayText("Ceilings")]
+        OST_Ceilings = -2000038,
+        [DisplayText("Roofs")]
+        OST_Roofs = -2000035,
+        [DisplayText("Floors")]
+        OST_Floors = -2000032,
+        [DisplayText("Doors")]
+        OST_Doors = -2000023,
+        [DisplayText("Windows")]
+        OST_Windows = -2000014,
+        [DisplayText("Walls")]
+        OST_Walls = -2000011,
+    }
+}

--- a/Revit_oM/Enums/Category.cs
+++ b/Revit_oM/Enums/Category.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base.Attributes;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base.Attributes;
 
 namespace BH.oM.Revit.Enums
 {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1226
Closes #1295

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231312%2DCategoriesAsEnum&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - open your fav model and try pulling by category chosen from dropdown. Dropdown UX improvement has been proposed in https://github.com/BHoM/Grasshopper_UI/pull/677 and https://github.com/BHoM/BHoM_UI/pull/450.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.oM.Revit.Enums.Category` added with all Revit categories along with human-readable labels in attributes
- category matching mechanism has been refined in a way that if a category is correctly added to the above enum, it will both appear in the UI dropdown as well as become available in `BH.Revit.Engine.Core.Query.BuiltInCategory(string, bool)`
- `CategoriesWithNames` method added that returns a collection of built in categories with correspondent labels that are consistently supported by the system

### Additional comments
<!-- As required -->
Now we should be able to freely extend the list of supported categories @travispotterBH - for now I added `Revision` from the nonstandard ones.