### PR TITLE
`Query.DrawingArea` - titleblock empty type bug fix

### DIFF
--- a/Revit_Core_Engine/Query/DrawingArea.cs
+++ b/Revit_Core_Engine/Query/DrawingArea.cs
@@ -140,7 +140,9 @@ namespace BH.Revit.Engine.Core
             {
                 familyTransaction.Start();
 
-                familyDoc.FamilyManager.CurrentType = symbolFamilyType;
+                if (symbolFamilyType != null)
+                    familyDoc.FamilyManager.CurrentType = symbolFamilyType;
+
                 previewView.TemporaryViewModes.PreviewFamilyVisibility = PreviewFamilyVisibilityMode.On;
 
                 familyTransaction.Commit();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1403 

<!-- Add short description of what has been fixed -->
Added null check for empty symbol family types.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->