### PR TITLE
Improve `SpatialBoundCondition` values

### DIFF
--- a/Revit_Core_Engine/Query/SpatialBoundCondition.cs
+++ b/Revit_Core_Engine/Query/SpatialBoundCondition.cs
@@ -51,7 +51,7 @@ namespace BH.Revit.Engine.Core
                 }
                 else if (elem.GetBoundarySegments(new SpatialElementBoundaryOptions()).Count > 0)
                 {
-                    return BoundCondition.Redundant;
+                    return BoundCondition.Overlapping;
                 }
                 else
                 {

--- a/Revit_Core_Engine/Query/SpatialBoundCondition.cs
+++ b/Revit_Core_Engine/Query/SpatialBoundCondition.cs
@@ -38,7 +38,7 @@ namespace BH.Revit.Engine.Core
         [Description("Check if a room/space/area is bounded, unplaced, redundant, or not enclosed.")]
         [Input("elem", "A spatial element to be check if it's bounded, unplaced, redundant, or not enclosed.")]
         [Output("BoundCondition", "The bound condition of the spatial element to be checked.")]
-        public static BoundCondition? SpatialBoundCondition(this SpatialElement elem, bool volumeComputationEnabled = false)
+        public static BoundCondition? SpatialBoundCondition(this SpatialElement elem)
         {
             if (elem == null)
                 return null;
@@ -58,7 +58,7 @@ namespace BH.Revit.Engine.Core
                     return BoundCondition.NotEnclosed;
                 }
             }
-            else if (volumeComputationEnabled)
+            else if (AreaVolumeSettings.GetAreaVolumeSettings(elem.Document).ComputeVolumes)
             {
                 if (elem is Room room && room.Volume == 0
                     || elem is Space space && space.Volume == 0)

--- a/Revit_Core_Engine/Query/SpatialBoundCondition.cs
+++ b/Revit_Core_Engine/Query/SpatialBoundCondition.cs
@@ -38,10 +38,10 @@ namespace BH.Revit.Engine.Core
         [Description("Check if a room/space/area is bounded, unplaced, redundant, or not enclosed.")]
         [Input("elem", "A spatial element to be check if it's bounded, unplaced, redundant, or not enclosed.")]
         [Output("BoundCondition", "The bound condition of the spatial element to be checked.")]
-        public static BoundCondition? SpatialBoundCondition(this SpatialElement elem)
+        public static BoundCondition SpatialBoundCondition(this SpatialElement elem)
         {
             if (elem == null)
-                return null;
+                return BoundCondition.Unknown;
 
             if (elem.Area == 0)
             {

--- a/Revit_Core_Engine/Query/SpatialBoundCondition.cs
+++ b/Revit_Core_Engine/Query/SpatialBoundCondition.cs
@@ -21,10 +21,10 @@
  */
 
 using Autodesk.Revit.DB;
-using Autodesk.Revit.DB.Structure;
+using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.DB.Mechanical;
 using BH.oM.Adapters.Revit.Enums;
 using BH.oM.Base.Attributes;
-using System;
 using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core
@@ -38,7 +38,7 @@ namespace BH.Revit.Engine.Core
         [Description("Check if a room/space/area is bounded, unplaced, redundant, or not enclosed.")]
         [Input("elem", "A spatial element to be check if it's bounded, unplaced, redundant, or not enclosed.")]
         [Output("BoundCondition", "The bound condition of the spatial element to be checked.")]
-        public static BoundCondition? SpatialBoundCondition(this SpatialElement elem)
+        public static BoundCondition? SpatialBoundCondition(this SpatialElement elem, bool volumeComputationEnabled = false)
         {
             if (elem == null)
                 return null;
@@ -58,6 +58,16 @@ namespace BH.Revit.Engine.Core
                     return BoundCondition.NotEnclosed;
                 }
             }
+            else if (volumeComputationEnabled)
+            {
+                if (elem is Room room && room.Volume == 0
+                    || elem is Space space && space.Volume == 0)
+                {
+                    //Revit can fail to create the geometry for a room or space with very complex boundary.
+                    return BoundCondition.NoGeometry;
+                }
+            }
+
             return BoundCondition.Bounded;
         }
 

--- a/Revit_oM/Enums/BoundCondition.cs
+++ b/Revit_oM/Enums/BoundCondition.cs
@@ -29,9 +29,10 @@ namespace BH.oM.Adapters.Revit.Enums
     [Description("An enumerator defining possible bound condition of a Revit room/space/area. " +
         "Below is the meaning of each condition for rooms. The same applies to spaces and areas." +
         "- Unplaced: https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-BC1DC181-B6D0-4479-8385-363A9EE5E75E" +
-        "- Not enclosed: https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-1AEDF540-7CB3-4CAB-885A-ACDF70154312" +
-        "- Redundant(Overlapping another space): https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-0DF409DD-3BBD-4488-B544-D075D1807747" +
-        "- Bounded (fully bounded on all sides by bounding elements): https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-241430FC-8084-43A1-AA3A-681B2883B0FC")]
+        "- Not Enclosed: https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-1AEDF540-7CB3-4CAB-885A-ACDF70154312" +
+        "- Overlapping: Overlaps another space, or 'Redundant' in Revit's term): https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-0DF409DD-3BBD-4488-B544-D075D1807747" +
+        "- Bounded (fully bounded on all sides by bounding elements): https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-241430FC-8084-43A1-AA3A-681B2883B0FC" +
+        "- No Geometry: the spatial element has a boundary that is too complex for Revit to created its geometric volume. Fixing this will require manually reducing its boundary complexity in the model, such as by using space/room separation lines.")]
     public enum BoundCondition
     {
         Bounded,

--- a/Revit_oM/Enums/BoundCondition.cs
+++ b/Revit_oM/Enums/BoundCondition.cs
@@ -39,7 +39,8 @@ namespace BH.oM.Adapters.Revit.Enums
         Unplaced,
         NotEnclosed,
         Overlapping,
-        NoGeometry
+        NoGeometry,
+        Unknown
     }
 
     /***************************************************/

--- a/Revit_oM/Enums/BoundCondition.cs
+++ b/Revit_oM/Enums/BoundCondition.cs
@@ -30,14 +30,14 @@ namespace BH.oM.Adapters.Revit.Enums
         "Below is the meaning of each condition for rooms. The same applies to spaces and areas." +
         "- Unplaced: https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-BC1DC181-B6D0-4479-8385-363A9EE5E75E" +
         "- Not enclosed: https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-1AEDF540-7CB3-4CAB-885A-ACDF70154312" +
-        "- Redundant: https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-0DF409DD-3BBD-4488-B544-D075D1807747" +
+        "- Redundant(Overlapping another space): https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-0DF409DD-3BBD-4488-B544-D075D1807747" +
         "- Bounded (fully bounded on all sides by bounding elements): https://help.autodesk.com/view/RVT/2022/ENU/?guid=GUID-241430FC-8084-43A1-AA3A-681B2883B0FC")]
     public enum BoundCondition
     {
         Bounded,
         Unplaced,
         NotEnclosed,
-        Redundant,
+        Overlapping,
         NoGeometry
     }
 

--- a/Revit_oM/Enums/BoundCondition.cs
+++ b/Revit_oM/Enums/BoundCondition.cs
@@ -38,6 +38,7 @@ namespace BH.oM.Adapters.Revit.Enums
         Unplaced,
         NotEnclosed,
         Redundant,
+        NoGeometry
     }
 
     /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1414 

<!-- Add short description of what has been fixed -->
- Renamed Redundant to Overlapping
- Added NoGeometry
- Added conditions for arriving at NoGeometry to the `SpatialBoundCondition` query method.

Please note the edge case for NoGeometry only exists in Revit models with volume computation turned on:

![image](https://github.com/BHoM/Revit_Toolkit/assets/102604891/ee43e4cc-c198-4ce4-b4d8-d247f16dfd90)

### Test files
<!-- Link to test files to validate the proposed changes -->
Building the repo should raise no error, and bot checks should pass.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->