### PR TITLE
Revit_Engine: fix the copy of the DiffingConfig properties

### DIFF
--- a/Revit_Engine/Compute/RevitDiffing.cs
+++ b/Revit_Engine/Compute/RevitDiffing.cs
@@ -150,8 +150,7 @@ namespace BH.Engine.Adapters.Revit
             {
                 rcc = new RevitComparisonConfig();
 
-                if (diffConfig != null)
-                    BH.Engine.Reflection.Modify.CopyPropertiesFromParent(rcc, diffConfig?.ComparisonConfig);
+                BH.Engine.Reflection.Modify.CopyPropertiesFromParent(rcc, diffConfig?.ComparisonConfig);
             }
 
             // Get the past and following RevitIdentifiers fragments.
@@ -183,7 +182,7 @@ namespace BH.Engine.Adapters.Revit
                 followingIds = followingIdFragments.Select(x => x.PersistentId.ToString()).ToList();
             }
 
-             //Check for duplicate ids
+            //Check for duplicate ids
             bool dupsInPastIds = pastIds.Count != pastIds.Distinct().Count();
             bool dupsInFollIds = followingIds.Count != followingIds.Distinct().Count();
 
@@ -194,7 +193,7 @@ namespace BH.Engine.Adapters.Revit
                 if (dupsInFollIds) messageSubjects.Add(nameof(followingObjects));
                 string message = $"Some of the {string.Join(" and ", messageSubjects)} contain duplicate {revitIdName}s. ";
 
-                if((dupsInPastIds && pastObjects.Any(x => x.GetType().Namespace.Contains("Structure"))) || 
+                if ((dupsInPastIds && pastObjects.Any(x => x.GetType().Namespace.Contains("Structure"))) ||
                     (dupsInFollIds && followingObjects.Any(x => x.GetType().Namespace.Contains("Structure"))))
                     message += "\nIf trying to diff structural objects, try pulling using the Phsyical discipline rather than Structural discipline, as models containing disjointed floors and walls and/or curved beams lead to one Revit element being converted into multiple structural BHoM elements.";
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1333

<!-- Add short description of what has been fixed -->
Fixes some mistakes in the assignment of the properties to the DiffingConfig during the RevitDiffing.  
This removes some side-effects in edge cases like when using the `RevitComparisonConfig.ParameterNumericTolerances` feature.

### Test files
<!-- Link to test files to validate the proposed changes -->
Run the tests in DiffingTests prototypes. All must pass. The relevant ones are the ones linked in https://github.com/BHoM/DiffingTests_Prototypes/issues/10: in the `RevitDiffingTests` project, look for  `PropertyNumericTolerances_Equal` and `PropertyNumericTolerances_Different` (in the test class `RevitObjectDifferencesTests`).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixes bug that created side-effects in edge cases like when using the `RevitComparisonConfig.ParameterNumericTolerances` feature.

### Additional comments
<!-- As required -->