### PR TITLE
Elements In Path - infinite loop bug fix

### DIFF
--- a/Revit_Core_Engine/Query/ElementsInPath.cs
+++ b/Revit_Core_Engine/Query/ElementsInPath.cs
@@ -37,10 +37,10 @@ namespace BH.Revit.Engine.Core
         /****               Public methods              ****/
         /***************************************************/
 
-        [Description("Returns list of elements connected to each other between starting and ending element in MEP network. For elements not connected in the system the result is null.")]
+        [Description("Returns list of element ids connected to each other between starting and ending element in MEP network. For elements not connected in the system the result is null.")]
         [Input("startingElement", "Starting element in the path of the elements.")]
         [Input("endingElement", "Ending element in the path of the elements.")]
-        [Output("elementPath", "Elements in path between starting and ending element.")]
+        [Output("elementPath", "Element ids in path between starting and ending element.")]
         public static List<ElementId> ElementsInPath(this Element startingElement, Element endingElement)
         {
             if (startingElement == null || endingElement == null) 
@@ -102,7 +102,6 @@ namespace BH.Revit.Engine.Core
             List<Element> connectedElements = element.ConnectedElements();
             return connectedElements.Where(x => x is FamilyInstance || x is Duct || x is FlexDuct || x is Pipe || x is FlexPipe || x is CableTrayConduitBase || x is Wire).ToList();
         }
-
 
         /***************************************************/
 

--- a/Revit_Core_Engine/Query/ElementsInPath.cs
+++ b/Revit_Core_Engine/Query/ElementsInPath.cs
@@ -47,7 +47,7 @@ namespace BH.Revit.Engine.Core
                 return null;
 
             Document doc = startingElement.Document;
-            List<ElementId> result = ElementPath(startingElement, endingElement, new HashSet<int>()).Select(x => new ElementId(x)).ToList();
+            List<ElementId> result = ElementPath(startingElement, endingElement, new HashSet<int>())?.Select(x => new ElementId(x)).ToList();
 
             return result;
         }

--- a/Revit_Core_Engine/Query/ElementsInPath.cs
+++ b/Revit_Core_Engine/Query/ElementsInPath.cs
@@ -65,7 +65,7 @@ namespace BH.Revit.Engine.Core
                 visitedElementIds.Add(element.Id.IntegerValue);
 
             List<Element> connectedElements = element.ConnectedNetworkElements();
-            List<Element> nextElements = connectedElements.Where(x => !visitedElementIds.Contains(x.Id.IntegerValue)).ToList();
+            List<Element> nextElements = connectedElements.Where(x => !visitedElementIds.Contains(x.Id.IntegerValue)).OrderBy(x => x.LocationPoint().DistanceTo(endingElement.LocationPoint())).ToList();
 
             if (nextElements.Count == 0)
             {
@@ -101,6 +101,21 @@ namespace BH.Revit.Engine.Core
         {
             List<Element> connectedElements = element.ConnectedElements();
             return connectedElements.Where(x => x is FamilyInstance || x is Duct || x is FlexDuct || x is Pipe || x is FlexPipe || x is CableTrayConduitBase || x is Wire).ToList();
+        }
+
+
+        /***************************************************/
+
+        private static XYZ LocationPoint(this Element element)
+        {
+            Location location = element.Location;
+
+            if (location is LocationPoint locationPoint)
+                return locationPoint.Point;
+            else if (location is LocationCurve locationCurve)
+                return locationCurve.Curve.Evaluate(0.5, true);
+
+            return null;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1487 

<!-- Add short description of what has been fixed -->
Replace `List<Element>` with `HashSet<int>` that fixes infinite loop bug and improves performance of the method. Added ordering by location point to get the results quicker.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Revit 2022 - test model](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%231488-ElementsInPathInfiniteLoopFix?csf=1&web=1&e=yCcYVO)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->