### PR TITLE
Conversion of colour parameters fixed

### DIFF
--- a/Revit_Core_Engine/Query/IsColourParameter.cs
+++ b/Revit_Core_Engine/Query/IsColourParameter.cs
@@ -21,11 +21,20 @@
  */
 
 using Autodesk.Revit.DB;
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
 
 namespace BH.Revit.Engine.Core
 {
     public static partial class Query
     {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Checks whether the Revit parameter represents a colour.")]
+        [Input("parameter", "Revit parameter to check whether it is an enum.")]
+        [Output("colour", "True if the Revit parameter is a colour, otherwise false.")]
         public static bool IsColourParameter(this Parameter parameter)
         {
             if (parameter?.StorageType != StorageType.Integer)
@@ -37,5 +46,7 @@ namespace BH.Revit.Engine.Core
             return parameter.Definition.GetGroupTypeId() == Autodesk.Revit.DB.GroupTypeId.Graphics;
 #endif
         }
+
+        /***************************************************/
     }
 }

--- a/Revit_Core_Engine/Query/IsColourParameter.cs
+++ b/Revit_Core_Engine/Query/IsColourParameter.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        public static bool IsColourParameter(this Parameter parameter)
+        {
+            if (parameter?.StorageType != StorageType.Integer)
+                return false;
+
+#if REVIT2021
+            return parameter.Definition.ParameterGroup == BuiltInParameterGroup.PG_GRAPHICS;
+#else
+            return parameter.Definition.GetGroupTypeId() == Autodesk.Revit.DB.GroupTypeId.Graphics;
+#endif
+        }
+    }
+}

--- a/Revit_Core_Engine/Query/ParameterValue.cs
+++ b/Revit_Core_Engine/Query/ParameterValue.cs
@@ -49,6 +49,11 @@ namespace BH.Revit.Engine.Core
                 case StorageType.Integer:
                     if (parameter.IsBooleanParameter())
                         return parameter.AsInteger() == 1;
+                    else if (parameter.IsColourParameter())
+                    {
+                        int argb = parameter.AsInteger();
+                        return new Color((byte)(argb & byte.MaxValue), (byte)((argb >> 8) & byte.MaxValue), (byte)((argb >> 16) & byte.MaxValue)).FromRevit();
+                    }
                     else if (parameter.IsEnumParameter())
                         return parameter.AsValueString();
                     else if (string.IsNullOrEmpty(parameter.AsValueString()))


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1554

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231555%2DColourConvertBug) - pull the element, check if coloured preview works, then update and ideally pull again to confirm it all works. Worth testing against Revit 2021, 2022 and 2025 due to differences in the Revit API as well as .NET version.

Finally worth running unit tests for `Pull` as well.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->