### PR TITLE
Invalid workset information stopped from being passed on pull from non-workshared models

### DIFF
--- a/Revit_Core_Engine/Query/Identifiers.cs
+++ b/Revit_Core_Engine/Query/Identifiers.cs
@@ -110,9 +110,12 @@ namespace BH.Revit.Engine.Core
             if (parameter != null)
                 int.TryParse(parameter.AsValueString(), out familyTypeId);
 
-            parameter = element.get_Parameter(BuiltInParameter.ELEM_PARTITION_PARAM);
-            if (parameter != null)
-                workset = parameter.AsValueString();
+            if (element.Document.IsWorkshared)
+            {
+                parameter = element.get_Parameter(BuiltInParameter.ELEM_PARTITION_PARAM);
+                if (parameter != null)
+                    workset = parameter.AsValueString();
+            }
 
             if (element.ViewSpecific)
                 ownerViewId = element.OwnerViewId.IntegerValue;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1369

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Open the following models together with the .gh script located [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231370%2DWorksetBugOnPull&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4):
- _rac_basic_sample_project.rvt_ - workset should be empty (non-workshared model)
- _rme_advanced_sample_project.rvt_ - workset should be empty (non-workshared model)
- any workshared model - workset should be same as in Revit


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->