### PR TITLE
Fix null exception on pulling Nurbs bars

### DIFF
--- a/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
+++ b/Revit_Core_Engine/Convert/Structure/FromRevit/Bars.cs
@@ -28,6 +28,7 @@ using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Base.Attributes;
+using BH.oM.Geometry;
 using BH.oM.Spatial.ShapeProfiles;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.MaterialFragments;
@@ -137,6 +138,12 @@ namespace BH.Revit.Engine.Core
             bars = new List<Bar>();
             if (locationCurve != null)
             {
+                if (locationCurve is NurbsCurve)
+                {
+                    BH.Engine.Base.Compute.RecordWarning($"Cannot pull Revit ElementID {familyInstance.Id.IntegerValue} because its location is of an unsupported type: NurbsCurve.");
+                    return bars;
+                }
+
                 //TODO: check category of familyInstance to recognize which rotation query to use
                 double rotation = familyInstance.OrientationAngle(settings);
                 foreach (BH.oM.Geometry.Line line in locationCurve.ICollapseToPolyline(Math.PI / 12).SubParts())


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1323 

<!-- Add short description of what has been fixed -->
Added a check on location curve type to prevent a null reference.

### Test files
<!-- Link to test files to validate the proposed changes -->
Requires Revit 2022.
[SharePoint folder](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%231323-FixNullExceptionOnPullingNurbsBars?csf=1&web=1&e=miI65E)

Pull any Revit beam that is based on a Nurbs curve. Any ID below will do:
1208663, 1208973, 1209221, 1209288, 1209467, 1209792, 1209794, 1209824, 1209826, 1209828, 1209830, 1209832, 1209834, 1209836, 1209876, 1209878, 1209880, 1209882, 1209884, 1209886, 1209888, 1209930, 1209932, 1209934, 1209936, 1209938, 1209940, 1209942, 1209982, 1209984, 1209986, 1209988, 1209990, 1209992, 1209994, 1210036, 1210038, 1210040, 1210042, 1210044, 1210046, 1210048, 1211097, 1211099, 1211101, 1211103, 1211105, 1211117, 1211119, 1211121, 1211125, 1211127, 1211129, 1211131, 1211133, 1211135, 1211137, 1211139, 1211141, 1211143, 1211145, 1211147, 1211149, 1211153, 1211155, 1211157, 1211159, 1211161, 1211163, 1211165, 1211167, 1211169, 1211171, 1211173, 1211175, 1211177, 1211179, 1211181, 1211183, 1211185, 1211187, 1211189, 1215099, 1215101, 1215103, 1215105, 1215107, 1215119, 1215121, 1215123, 1215127, 1215129, 1215131, 1215133, 1215135, 1215137, 1215139, 1215141, 1215143, 1215145, 1215147, 1215149, 1215151, 1215155, 1215157, 1215159, 1215161, 1215163, 1215165, 1215167, 1215169, 1215171, 1215173, 1215175, 1215177, 1215179, 1215181, 1215183, 1215185, 1215187, 1215189, 1215191,

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Fix null exception on pulling Nurbs bars
