### PR TITLE
Convert from Revit to MeshElement stopped from crashing in case of invalid Revit geometry

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/FromRevit/MeshElement.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/MeshElement.cs
@@ -56,11 +56,18 @@ namespace BH.Revit.Engine.Core
 
             Options meshOptions = Create.Options(ViewDetailLevel.Medium, false, false);
 
-            meshElement = new MeshElement()
+            meshElement = new MeshElement { Name = element.Name };
+            if (element.Location != null)
             {
-                Name = element.Name,
-                Mesh = element.MeshedGeometry(meshOptions, settings)?.Join(false)
-            };
+                try
+                {
+                    meshElement.Mesh = element.MeshedGeometry(meshOptions, settings)?.Join(false);
+                }
+                catch
+                {
+                    BH.Engine.Base.Compute.RecordWarning($"Mesh extraction from element {element.Name}, ElementId: {element.Id} failed.");
+                }
+            }
 
             //Set identifiers, parameters & custom data
             meshElement.SetIdentifiers(element);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1319

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231321%2DMeshElementConvertBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->