### PR TITLE
`Query.Bounds` - add overload for collection of bounding boxes, `DoesIntesect` - add transform input

### DIFF
--- a/Revit_Core_Engine/Query/Bounds.cs
+++ b/Revit_Core_Engine/Query/Bounds.cs
@@ -150,6 +150,34 @@ namespace BH.Revit.Engine.Core
         }
 
         /***************************************************/
+
+        [Description("Returns combined bounding box of the given collection of bounding boxes.")]
+        [Input("bboxes", "A collection of the bounding boxes to get the bounds for.")]
+        [Output("bounds", "Combined bounding box of the bounding boxes.")]
+        public static BoundingBoxXYZ Bounds(this IEnumerable<BoundingBoxXYZ> bboxes)
+        {
+            List<XYZ> points = new List<XYZ>();
+
+            foreach (BoundingBoxXYZ bbox in bboxes)
+            {
+                Transform transform = bbox.Transform;
+
+                if (!transform.IsIdentity)
+                {
+                    points.Add(transform.OfPoint(bbox.Min));
+                    points.Add(transform.OfPoint(bbox.Max));
+                }
+                else
+                {
+                    points.Add(bbox.Min);
+                    points.Add(bbox.Max);
+                }
+            }
+
+            return points.Bounds();
+        }
+
+        /***************************************************/
     }
 }
 

--- a/Revit_Core_Engine/Query/Bounds.cs
+++ b/Revit_Core_Engine/Query/Bounds.cs
@@ -153,29 +153,10 @@ namespace BH.Revit.Engine.Core
 
         [Description("Returns combined bounding box of the given collection of bounding boxes.")]
         [Input("bboxes", "A collection of the bounding boxes to get the bounds for.")]
-        [Output("bounds", "Combined bounding box of the bounding boxes.")]
+        [Output("bounds", "Combined bounding box of given bounding boxes.")]
         public static BoundingBoxXYZ Bounds(this IEnumerable<BoundingBoxXYZ> bboxes)
         {
-            List<XYZ> points = new List<XYZ>();
-
-            foreach (BoundingBoxXYZ bbox in bboxes)
-            {
-                Transform transform = bbox.Transform;
-
-                if (!transform.IsIdentity)
-                {
-                    BoundingBoxXYZ transformedBbox = bbox.BoundsOfTransformed(transform);
-                    points.Add(transformedBbox.Min);
-                    points.Add(transformedBbox.Max);
-                }
-                else
-                {
-                    points.Add(bbox.Min);
-                    points.Add(bbox.Max);
-                }
-            }
-
-            return points.Bounds();
+            return bboxes.SelectMany(x => x.CornerPoints()).Bounds();
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/Bounds.cs
+++ b/Revit_Core_Engine/Query/Bounds.cs
@@ -164,8 +164,9 @@ namespace BH.Revit.Engine.Core
 
                 if (!transform.IsIdentity)
                 {
-                    points.Add(transform.OfPoint(bbox.Min));
-                    points.Add(transform.OfPoint(bbox.Max));
+                    BoundingBoxXYZ transformedBbox = bbox.BoundsOfTransformed(transform);
+                    points.Add(transformedBbox.Min);
+                    points.Add(transformedBbox.Max);
                 }
                 else
                 {

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -76,7 +76,7 @@ namespace BH.Revit.Engine.Core
                 return false;
             }
 
-            if (transform == null || !element.Document.IsLinked)
+            if (transform == null)
                 transform = Transform.Identity;
 
             Outline outline = new Outline(bbox.Min, bbox.Max);

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -64,6 +64,7 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
+        [PreviousVersion("7.1", "BH.Revit.Engine.Core.Query.DoesIntersect(Autodesk.Revit.DB.BoundingBoxXYZ, Autodesk.Revit.DB.Element)")]
         [Description("Check if bounding box intersects with element.")]
         [Input("bbox", "Bounding box to check the intersection for.")]
         [Input("element", "Element to check the intersection for.")]

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -67,7 +67,7 @@ namespace BH.Revit.Engine.Core
         [Description("Check if bounding box intersects with element.")]
         [Input("bbox", "Bounding box to check the intersection for.")]
         [Input("element", "Element to check the intersection for.")]
-        [Input("transform", "Transform of the element. If null, it will be calculated from the first link instance matching the element document.")]
+        [Input("transform", "Transform of the element. If element is from revit link, revit link instance transform should be used.")]
         [Output("bool", "Result of the intersect checking.")]
         public static bool DoesIntersect(this BoundingBoxXYZ bbox, Element element, Transform transform = null)
         {
@@ -76,8 +76,8 @@ namespace BH.Revit.Engine.Core
                 return false;
             }
 
-            if (transform == null)
-                transform = element.Document.IsLinked ? element.Document.LinkTransform() : Transform.Identity;
+            if (transform == null || !element.Document.IsLinked)
+                transform = Transform.Identity;
 
             Outline outline = new Outline(bbox.Min, bbox.Max);
 

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -67,6 +67,7 @@ namespace BH.Revit.Engine.Core
         [Description("Check if bounding box intersects with element.")]
         [Input("bbox", "Bounding box to check the intersection for.")]
         [Input("element", "Element to check the intersection for.")]
+        [Input("transform", "Transform of the element. If null, it will be calculated from the first link instance matching the element document.")]
         [Output("bool", "Result of the intersect checking.")]
         public static bool DoesIntersect(this BoundingBoxXYZ bbox, Element element, Transform transform = null)
         {

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -68,14 +68,16 @@ namespace BH.Revit.Engine.Core
         [Input("bbox", "Bounding box to check the intersection for.")]
         [Input("element", "Element to check the intersection for.")]
         [Output("bool", "Result of the intersect checking.")]
-        public static bool DoesIntersect(this BoundingBoxXYZ bbox, Element element)
+        public static bool DoesIntersect(this BoundingBoxXYZ bbox, Element element, Transform transform = null)
         {
             if (bbox == null || element == null)
             {
                 return false;
             }
 
-            Transform transform = element.Document.LinkTransform();
+            if (transform == null)
+                transform = element.Document.IsLinked ? element.Document.LinkTransform() : Transform.Identity;
+
             Outline outline = new Outline(bbox.Min, bbox.Max);
 
             if (bbox.Transform.IsTranslation)

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -67,7 +67,7 @@ namespace BH.Revit.Engine.Core
         [Description("Check if bounding box intersects with element.")]
         [Input("bbox", "Bounding box to check the intersection for.")]
         [Input("element", "Element to check the intersection for.")]
-        [Input("transform", "Transform of the element. If element is from revit link, revit link instance transform should be used.")]
+        [Input("transform", "Transform of the element. In most usual case of a linked element being checked against a bounding box in host document's coordinate system, Revit link instance transform should be used.")]
         [Output("bool", "Result of the intersect checking.")]
         public static bool DoesIntersect(this BoundingBoxXYZ bbox, Element element, Transform transform = null)
         {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->
- Add `Bounds` for `IEnumerable<BoundingBoxXYZ>`
- Add transform input to `DoesIntersect`

Breaking change in DoesIntersect(BoundingBoxXYZ, Element) method - element transform calculation has been removed from the body as it can produce incorrect results. Transform of element has been added as an input.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->