### PR TITLE
Initial LightingFixture Convert Method and Read/Create Capability

### DIFF
--- a/Revit_Core_Engine/Convert/Lighting/FromRevit/Luminaire.cs
+++ b/Revit_Core_Engine/Convert/Lighting/FromRevit/Luminaire.cs
@@ -54,7 +54,7 @@ namespace BH.Revit.Engine.Core
             {
                 Name = revitLightingFixture.FamilyTypeFullName(),
                 Position = (revitLightingFixture.Location as LocationPoint)?.Point?.PointFromRevit(),
-                Direction = (revitLightingFixture.GetTotalTransform().BasisZ.VectorFromRevit())
+                Orientation = (revitLightingFixture.GetTotalTransform().BasisFromRevit())
             };
             
             // Set type

--- a/Revit_Core_Engine/Convert/Lighting/FromRevit/Luminaire.cs
+++ b/Revit_Core_Engine/Convert/Lighting/FromRevit/Luminaire.cs
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        [Description("Convert a Revit family instance that is a lighting fixture.")]
+        [Input("revitLightingFixture", "Revit family instance to be converted.")]
+        [Input("settings", "Revit adapter settings.")]
+        [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("luminaire", "BHoM Luminaire object converted from a Revit lighting fixture element.")]
+        public static BH.oM.Lighting.Elements.Luminaire LuminaireFromRevit (this FamilyInstance revitLightingFixture, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            settings = settings.DefaultIfNull();
+            
+            // Reuse a BHoM obj from refObjects it it has been converted before
+            BH.oM.Lighting.Elements.Luminaire bhomLight = refObjects.GetValue<BH.oM.Lighting.Elements.Luminaire>(revitLightingFixture.Id);
+            if (bhomLight != null)
+                return bhomLight;
+
+            bhomLight = new BH.oM.Lighting.Elements.Luminaire()
+            {
+                Name = revitLightingFixture.FamilyTypeFullName(),
+                Position = (revitLightingFixture.Location as LocationPoint)?.Point?.PointFromRevit(),
+                Direction = (revitLightingFixture.GetTotalTransform().BasisZ.VectorFromRevit())
+            };
+            
+            // Set type
+            bhomLight.LuminaireType = revitLightingFixture.LuminaireTypeFromRevit(settings, refObjects);
+
+            // Set identifiers, parameters & custom data
+            bhomLight.SetIdentifiers(revitLightingFixture);
+            bhomLight.CopyParameters(revitLightingFixture, settings.MappingSettings);
+            bhomLight.SetProperties(revitLightingFixture, settings.MappingSettings);
+
+            refObjects.AddOrReplace(revitLightingFixture.Id, bhomLight);
+            return bhomLight;
+        }
+        
+        /***************************************************/
+    }
+}
+
+
+

--- a/Revit_Core_Engine/Convert/Lighting/FromRevit/Luminaire.cs
+++ b/Revit_Core_Engine/Convert/Lighting/FromRevit/Luminaire.cs
@@ -58,7 +58,7 @@ namespace BH.Revit.Engine.Core
             };
             
             // Set type
-            bhomLight.LuminaireType = revitLightingFixture.LuminaireTypeFromRevit(settings, refObjects);
+            bhomLight.LuminaireType = revitLightingFixture.Symbol.LuminaireTypeFromRevit(settings, refObjects);
 
             // Set identifiers, parameters & custom data
             bhomLight.SetIdentifiers(revitLightingFixture);

--- a/Revit_Core_Engine/Convert/Lighting/FromRevit/LuminaireType.cs
+++ b/Revit_Core_Engine/Convert/Lighting/FromRevit/LuminaireType.cs
@@ -56,7 +56,7 @@ namespace BH.Revit.Engine.Core
 
             luminaireType = new LuminaireType
             {
-                Name = familySymbol.Family.Name + " : " + familySymbol.Name,
+                Name = familySymbol.FamilyTypeFullName(),
             };
 
             //Set identifiers, parameters & custom data

--- a/Revit_Core_Engine/Convert/Lighting/FromRevit/LuminaireType.cs
+++ b/Revit_Core_Engine/Convert/Lighting/FromRevit/LuminaireType.cs
@@ -41,30 +41,30 @@ namespace BH.Revit.Engine.Core
         /****               Public Methods              ****/
         /***************************************************/
 
-        [Description("Extracts the LuminaireType from a Revit FamilyInstance.")]
-        [Input("familyInstance", "Revit FamilyInstance to be queried.")]
+        [Description("Converts Revit FamilySymbol to BHoM LuminaireType.")]
+        [Input("familySymbol", "Revit FamilySymbol to be queried.")]
         [Input("settings", "Revit adapter settings to be used while performing the convert.")]
         [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        [Output("LuminaireType", "BH.oM.Elements.Lighting.LuminaireType extracted from the input Revit FamilyInstance.")]
-        public static LuminaireType LuminaireTypeFromRevit(this FamilyInstance familyInstance, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        [Output("LuminaireType", "BH.oM.Elements.Lighting.LuminaireType extracted from the input Revit FamilySymbol.")]
+        public static LuminaireType LuminaireTypeFromRevit(this FamilySymbol familySymbol, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
 
-            LuminaireType luminaireType = refObjects.GetValue<LuminaireType>(familyInstance.Symbol.Id);
+            LuminaireType luminaireType = refObjects.GetValue<LuminaireType>(familySymbol.Id);
             if (luminaireType != null)
                 return luminaireType;
 
             luminaireType = new LuminaireType
             {
-                Name = familyInstance.Symbol.Name,
+                Name = familySymbol.Name,
             };
 
             //Set identifiers, parameters & custom data
-            luminaireType.SetIdentifiers(familyInstance.Symbol);
-            luminaireType.CopyParameters(familyInstance.Symbol, settings.MappingSettings);
-            luminaireType.SetProperties(familyInstance.Symbol, settings.MappingSettings);
+            luminaireType.SetIdentifiers(familySymbol);
+            luminaireType.CopyParameters(familySymbol, settings.MappingSettings);
+            luminaireType.SetProperties(familySymbol, settings.MappingSettings);
 
-            refObjects.AddOrReplace(familyInstance.Symbol.Id, luminaireType);
+            refObjects.AddOrReplace(familySymbol.Id, luminaireType);
             return luminaireType;
         }
 

--- a/Revit_Core_Engine/Convert/Lighting/FromRevit/LuminaireType.cs
+++ b/Revit_Core_Engine/Convert/Lighting/FromRevit/LuminaireType.cs
@@ -56,7 +56,8 @@ namespace BH.Revit.Engine.Core
 
             luminaireType = new LuminaireType
             {
-                Name = familySymbol.Name,
+                Name = familySymbol.Family.Name,
+                Model = familySymbol.Name,
             };
 
             //Set identifiers, parameters & custom data

--- a/Revit_Core_Engine/Convert/Lighting/FromRevit/LuminaireType.cs
+++ b/Revit_Core_Engine/Convert/Lighting/FromRevit/LuminaireType.cs
@@ -56,8 +56,7 @@ namespace BH.Revit.Engine.Core
 
             luminaireType = new LuminaireType
             {
-                Name = familySymbol.Family.Name,
-                Model = familySymbol.Name,
+                Name = familySymbol.Family.Name + " : " + familySymbol.Name,
             };
 
             //Set identifiers, parameters & custom data

--- a/Revit_Core_Engine/Convert/Lighting/LightingFixture.cs
+++ b/Revit_Core_Engine/Convert/Lighting/LightingFixture.cs
@@ -36,11 +36,11 @@ namespace BH.Revit.Engine.Core
         /****               Public Methods              ****/
         /***************************************************/
 
-        [Description("Convert a Revit family instance that is a fitting or an accessory to a BHoM Fitting.")]
+        [Description("Convert a Revit family instance that is a lighting fixture.")]
         [Input("revitLightingFixture", "Revit family instance to be converted.")]
         [Input("settings", "Revit adapter settings.")]
         [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
-        [Output("fitting", "BHoM fitting object converted from a Revit family instance element.")]
+        [Output("luminaire", "BHoM Luminaire object converted from a Revit lighting fixture element.")]
         public static BH.oM.Lighting.Elements.Luminaire LuminaireFromRevit (this FamilyInstance revitLightingFixture, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
         {
             settings = settings.DefaultIfNull();
@@ -53,7 +53,7 @@ namespace BH.Revit.Engine.Core
             bhomLight = new BH.oM.Lighting.Elements.Luminaire()
             {
                 Position = (revitLightingFixture.Location as LocationPoint)?.Point?.PointFromRevit(),
-                Direction = (revitLightingFixture.GetTransform().BasisZ.VectorFromRevit())
+                Direction = (revitLightingFixture.GetTotalTransform().BasisZ.VectorFromRevit())
             };
             bhomLight.LuminaireType = new oM.Lighting.Elements.LuminaireType()
             { Name = revitLightingFixture.FamilyTypeFullName() };

--- a/Revit_Core_Engine/Convert/Lighting/LightingFixture.cs
+++ b/Revit_Core_Engine/Convert/Lighting/LightingFixture.cs
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        [Description("Convert a Revit family instance that is a fitting or an accessory to a BHoM Fitting.")]
+        [Input("revitLightingFixture", "Revit family instance to be converted.")]
+        [Input("settings", "Revit adapter settings.")]
+        [Input("refObjects", "A collection of objects processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("fitting", "BHoM fitting object converted from a Revit family instance element.")]
+        public static BH.oM.Lighting.Elements.Luminaire LuminaireFromRevit (this FamilyInstance revitLightingFixture, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            settings = settings.DefaultIfNull();
+            
+            // Reuse a BHoM fitting from refObjects it it has been converted before
+            BH.oM.Lighting.Elements.Luminaire bhomLight = refObjects.GetValue<BH.oM.Lighting.Elements.Luminaire>(revitLightingFixture.Id);
+            if (bhomLight != null)
+                return bhomLight;
+
+            bhomLight = new BH.oM.Lighting.Elements.Luminaire()
+            {
+                Position = (revitLightingFixture.Location as LocationPoint)?.Point?.PointFromRevit(),
+                Direction = (revitLightingFixture.GetTransform().BasisZ.VectorFromRevit())
+            };
+            bhomLight.LuminaireType = new oM.Lighting.Elements.LuminaireType()
+            { Name = revitLightingFixture.FamilyTypeFullName() };
+
+            //Set type
+            revitLightingFixture.CopyTypeToFragment(bhomLight, settings, refObjects);
+
+            //Set identifiers, parameters & custom data
+            bhomLight.SetIdentifiers(revitLightingFixture);
+            bhomLight.CopyParameters(revitLightingFixture, settings.MappingSettings);
+            bhomLight.SetProperties(revitLightingFixture, settings.MappingSettings);
+
+            refObjects.AddOrReplace(revitLightingFixture.Id, bhomLight);
+            return bhomLight;
+        }
+        
+        /***************************************************/
+    }
+}
+
+
+

--- a/Revit_Core_Engine/Convert/Lighting/ToRevit/Luminaire.cs
+++ b/Revit_Core_Engine/Convert/Lighting/ToRevit/Luminaire.cs
@@ -49,7 +49,7 @@ namespace BH.Revit.Engine.Core
         [Input("settings", "Revit adapter settings to be used while performing the convert.")]
         [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
         [Output("lightingFixture", "Revit LightingFixture element resulting from the BH.oM.Lighting.Elements.Luminaire.")]
-        public static FamilyInstance ToRevitLightingFixture (this Luminaire luminaire, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
+        public static FamilyInstance ToRevitFamilyInstance (this Luminaire luminaire, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
         {
             if (luminaire == null || document == null)
                 return null;

--- a/Revit_Core_Engine/Convert/Lighting/ToRevit/Luminaire.cs
+++ b/Revit_Core_Engine/Convert/Lighting/ToRevit/Luminaire.cs
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Structure;
+using BH.Engine.Adapters.Revit;
+using BH.oM.Adapters.Revit.Elements;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Geometry;
+using BH.oM.Lighting.Elements;
+using BH.oM.Physical.Elements;
+using BH.oM.Spatial.SettingOut;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        [Description("Converts BH.oM.Lighting.Elements.Luminaire to a Revit LightingFixture.")]
+        [Input("luminaire", "BH.oM.Lighting.Elements.Luminaire to be converted.")]
+        [Input("document", "Revit document, in which the output of the convert will be created.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("lightingFixture", "Revit LightingFixture element resulting from the BH.oM.Lighting.Elements.Luminaire.")]
+        public static FamilyInstance ToRevitLightingFixture (this Luminaire luminaire, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
+        {
+            if (luminaire == null || document == null)
+                return null;
+
+            FamilyInstance familyInstance = refObjects.GetValue<FamilyInstance>(document, luminaire.BHoM_Guid);
+            if (familyInstance != null)
+                return familyInstance;
+
+            settings = settings.DefaultIfNull();
+
+            FamilySymbol familySymbol = (FamilySymbol)luminaire.ElementType(document, settings);
+            if (familySymbol == null)
+            {
+                Compute.ElementTypeNotFoundWarning(luminaire);
+                return null;
+            }
+
+            if (luminaire.Position != null)
+                return Create.FamilyInstance(document, familySymbol, (luminaire.Position).ToRevit(), luminaire.Orientation.ToRevit(), luminaire.HostElement(document, settings), settings);
+            else
+            {
+                BH.Engine.Base.Compute.RecordError($"A family could not be created based on the given luminaire because its location was invalid. BHoM_Guid: {luminaire.BHoM_Guid}");
+                return null;
+            }
+        }
+        
+        /***************************************************/
+    }
+}
+
+
+

--- a/Revit_Core_Engine/Convert/Lighting/ToRevit/Luminaire.cs
+++ b/Revit_Core_Engine/Convert/Lighting/ToRevit/Luminaire.cs
@@ -60,7 +60,7 @@ namespace BH.Revit.Engine.Core
 
             settings = settings.DefaultIfNull();
 
-            FamilySymbol familySymbol = (FamilySymbol)luminaire.ElementType(document, settings);
+            FamilySymbol familySymbol = luminaire.ElementType(document, settings) as FamilySymbol;
             if (familySymbol == null)
             {
                 Compute.ElementTypeNotFoundWarning(luminaire);
@@ -71,7 +71,7 @@ namespace BH.Revit.Engine.Core
                 return Create.FamilyInstance(document, familySymbol, (luminaire.Position).ToRevit(), luminaire.Orientation.ToRevit(), luminaire.HostElement(document, settings), settings);
             else
             {
-                BH.Engine.Base.Compute.RecordError($"A family could not be created based on the given luminaire because its location was invalid. BHoM_Guid: {luminaire.BHoM_Guid}");
+                BH.Engine.Base.Compute.RecordError($"An element could not be created based on the given luminaire because its location was invalid. BHoM_Guid: {luminaire.BHoM_Guid}");
                 return null;
             }
         }

--- a/Revit_Core_Engine/Convert/ToRevit.cs
+++ b/Revit_Core_Engine/Convert/ToRevit.cs
@@ -359,7 +359,7 @@ namespace BH.Revit.Engine.Core
         [Output("lightingFixture", "Revit LightingFixture element resulting from the BH.oM.Lighting.Elements.Luminaire.")]
         public static Element ToRevit(this BH.oM.Lighting.Elements.Luminaire luminaire, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
         {
-            return luminaire.ToRevitLightingFixture(document, settings, refObjects);
+            return luminaire.ToRevitFamilyInstance(document, settings, refObjects);
         }
 
 

--- a/Revit_Core_Engine/Convert/ToRevit.cs
+++ b/Revit_Core_Engine/Convert/ToRevit.cs
@@ -349,6 +349,19 @@ namespace BH.Revit.Engine.Core
             return assembly.ToRevitAssembly(document, settings, refObjects);
         }
 
+        /***************************************************/
+
+        [Description("Converts BH.oM.Lighting.Elements.Luminaire to a Revit LightingFixture.")]
+        [Input("luminaire", "BH.oM.Lighting.Elements.Luminaire to be converted.")]
+        [Input("document", "Revit document, in which the output of the convert will be created.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("lightingFixture", "Revit LightingFixture element resulting from the BH.oM.Lighting.Elements.Luminaire.")]
+        public static Element ToRevit(this BH.oM.Lighting.Elements.Luminaire luminaire, Document document, RevitSettings settings = null, Dictionary<Guid, List<int>> refObjects = null)
+        {
+            return luminaire.ToRevitLightingFixture(document, settings, refObjects);
+        }
+
 
         /***************************************************/
         /****             Disallowed Types              ****/

--- a/Revit_Core_Engine/Query/BHoMType.cs
+++ b/Revit_Core_Engine/Query/BHoMType.cs
@@ -143,6 +143,8 @@ namespace BH.Revit.Engine.Core
                 default:
                     if (typeof(BH.oM.Spatial.ShapeProfiles.IProfile).BuiltInCategories().Contains((BuiltInCategory)familySymbol.Category.Id.IntegerValue))
                         return typeof(BH.oM.Spatial.ShapeProfiles.IProfile);
+                    else if (typeof(BH.oM.Lighting.Elements.LuminaireType).BuiltInCategories().Contains((BuiltInCategory)familySymbol.Category.Id.IntegerValue))
+                        return typeof(BH.oM.Lighting.Elements.Luminaire);
                     else
                         return null;
             }

--- a/Revit_Core_Engine/Query/BHoMType.cs
+++ b/Revit_Core_Engine/Query/BHoMType.cs
@@ -144,7 +144,7 @@ namespace BH.Revit.Engine.Core
                     if (typeof(BH.oM.Spatial.ShapeProfiles.IProfile).BuiltInCategories().Contains((BuiltInCategory)familySymbol.Category.Id.IntegerValue))
                         return typeof(BH.oM.Spatial.ShapeProfiles.IProfile);
                     else if (typeof(BH.oM.Lighting.Elements.LuminaireType).BuiltInCategories().Contains((BuiltInCategory)familySymbol.Category.Id.IntegerValue))
-                        return typeof(BH.oM.Lighting.Elements.Luminaire);
+                        return typeof(BH.oM.Lighting.Elements.LuminaireType);
                     else
                         return null;
             }

--- a/Revit_Core_Engine/Query/BHoMType.cs
+++ b/Revit_Core_Engine/Query/BHoMType.cs
@@ -110,6 +110,8 @@ namespace BH.Revit.Engine.Core
                     else if (typeof(BH.oM.Architecture.BuildersWork.Opening).BuiltInCategories().Contains(category)
                             && settings.MappingSettings.MappedFamilyNames(typeof(BH.oM.Architecture.BuildersWork.Opening)).Contains(familyName))
                         return typeof(BH.oM.Architecture.BuildersWork.Opening);
+                    else if (typeof(BH.oM.Lighting.Elements.Luminaire).BuiltInCategories().Contains(category))
+                        return typeof(BH.oM.Lighting.Elements.Luminaire);
                     break;
                 case Discipline.Environmental:
                     if (typeof(BH.oM.MEP.System.Fittings.Fitting).BuiltInCategories().Contains(category))

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -230,6 +230,12 @@ namespace BH.Revit.Engine.Core
                 {
                     Autodesk.Revit.DB.BuiltInCategory.OST_LightingFixtures,
                 }
+            },
+            {
+                typeof (BH.oM.Lighting.Elements.LuminaireType), new BuiltInCategory[]
+                {
+                    Autodesk.Revit.DB.BuiltInCategory.OST_LightingFixtures,
+                }
             }
         };
 

--- a/Revit_Core_Engine/Query/BuiltInCategories.cs
+++ b/Revit_Core_Engine/Query/BuiltInCategories.cs
@@ -224,6 +224,12 @@ namespace BH.Revit.Engine.Core
                 {
                     Autodesk.Revit.DB.BuiltInCategory.OST_Roofs,
                 }
+            },
+            {
+                typeof (BH.oM.Lighting.Elements.Luminaire), new BuiltInCategory[]
+                {
+                    Autodesk.Revit.DB.BuiltInCategory.OST_LightingFixtures,
+                }
             }
         };
 

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -134,7 +134,7 @@ namespace BH.Revit.Engine.Core
         [Output("lightingFixtureType", "Revit LightingFixture type to be used when converting the input BHoM object to Revit.")]
         public static FamilySymbol ElementType(this BH.oM.Lighting.Elements.Luminaire luminaire, Document document, RevitSettings settings = null)
         {
-            return (FamilySymbol)luminaire.ElementTypeInclProperty(luminaire.LuminaireType, document, luminaire.LuminaireType.BuiltInCategories(), settings);
+            return luminaire.ElementTypeInclProperty(luminaire.LuminaireType, document, luminaire.LuminaireType.BuiltInCategories(), settings) as FamilySymbol;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -26,6 +26,8 @@ using BH.Engine.Adapters.Revit;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
 using BH.oM.Base.Attributes;
+using BH.oM.Lighting.Elements;
+using BH.oM.Physical.Elements;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -125,6 +127,23 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Returns the Revit LightingFixture type to be used when converting a given BHoM Luminaire to Revit.")]
+        [Input("luminaire", "BHoM Luminaire to find a correspondent Revit element type for.")]
+        [Input("document", "Revit document to parse in search for the element type.")]
+        [Input("settings", "Revit adapter settings to be used while performing the query.")]
+        [Output("lightingFixtureType", "Revit LightingFixture type to be used when converting the input BHoM object to Revit.")]
+        public static FamilySymbol ElementType(this BH.oM.Lighting.Elements.Luminaire luminaire, Document document, RevitSettings settings = null)
+        {
+            HashSet<BuiltInCategory> categories = luminaire.BuiltInCategories();
+
+            string familyName, familyTypeName;
+            luminaire.LuminaireFamilyAndTypeNames(out familyName, out familyTypeName);
+
+            return document.ElementType(familyName, familyTypeName, categories, settings) as FamilySymbol;
+        }
+
+        /***************************************************/
+
         [Description("Returns the Revit rebar bar type to be used when converting a given BHoM reinforcing bar to Revit.")]
         [Input("bar", "BHoM reinforcing bar to find a correspondent Revit element type for.")]
         [Input("document", "Revit document to parse in search for the element type.")]
@@ -155,6 +174,7 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
 
         [Description("Returns the Revit element type to be used when converting a given BHoM object to Revit.")]
         [Input("bHoMObject", "BHoM object to find a correspondent Revit element type for.")]
@@ -258,6 +278,17 @@ namespace BH.Revit.Engine.Core
                 return collector.Cast<T>().FirstOrDefault(x => x.FamilyName == familyName && x.Name == familyTypeName);
             else
                 return collector.FirstOrDefault(x => x.Name == familyTypeName) as T;
+        }
+
+        /***************************************************/
+
+        private static void LuminaireFamilyAndTypeNames(this Luminaire luminaire, out string familyName, out string familyTypeName)
+        {
+            familyName = luminaire.LuminaireType.Name;
+            familyTypeName = luminaire.LuminaireType.Model;
+
+            if (string.IsNullOrEmpty(familyTypeName))
+                familyTypeName = luminaire.Name;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/ElementType.cs
+++ b/Revit_Core_Engine/Query/ElementType.cs
@@ -134,12 +134,7 @@ namespace BH.Revit.Engine.Core
         [Output("lightingFixtureType", "Revit LightingFixture type to be used when converting the input BHoM object to Revit.")]
         public static FamilySymbol ElementType(this BH.oM.Lighting.Elements.Luminaire luminaire, Document document, RevitSettings settings = null)
         {
-            HashSet<BuiltInCategory> categories = luminaire.BuiltInCategories();
-
-            string familyName, familyTypeName;
-            luminaire.LuminaireFamilyAndTypeNames(out familyName, out familyTypeName);
-
-            return document.ElementType(familyName, familyTypeName, categories, settings) as FamilySymbol;
+            return (FamilySymbol)luminaire.ElementTypeInclProperty(luminaire.LuminaireType, document, luminaire.LuminaireType.BuiltInCategories(), settings);
         }
 
         /***************************************************/
@@ -278,17 +273,6 @@ namespace BH.Revit.Engine.Core
                 return collector.Cast<T>().FirstOrDefault(x => x.FamilyName == familyName && x.Name == familyTypeName);
             else
                 return collector.FirstOrDefault(x => x.Name == familyTypeName) as T;
-        }
-
-        /***************************************************/
-
-        private static void LuminaireFamilyAndTypeNames(this Luminaire luminaire, out string familyName, out string familyTypeName)
-        {
-            familyName = luminaire.LuminaireType.Name;
-            familyTypeName = luminaire.LuminaireType.Model;
-
-            if (string.IsNullOrEmpty(familyTypeName))
-                familyTypeName = luminaire.Name;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -47,8 +47,7 @@
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="	xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y
-					xcopy &quot;$(ProjectDir)Files\Families&quot; &quot;C:\ProgramData\BHoM\Resources\Revit\Families&quot; /Y /I /E" />
+    <Exec Command="	xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;					xcopy &quot;$(ProjectDir)Files\Families&quot; &quot;C:\ProgramData\BHoM\Resources\Revit\Families&quot; /Y /I /E" />
   </Target>
 
   <ItemGroup>

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -47,7 +47,8 @@
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="	xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;					xcopy &quot;$(ProjectDir)Files\Families&quot; &quot;C:\ProgramData\BHoM\Resources\Revit\Families&quot; /Y /I /E" />
+    <Exec Command="	xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y
+					xcopy &quot;$(ProjectDir)Files\Families&quot; &quot;C:\ProgramData\BHoM\Resources\Revit\Families&quot; /Y /I /E" />
   </Target>
 
   <ItemGroup>
@@ -142,7 +143,9 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Lighting_oM">
-      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Lighting_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Lighting_oM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Matter_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Matter_Engine.dll</HintPath>

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -47,8 +47,7 @@
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="	xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y
-					xcopy &quot;$(ProjectDir)Files\Families&quot; &quot;C:\ProgramData\BHoM\Resources\Revit\Families&quot; /Y /I /E" />
+    <Exec Command="	xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;					xcopy &quot;$(ProjectDir)Files\Families&quot; &quot;C:\ProgramData\BHoM\Resources\Revit\Families&quot; /Y /I /E" />
   </Target>
 
   <ItemGroup>
@@ -141,6 +140,9 @@
       <HintPath>$(ProgramData)\BHoM\Assemblies\Library_Engine.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Lighting_oM">
+      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Lighting_oM.dll</HintPath>
     </Reference>
     <Reference Include="Matter_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Matter_Engine.dll</HintPath>

--- a/Revit_Core_Engine/Revit_Core_Engine.csproj
+++ b/Revit_Core_Engine/Revit_Core_Engine.csproj
@@ -47,8 +47,9 @@
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="	xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;					xcopy &quot;$(ProjectDir)Files\Families&quot; &quot;C:\ProgramData\BHoM\Resources\Revit\Families&quot; /Y /I /E" />
-  </Target>
+    <Exec Command="	xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y
+					xcopy &quot;$(ProjectDir)Files\Families&quot; &quot;C:\ProgramData\BHoM\Resources\Revit\Families&quot; /Y /I /E" />
+   </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\Revit_Engine\Revit_Engine.csproj" />

--- a/Revit_Engine/Query/GetRevitElementType.cs
+++ b/Revit_Engine/Query/GetRevitElementType.cs
@@ -164,6 +164,13 @@ namespace BH.Engine.Adapters.Revit
             return bHoMObject.Property;
         }
 
+        /***************************************************/
+
+        private static IBHoMObject GetRevitElementType(this BH.oM.Lighting.Elements.Luminaire bHoMObject)
+        {
+            return bHoMObject.LuminaireType;
+        }
+
 
         /***************************************************/
         /****              Fallback methods             ****/

--- a/Revit_Engine/Revit_Engine.csproj
+++ b/Revit_Engine/Revit_Engine.csproj
@@ -115,6 +115,11 @@
       <HintPath>$(ProgramData)\BHoM\Assemblies\Library_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Lighting_oM">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Lighting_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="MEP_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\MEP_oM.dll</HintPath>


### PR DESCRIPTION
### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/1501

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1340
Closes #1347 

Added functionality for reading LightingFixtures as BHoM Luminaires. Includes reading position, Type Name, Revit Parameters/Identifiers and Orientation of LightingFixture. Note that for default LightingFixture families placed on a Ref Level, this orientation will be in the positive Z direction. While correct for representation of the Revit orientation, this may require additional handling to get desired orientation of the Luminaire for other usage. This may necessitate future additional methods for Revit vs Luminaire Orientation handling. 

Also added LightingFixture creation from Luminaires, with basic functionality for placing at specified location per LuminaireType Name and Model.


### Test files
[Test File](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%231340-ReadLightingFixtures?csf=1&web=1&e=sRulZP)
Test by opening up the Revit and GH files, selecting elements in Revit, and then following STEP 1 and STEP 2 in the GH file to confirm Pull and Push functionality.
