### PR TITLE
Naming of pulled physical/arch elements unified

### DIFF
--- a/Revit_Core_Engine/Convert/Architecture/FromRevit/Opening.cs
+++ b/Revit_Core_Engine/Convert/Architecture/FromRevit/Opening.cs
@@ -57,7 +57,7 @@ namespace BH.Revit.Engine.Core
             if (opening != null)
                 return opening;
             
-            opening = new oM.Architecture.BuildersWork.Opening { Name = instance.Name };
+            opening = new oM.Architecture.BuildersWork.Opening { Name = instance.FamilyTypeFullName() };
 
             //Set coordinate system
             opening.CoordinateSystem = instance.CoordinateSystem();

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Beam.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Beam.cs
@@ -53,7 +53,7 @@ namespace BH.Revit.Engine.Core
 
             oM.Geometry.ICurve locationCurve = familyInstance.LocationCurveFraming(settings);
             IFramingElementProperty property = familyInstance.FramingElementProperty(settings, refObjects);
-            beam = BH.Engine.Physical.Create.Beam(locationCurve, property);
+            beam = BH.Engine.Physical.Create.Beam(locationCurve, property, familyInstance.FamilyTypeFullName());
 
             //Set identifiers, parameters & custom data
             beam.SetIdentifiers(familyInstance);

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/Column.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/Column.cs
@@ -53,7 +53,7 @@ namespace BH.Revit.Engine.Core
 
             oM.Geometry.ICurve locationCurve = familyInstance.LocationCurveColumn(settings);
             IFramingElementProperty property = familyInstance.FramingElementProperty(settings, refObjects);
-            column = BH.Engine.Physical.Create.Column(locationCurve, property);
+            column = BH.Engine.Physical.Create.Column(locationCurve, property, familyInstance.FamilyTypeFullName());
 
             //Set identifiers, parameters & custom data
             column.SetIdentifiers(familyInstance);

--- a/Revit_Core_Engine/Query/FramingElementProperty.cs
+++ b/Revit_Core_Engine/Query/FramingElementProperty.cs
@@ -84,7 +84,7 @@ namespace BH.Revit.Engine.Core
             // Get rotation
             double rotation = familyInstance.OrientationAngle(settings);
             
-            framingProperty = BH.Engine.Physical.Create.ConstantFramingProperty(profile, material, rotation, familyInstance.Symbol.Name);
+            framingProperty = BH.Engine.Physical.Create.ConstantFramingProperty(profile, material, rotation, familyInstance.Symbol.FamilyTypeFullName());
 
             //Set identifiers, parameters & custom data
             framingProperty.SetIdentifiers(familyInstance.Symbol);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1519

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See #1519.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
Originally I expected the problem to occur to most types in Revit_Toolkit, but apparently columns and framing were almost the only pushable types that would suffer from it - so luckily the change is quite surgical and safe, as far as I can think of potential consequences.