### PR TITLE
`FamilyInstance_WorkPlaneBased` - fixed direction for null orientation value

### DIFF
--- a/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
@@ -440,10 +440,13 @@ namespace BH.Revit.Engine.Core
                     if (orientation.BasisZ.DotProduct(orientation.BasisX.CrossProduct(orientation.BasisY)) < 0)
                         refDir = -refDir;
                 }
-                else if (host.Location is LocationCurve hostCurve)
+                else if (((host.Location as LocationCurve)?.Curve) is Line line)
                 {
-                    if (hostCurve.Curve is Line line)
-                        refDir = line.Direction;
+                    Transform linkTransform = linkInstance?.GetTotalTransform() ?? Transform.Identity;
+                    if (!linkTransform.IsIdentity)
+                        line = line.CreateTransformed(linkTransform) as Line;
+
+                    refDir = line.Direction;
                 }
 
                 FamilyInstance familyInstance = document.Create.NewFamilyInstance(reference, location, refDir, familySymbol);

--- a/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
+++ b/Revit_Core_Engine/Create/FamilyInstance/FamilyInstance.cs
@@ -440,6 +440,11 @@ namespace BH.Revit.Engine.Core
                     if (orientation.BasisZ.DotProduct(orientation.BasisX.CrossProduct(orientation.BasisY)) < 0)
                         refDir = -refDir;
                 }
+                else if (host.Location is LocationCurve hostCurve)
+                {
+                    if (hostCurve.Curve is Line line)
+                        refDir = line.Direction;
+                }
 
                 FamilyInstance familyInstance = document.Create.NewFamilyInstance(reference, location, refDir, familySymbol);
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->
Fixed direction value for placing hosted elements on line elements (walls, ducts, pipes) if input orientation is null. 

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->