### PR TITLE
Handle random order from `ConnectorManager.Connectors`

### DIFF
--- a/Revit_Core_Engine/Query/LocationCurve.cs
+++ b/Revit_Core_Engine/Query/LocationCurve.cs
@@ -173,7 +173,11 @@ namespace BH.Revit.Engine.Core
             
             List<BH.oM.Geometry.Point> endPoints = connectors.Where(x => x.ConnectorType == ConnectorType.End).Select(x => x.Origin.PointFromRevit()).ToList();
             List<BH.oM.Geometry.Point> midPoints = connectors.Where(x => x.ConnectorType != ConnectorType.End).Select(x => x.Origin.PointFromRevit()).ToList();
-            
+
+            //Thanks to Revit, the order of connectors from connectorManager.Connectors isn't always the same!
+            //So, we need SortCollinear to maintain the same connector order each time we pull an object.
+            endPoints = endPoints.SortCollinear();
+
             BH.oM.Geometry.Line line = BH.Engine.Geometry.Create.Line(endPoints[0], endPoints[1]);
             List<BH.oM.Geometry.Line> result = new List<BH.oM.Geometry.Line>();
 

--- a/Revit_Core_Engine/Query/OrientationAngle.cs
+++ b/Revit_Core_Engine/Query/OrientationAngle.cs
@@ -24,12 +24,11 @@ using Autodesk.Revit.DB;
 using BH.Engine.Adapters.Revit;
 using BH.Engine.Geometry;
 using BH.oM.Adapters.Revit.Settings;
-using BH.oM.Physical.Elements;
 using BH.oM.Base.Attributes;
+using BH.oM.Geometry;
+using BH.oM.Physical.Elements;
 using System;
 using System.ComponentModel;
-using System.Linq;
-using BH.oM.Geometry;
 
 namespace BH.Revit.Engine.Core
 {
@@ -90,8 +89,8 @@ namespace BH.Revit.Engine.Core
 
                     //Thanks to Revit, the order of connectors from connectorManager.Connectors isn't always the same!
                     //So, we need to get the connector whose origin has the smallest X,Y & Z values in order to measure OrientationAngle consistently.
-                    var p1 = connector.Origin;
-                    var p2 = conn.Origin;
+                    XYZ p1 = connector.Origin;
+                    XYZ p2 = conn.Origin;
 
                     if ((p1.X - p2.X) > Tolerance.Distance
                         || (p1.Y - p2.Y) > Tolerance.Distance

--- a/Revit_Core_Engine/Query/OrientationAngle.cs
+++ b/Revit_Core_Engine/Query/OrientationAngle.cs
@@ -29,6 +29,7 @@ using BH.oM.Base.Attributes;
 using System;
 using System.ComponentModel;
 using System.Linq;
+using BH.oM.Geometry;
 
 namespace BH.Revit.Engine.Core
 {
@@ -81,8 +82,23 @@ namespace BH.Revit.Engine.Core
                 // Get the End connector for this duct
                 if (conn.ConnectorType == ConnectorType.End)
                 {
-                    connector = conn;
-                    break;
+                    if (connector == null)
+                    {
+                        connector = conn;
+                        continue;
+                    }
+
+                    //Thanks to Revit, the order of connectors from connectorManager.Connectors isn't always the same!
+                    //So, we need to get the connector whose origin has the smallest X,Y & Z values in order to measure OrientationAngle consistently.
+                    var p1 = connector.Origin;
+                    var p2 = conn.Origin;
+
+                    if ((p1.X - p2.X) > Tolerance.Distance
+                        || (p1.Y - p2.Y) > Tolerance.Distance
+                        || (p1.Z - p2.Z) > Tolerance.Distance)
+                    {
+                        connector = conn;
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: The bug seems to only affects unit test projects so far, so no rush to merge before the beta deadline.

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1374 

<!-- Add short description of what has been fixed -->
Used `SortCollinear` and its principle to sort connectors of an MEP curve based on their origin point locations.

### Test files
<!-- Link to test files to validate the proposed changes -->
[SharePoint folder](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%231375-HandleRandomConnectorsOrder?csf=1&web=1&e=4QgbKa)

- Use Revit 2020 or later
- Try pulling any cable tray by inputting its ID
- Check the output Json file after each pull to confirm every pull produces exactly the same result. In particular, check the start and end points of the element as well as its orientation angle.

![image](https://github.com/BHoM/Revit_Toolkit/assets/102604891/e22a8573-3cdf-48db-82b4-91c9abefd478)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Handle random order from `ConnectorManager.Connectors`
