### PR TITLE
Fix PlanarSurface conversion bug

### DIFF
--- a/Revit_Core_Engine/Convert/Geometry/FromRevit/Surface.cs
+++ b/Revit_Core_Engine/Convert/Geometry/FromRevit/Surface.cs
@@ -44,12 +44,14 @@ namespace BH.Revit.Engine.Core
             if (face == null)
                 return null;
 
-            CurveLoop externalLoop = face.ExternalCurveLoop();
+            CurveLoop boundary = face.ExternalCurveLoop();
+            double perimeterLength = boundary.GetExactLength();
 
-            List<CurveLoop> crvLoops = face.GetEdgesAsCurveLoops().ToList();
-            List<ICurve> internalBoundaries = crvLoops.Where(x => x != externalLoop).Select(x => x.FromRevit() as ICurve).ToList();
+            List<ICurve> openings = face.GetEdgesAsCurveLoops().ToList()
+                .Where(x => perimeterLength - x.GetExactLength() > Tolerance.Distance)
+                .Select(x => x.FromRevit() as ICurve).ToList();
 
-            return new PlanarSurface(externalLoop.FromRevit(), internalBoundaries);
+            return new PlanarSurface(boundary.FromRevit(), openings);
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1499 

<!-- Add short description of what has been fixed -->
Instead of comparing objects, we can detect internal openings by their bounding boxes, which should be always smaller than the main external boundary's bounding box.

![2024 loops fixed](https://github.com/user-attachments/assets/9d81bad7-f74a-4b84-a363-70c78e59f7af)


### Test files
<!-- Link to test files to validate the proposed changes -->
TBC

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->