### PR TITLE
Handle error when converting faces with open curve loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ bld/
 *.user
 .vs/
 .idea/
+**/launchSettings.json

--- a/Revit_Core_Engine/Convert/Geometry/FromRevit/Surface.cs
+++ b/Revit_Core_Engine/Convert/Geometry/FromRevit/Surface.cs
@@ -46,6 +46,9 @@ namespace BH.Revit.Engine.Core
                 return null;
 
             List<CurveLoop> crvLoops = face.GetEdgesAsCurveLoops().ToList();
+            if (crvLoops.Count == 1)
+                return new PlanarSurface(crvLoops[0].FromRevit(), new List<ICurve>());
+
             CurveLoop externalLoop = crvLoops.FirstOrDefault(x => !x.IsOpen() && x.IsCounterclockwise(face.FaceNormal));
 
             //The face may violate conventional winding directions, or Revit may see a complex curve loop as 'Open' and refuses to calculate IsCounterclockwise

--- a/Revit_Core_Engine/Convert/Geometry/FromRevit/Surface.cs
+++ b/Revit_Core_Engine/Convert/Geometry/FromRevit/Surface.cs
@@ -46,9 +46,6 @@ namespace BH.Revit.Engine.Core
                 return null;
 
             List<CurveLoop> crvLoops = face.GetEdgesAsCurveLoops().ToList();
-            if (crvLoops.Count == 1)
-                return new PlanarSurface(crvLoops[0].FromRevit(), new List<ICurve>());
-
             CurveLoop externalLoop = crvLoops.FirstOrDefault(x => !x.IsOpen() && x.IsCounterclockwise(face.FaceNormal));
 
             //The face may violate conventional winding directions, or Revit may see a complex curve loop as 'Open' and refuses to calculate IsCounterclockwise
@@ -72,10 +69,9 @@ namespace BH.Revit.Engine.Core
                 }
             }
 
-            ICurve externalBoundary = externalLoop.FromRevit();
             List<ICurve> internalBoundaries = crvLoops.Where(x => x != externalLoop).Select(x => x.FromRevit() as ICurve).ToList();
 
-            return new PlanarSurface(externalBoundary, internalBoundaries);
+            return new PlanarSurface(externalLoop.FromRevit(), internalBoundaries);
         }
 
 

--- a/Revit_Core_Engine/Convert/Geometry/FromRevit/Surface.cs
+++ b/Revit_Core_Engine/Convert/Geometry/FromRevit/Surface.cs
@@ -40,7 +40,7 @@ namespace BH.Revit.Engine.Core
         [Description("Converts a Revit PlanarFace to BH.oM.Geometry.PlanarSurface.")]
         [Input("face", "Revit PlanarFace to be converted.")]
         [Output("surface", "BH.oM.Geometry.PlanarSurface resulting from converting the input Revit PlanarFace.")]
-        public static oM.Geometry.PlanarSurface FromRevit(this PlanarFace face)
+        public static PlanarSurface FromRevit(this PlanarFace face)
         {
             if (face == null)
                 return null;
@@ -72,10 +72,10 @@ namespace BH.Revit.Engine.Core
                 }
             }
 
-            oM.Geometry.ICurve externalBoundary = externalLoop.FromRevit();
-            List<oM.Geometry.ICurve> internalBoundaries = crvLoops.Where(x => x != externalLoop).Select(x => x.FromRevit() as oM.Geometry.ICurve).ToList();
+            ICurve externalBoundary = externalLoop.FromRevit();
+            List<ICurve> internalBoundaries = crvLoops.Where(x => x != externalLoop).Select(x => x.FromRevit() as ICurve).ToList();
 
-            return new oM.Geometry.PlanarSurface(externalBoundary, internalBoundaries);
+            return new PlanarSurface(externalBoundary, internalBoundaries);
         }
 
 
@@ -86,7 +86,7 @@ namespace BH.Revit.Engine.Core
         [Description("Converts a Revit Face to BH.oM.Geometry.ISurface.")]
         [Input("face", "Revit Face to be converted.")]
         [Output("surface", "BH.oM.Geometry.ISurface resulting from converting the input Revit Face.")]
-        public static oM.Geometry.ISurface IFromRevit(this Face face)
+        public static oM.Geometry.ISurface IFromRevit(this Autodesk.Revit.DB.Face face)
         {
             return FromRevit(face as dynamic);
         }
@@ -96,7 +96,7 @@ namespace BH.Revit.Engine.Core
         /****              Fallback Methods             ****/
         /***************************************************/
 
-        private static oM.Geometry.ISurface FromRevit(this Face face)
+        private static oM.Geometry.ISurface FromRevit(this Autodesk.Revit.DB.Face face)
         {
             BH.Engine.Base.Compute.RecordError(String.Format("Revit face of type {0} could not be converted to BHoM due to a missing convert method.", face.GetType()));
             return null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1462 

<!-- Add short description of what has been fixed -->
If externalLoop is null for any reason, we'll fall back on find the loop with the max area. This is slower than checking loop winding direction, but externalLoop is null in like 1 out of 1000 faces, so the performance hit isn't bad.

### Test files
<!-- Link to test files to validate the proposed changes -->
@pawelbaran : Do we need a test file for this PR?

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->