### PR TITLE
Fixed GetAllElementsVisibleInActiveView

### DIFF
--- a/Revit_Core_Engine/Objects/ActiveViewVisibilityContext.cs
+++ b/Revit_Core_Engine/Objects/ActiveViewVisibilityContext.cs
@@ -95,14 +95,15 @@ namespace BH.Revit.Engine.Core
         {
             Document doc = m_Documents.Peek();
             m_Elements[doc.PathName].Add(elementId);
-
             Element element = doc.GetElement(elementId);
-            if (element is RevitLinkInstance)
+
+            if (element is RevitLinkInstance linkInstance)
             {
-                RevitLinkInstance linkInstance = (RevitLinkInstance)element;
-                if (m_TargetDocument == null || m_TargetDocument.PathName == linkInstance.GetLinkDocument().PathName)
+                Document linkDoc = linkInstance.GetLinkDocument();
+
+                if (m_TargetDocument == null || m_TargetDocument.PathName == linkDoc.PathName)
                 {
-                    m_DocumentLookup[linkInstance.Document.PathName] = linkInstance.Document;
+                    m_DocumentLookup[linkDoc.PathName] = linkDoc;
                     return RenderNodeAction.Proceed;
                 }
             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1399 

<!-- Add short description of what has been fixed -->
Changed `linkInstance.Document` to `linkInstance.GetLinkDocument()`. This allows storing Ids of visible elements to the right document.

### Test files
<!-- Link to test files to validate the proposed changes -->
Please build this dependent PR and test on this Revit 2020 model called `Host.rvt` on [SharePoint](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%231400-FixGetAllElementsVisibleInActiveView?csf=1&web=1&e=nf0scD).

![image](https://github.com/BHoM/Revit_Toolkit/assets/102604891/6fdad79c-b736-43c7-a837-b27117cd51d0)

![image](https://github.com/BHoM/Revit_Toolkit/assets/102604891/f8cf24f2-09f0-45e3-94a2-eba8039da1ea)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->