### PR TITLE
Improve `Query.DrawingArea`

### DIFF
--- a/Revit_Core_Engine/Query/DrawingArea.cs
+++ b/Revit_Core_Engine/Query/DrawingArea.cs
@@ -67,16 +67,11 @@ namespace BH.Revit.Engine.Core
         [Output("outline", "The Title Block's drawing area.")]
         public static Outline DrawingArea(this FamilySymbol titleBlockSymbol)
         {
-            List<DetailLine> lines = titleBlockSymbol.VisibleLines();
-            CompositeGeometry compositeGeom = new CompositeGeometry();
-
-            foreach (DetailLine dLine in lines)
+            List<BH.oM.Geometry.Line> lines = titleBlockSymbol.VisibleLines();
+            CompositeGeometry compositeGeom = new CompositeGeometry()
             {
-                BH.oM.Geometry.Line bhomLine = dLine.GeometryCurve.IFromRevit() as BH.oM.Geometry.Line;
-
-                if (bhomLine != null)
-                    compositeGeom.Elements.Add(bhomLine);
-            }
+                Elements = lines.Cast<IGeometry>().ToList()
+            };
 
             BH.oM.Geometry.Point centrePoint = compositeGeom.Bounds().Centre();
 
@@ -119,8 +114,8 @@ namespace BH.Revit.Engine.Core
         /****             Private methods               ****/
         /***************************************************/
 
-        [Description("Returns all visible detail lines of the title block symbol.")]
-        private static List<DetailLine> VisibleLines(this FamilySymbol titleBlockSymbol)
+        [Description("Returns all visible lines of the title block symbol.")]
+        private static List<BH.oM.Geometry.Line> VisibleLines(this FamilySymbol titleBlockSymbol)
         {
             Document document = titleBlockSymbol.Document;
             Document familyDoc = document.EditFamily(titleBlockSymbol.Family);
@@ -164,8 +159,10 @@ namespace BH.Revit.Engine.Core
             }
 
             visibleLines.AddRange(nestedLines);
+            List<BH.oM.Geometry.Line> lines = visibleLines.Where(x => x.GeometryCurve is Autodesk.Revit.DB.Line).Select(x => x.GeometryCurve.IFromRevit()).Cast<BH.oM.Geometry.Line>().ToList();
+            familyDoc.Close(false);
 
-            return visibleLines;
+            return lines;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1401 

<!-- Add short description of what has been fixed -->
Fixed `Query.DrawingArea` to work correctly with various types of the title block and nested families.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->