### PR TITLE
Unit type of pulled parameters tweaked

### DIFF
--- a/Revit_Core_Engine/Convert/Revit/FromRevit/Parameter.cs
+++ b/Revit_Core_Engine/Convert/Revit/FromRevit/Parameter.cs
@@ -80,7 +80,7 @@ namespace BH.Revit.Engine.Core
                     break;
             }
 
-            string unitTypeIdentifier = parameter.Definition.GetDataType().UnitTypePropertyName();
+            string unitTypeIdentifier = parameter.UnitTypePropertyName();
             return new RevitParameter { Name = name, Value = value, IsReadOnly = parameter.IsReadOnly, UnitType = unitTypeIdentifier };
         }
 

--- a/Revit_Core_Engine/Query/UnitTypePropertyName.cs
+++ b/Revit_Core_Engine/Query/UnitTypePropertyName.cs
@@ -52,5 +52,12 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        public static string UnitTypePropertyName(this Parameter parameter)
+        {
+            return parameter.StorageType == StorageType.Double ? parameter.Definition.GetDataType().UnitTypePropertyName() : null;
+        }
+
+        /***************************************************/
     }
 }

--- a/Revit_Core_Engine/Query/UnitTypePropertyName.cs
+++ b/Revit_Core_Engine/Query/UnitTypePropertyName.cs
@@ -53,6 +53,9 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [Description("Returns name of SpecTypeId property that contains given Revit parameter's unit type object (enum for Revit up to 2020 or ForgeTypeId for later versions).")]
+        [Input("parameter", "Parameter to be queried for the correspondent SpecTypeId property name.")]
+        [Output("identifier", "Name of SpecTypeId property that contains the unit type object correspondent to the input parameter.")]
         public static string UnitTypePropertyName(this Parameter parameter)
         {
             return parameter.StorageType == StorageType.Double ? parameter.Definition.GetDataType().UnitTypePropertyName() : null;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231350%2DAddSupportForPrimitiveCollections&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - only parameters that are measured in units should have `UnitType` property assigned (particularly relevant in lower versions of Revit, where it always was `UT_Number`).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->