### PR TITLE
Updated Point Based One Level Placement to Place Per Level and Elevation

### DIFF
--- a/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
@@ -176,8 +176,10 @@ namespace BH.Revit.Engine.Core
             if (level == null)
                 return null;
 
-            XYZ xdir = orientation.ProjectedX(settings);
-            FamilyInstance familyInstance = document.Create.NewFamilyInstance(origin, familySymbol, xdir, level, StructuralType.NonStructural);
+            double ZToLevel = origin.Z - level.ProjectElevation;
+            origin = new XYZ(origin.X, origin.Y, ZToLevel);
+
+            FamilyInstance familyInstance = document.Create.NewFamilyInstance(origin, familySymbol, level, StructuralType.NonStructural);
             if (familyInstance == null)
                 return null;
 
@@ -186,6 +188,11 @@ namespace BH.Revit.Engine.Core
             
             if (host != null)
                 familyInstance.HostIgnoredWarning();
+
+            double angle = XYZ.BasisX.AngleOnPlaneTo(orientation.ProjectedX(settings), XYZ.BasisZ);
+            XYZ axisEnd = new XYZ(origin.X, origin.Y, origin.Z + 30);
+            Autodesk.Revit.DB.Line axis = Autodesk.Revit.DB.Line.CreateBound(origin, axisEnd);
+            ElementTransformUtils.RotateElement(document, familyInstance.Id, axis, angle);
 
             return familyInstance;
         }

--- a/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
@@ -177,7 +177,7 @@ namespace BH.Revit.Engine.Core
                 return null;
 
             double zToLevel = origin.Z - level.ProjectElevation;
-            origin = new XYZ(origin.X, origin.Y, ZToLevel);
+            origin = new XYZ(origin.X, origin.Y, zToLevel);
 
             FamilyInstance familyInstance = document.Create.NewFamilyInstance(origin, familySymbol, level, StructuralType.NonStructural);
             if (familyInstance == null)

--- a/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
@@ -176,7 +176,7 @@ namespace BH.Revit.Engine.Core
             if (level == null)
                 return null;
 
-            double ZToLevel = origin.Z - level.ProjectElevation;
+            double zToLevel = origin.Z - level.ProjectElevation;
             origin = new XYZ(origin.X, origin.Y, ZToLevel);
 
             FamilyInstance familyInstance = document.Create.NewFamilyInstance(origin, familySymbol, level, StructuralType.NonStructural);

--- a/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
@@ -190,9 +190,7 @@ namespace BH.Revit.Engine.Core
                 familyInstance.HostIgnoredWarning();
 
             double angle = XYZ.BasisX.AngleOnPlaneTo(orientation.ProjectedX(settings), XYZ.BasisZ);
-            XYZ axisEnd = new XYZ(origin.X, origin.Y, origin.Z + 30);
-            Autodesk.Revit.DB.Line axis = Autodesk.Revit.DB.Line.CreateBound(origin, axisEnd);
-            ElementTransformUtils.RotateElement(document, familyInstance.Id, axis, angle);
+            ElementTransformUtils.RotateElement(document, familyInstance.Id, Line.CreateUnbound(origin, XYZ.BasisZ), angle);
 
             return familyInstance;
         }


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1352 

Fixed method for Placing One-Level Based Elements at a Point so it uses the Revit API Method that creates them hosted to the level, rather than the previous method which leaves them unhosted and therefore minimally manipulatable in Revit after creation.


### Test files
[test files](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%231353-Point%20Based%20Elem%20Level%20Hosting%20Fix?csf=1&web=1&e=4srCs6)

To test, open the rvt model and then follow the instructions in the script, first selecting Revit Elements and Pulling them, then Pushing them back to Revit and confirming they match the pulled elements. Use the plan view to confirm that pushed elements are still hosted to Level 1 (Not highlighted magenta). Use the 3d view to visually inspect pushed elements and confirm that elements match elevations from the side for the element pulled and pushed. Note that some lighting fixtures will be in the correct location, but will be shorter due to instance property discrepancies. This is expected behavior and can be disregarded. Testing focus should be on element positioning and rotation.

