### PR TITLE
`DoesIntersect` - add intersection between point and element, point and solid, and solid vs solid

### DIFF
--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -110,6 +110,63 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        [Description("Check if point intersects with element.")]
+        [Input("point", "Point to check the intersection for.")]
+        [Input("element", "Element to check the intersection for.")]
+        [Output("bool", "Result of the intersect checking.")]
+        public static bool DoesIntersect(this XYZ point, Element element)
+        {
+            if (point == null || element == null)
+            {
+                return false;
+            }
+
+            List<Solid> solids = element.Solids(new Options());
+            Transform transform = element.Document.IsLinked ? element.Document.LinkTransform() : Transform.Identity;
+
+            if (!transform.IsIdentity)
+                solids = solids.Select(x => SolidUtils.CreateTransformed(x, transform)).ToList();
+
+            foreach (var solid in solids)
+            {
+                if (DoesIntersect(point, solid))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /***************************************************/
+
+        [Description("Check if point intersects with solid.")]
+        [Input("point", "Point to check the intersection for.")]
+        [Input("solid", "Solid to check the intersection for.")]
+        [Output("bool", "Result of the intersect checking.")]
+        public static bool DoesIntersect(this XYZ point, Solid solid)
+        {
+            if (point == null || solid == null)
+            {
+                return false;
+            }
+
+            Line line = Line.CreateBound(point, point.Add(XYZ.BasisZ));
+            SolidCurveIntersection sci = solid.IntersectWithCurve(line, new SolidCurveIntersectionOptions());
+
+            for (int i = 0; i < sci.SegmentCount; i++)
+            {
+                Curve c = sci.GetCurveSegment(i);
+
+                if (point.IsAlmostEqualTo(c.GetEndPoint(0), BH.oM.Geometry.Tolerance.Distance) || point.IsAlmostEqualTo(c.GetEndPoint(1), BH.oM.Geometry.Tolerance.Distance))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /***************************************************/
         /****              Private methods              ****/
         /***************************************************/
 

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -23,6 +23,7 @@
 
 using Autodesk.Revit.DB;
 using BH.oM.Base.Attributes;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -164,6 +165,23 @@ namespace BH.Revit.Engine.Core
             }
 
             return false;
+        }
+
+        /***************************************************/
+
+        [Description("Check if solid intersects with another solid.")]
+        [Input("solid1", "First solid to check the intersection for.")]
+        [Input("solid2", "Second solid to check the intersection for.")]
+        [Output("bool", "Result of the intersect checking.")]
+        public static bool DoesIntersect(this Solid solid1, Solid solid2)
+        {
+            if (solid1 == null || solid2 == null)
+            {
+                return false;
+            }
+
+            Solid intersectSolid = BooleanOperationsUtils.ExecuteBooleanOperation(solid1, solid2, BooleanOperationsType.Intersect);
+            return Math.Abs(intersectSolid.Volume) > BH.oM.Geometry.Tolerance.Distance;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -181,7 +181,7 @@ namespace BH.Revit.Engine.Core
             }
 
             Solid intersectSolid = BooleanOperationsUtils.ExecuteBooleanOperation(solid1, solid2, BooleanOperationsType.Intersect);
-            return Math.Abs(intersectSolid.Volume) > BH.oM.Geometry.Tolerance.Distance;
+            return Math.Abs(intersectSolid.Volume) > Math.Pow(BH.oM.Geometry.Tolerance.Distance, 3);
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1421

<!-- Add short description of what has been fixed -->
Add `DoesIntersect` method to check the intersection between point and element.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->