### PR TITLE
`DoesIntersect` point vs solid bug fix

### DIFF
--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -153,11 +153,10 @@ namespace BH.Revit.Engine.Core
         [Description("Check if point intersects with solid.")]
         [Input("point", "Point to check the intersection for.")]
         [Input("solid", "Solid to check the intersection for.")]
-        [Input("tolerance", "Tolerance of the intersection check.")]
         [Output("bool", "Result of the intersect checking.")]
-        public static bool DoesIntersect(this XYZ point, Solid solid, double tolerance = BH.oM.Geometry.Tolerance.Distance)
+        public static bool DoesIntersect(this XYZ point, Solid solid)
         {
-            return IsContaining(solid, point, tolerance);
+            return IsContaining(solid, point);
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/DoesIntersect.cs
+++ b/Revit_Core_Engine/Query/DoesIntersect.cs
@@ -153,28 +153,11 @@ namespace BH.Revit.Engine.Core
         [Description("Check if point intersects with solid.")]
         [Input("point", "Point to check the intersection for.")]
         [Input("solid", "Solid to check the intersection for.")]
+        [Input("tolerance", "Tolerance of the intersection check.")]
         [Output("bool", "Result of the intersect checking.")]
-        public static bool DoesIntersect(this XYZ point, Solid solid)
+        public static bool DoesIntersect(this XYZ point, Solid solid, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {
-            if (point == null || solid == null)
-            {
-                return false;
-            }
-
-            Line line = Line.CreateBound(point, point.Add(XYZ.BasisZ));
-            SolidCurveIntersection sci = solid.IntersectWithCurve(line, new SolidCurveIntersectionOptions());
-
-            for (int i = 0; i < sci.SegmentCount; i++)
-            {
-                Curve c = sci.GetCurveSegment(i);
-
-                if (point.IsAlmostEqualTo(c.GetEndPoint(0), BH.oM.Geometry.Tolerance.Distance) || point.IsAlmostEqualTo(c.GetEndPoint(1), BH.oM.Geometry.Tolerance.Distance))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return IsContaining(solid, point, tolerance);
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/IsContaining.cs
+++ b/Revit_Core_Engine/Query/IsContaining.cs
@@ -81,7 +81,8 @@ namespace BH.Revit.Engine.Core
                 for (int i = 0; i < sci.SegmentCount; i++)
                 {
                     Curve c = sci.GetCurveSegment(i);
-                    if (c.GetEndPoint(0).DistanceTo(point) < tolerance || c.GetEndPoint(1).DistanceTo(point) < tolerance)
+                    IntersectionResult ir = c.Project(point);
+                    if (ir != null && ir.Distance <= tolerance)
                         return true;
                 }
             }

--- a/Revit_Core_Engine/Query/IsContaining.cs
+++ b/Revit_Core_Engine/Query/IsContaining.cs
@@ -81,8 +81,7 @@ namespace BH.Revit.Engine.Core
                 for (int i = 0; i < sci.SegmentCount; i++)
                 {
                     Curve c = sci.GetCurveSegment(i);
-                    IntersectionResult ir = c.Project(point);
-                    if (ir != null && ir.Distance <= tolerance)
+                    if (c.GetEndPoint(0).DistanceTo(point) < tolerance || c.GetEndPoint(1).DistanceTo(point) < tolerance)
                         return true;
                 }
             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1530 

<!-- Add short description of what has been fixed -->
Not very beautiful, but temporary fix for `DoesIntersect` - point vs solid overload. Currently there are several overlapping methods in 3 different files (`DoesIntersect`, `IsContatining`, `IsInRange`) and they have to be unified in the future (issue #1465).

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->