### PR TITLE
Add `Query.Space` and `Query.LocationPoint` methods

### DIFF
--- a/Revit_Core_Engine/Query/ElementsInPath.cs
+++ b/Revit_Core_Engine/Query/ElementsInPath.cs
@@ -124,21 +124,6 @@ namespace BH.Revit.Engine.Core
 
         /***************************************************/
 
-        private static XYZ LocationPoint(this Element element)
-        {
-            Location location = element.Location;
-
-            if (location is LocationPoint locationPoint)
-                return locationPoint.Point;
-            else if (location is LocationCurve locationCurve)
-                return locationCurve.Curve.Evaluate(0.5, true);
-
-            return null;
-        }
-
-
-        /***************************************************/
-
         private static List<Domain> CommonDomains(this Element element1, Element element2)
         {
             List<Domain> el1Domains = element1.Connectors()?.Select(x => x.Domain).ToList();

--- a/Revit_Core_Engine/Query/LocationPoint.cs
+++ b/Revit_Core_Engine/Query/LocationPoint.cs
@@ -1,4 +1,26 @@
-﻿using Autodesk.Revit.DB;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
 using BH.oM.Base.Attributes;
 using System.ComponentModel;
 

--- a/Revit_Core_Engine/Query/LocationPoint.cs
+++ b/Revit_Core_Engine/Query/LocationPoint.cs
@@ -16,6 +16,9 @@ namespace BH.Revit.Engine.Core
         [Output("locationPoint", "The 3D point representing the location of the input Revit element")]
         public static XYZ LocationPoint(this Element element, bool useRoomCalculationPoint = false)
         {
+            if (element == null)
+                return null;
+
             XYZ locationPoint = null;
 
             // Handle FamilyInstance with Room Calculation Point
@@ -28,12 +31,12 @@ namespace BH.Revit.Engine.Core
             // Handle LocationPoint
             if (locationPoint == null && element.Location is LocationPoint lp)
             {
-                locationPoint = lp.Point;
+                locationPoint = lp?.Point;
             }
             // Handle LocationCurve
             else if (locationPoint == null && element.Location is LocationCurve lc)
             {
-                Curve curve = lc.Curve;
+                Curve curve = lc?.Curve;
                 locationPoint = curve.Evaluate(0.5, true); // Midpoint of the curve
             }
 

--- a/Revit_Core_Engine/Query/LocationPoint.cs
+++ b/Revit_Core_Engine/Query/LocationPoint.cs
@@ -1,0 +1,53 @@
+﻿using Autodesk.Revit.DB;
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Returns the 3D location point of a given Revit element. The method determines the most appropriate point based on the element type, such as the spatial element calculation point, the element's location point, the midpoint of its location curve, or the center of its bounding box.")]
+        [Input("element", "The Revit element from which to extract the location point.")]
+        [Input("useRoomCalculationPoint", "If true and the element is a FamilyInstance with a spatial element calculation point, use that point as the location.")]
+        [Output("locationPoint", "The 3D point representing the location of the input Revit element")]
+        public static XYZ LocationPoint(this Element element, bool useRoomCalculationPoint = false)
+        {
+            XYZ locationPoint = null;
+
+            // Handle FamilyInstance with Room Calculation Point
+            if (element is FamilyInstance fi)
+            {
+                if (useRoomCalculationPoint && fi.HasSpatialElementCalculationPoint)
+                    locationPoint = fi.GetSpatialElementCalculationPoint();
+            }
+
+            // Handle LocationPoint
+            if (locationPoint == null && element.Location is LocationPoint lp)
+            {
+                locationPoint = lp.Point;
+            }
+            // Handle LocationCurve
+            else if (locationPoint == null && element.Location is LocationCurve lc)
+            {
+                Curve curve = lc.Curve;
+                locationPoint = curve.Evaluate(0.5, true); // Midpoint of the curve
+            }
+
+            // Fallback to bounding box center
+            if (locationPoint == null)
+            {
+                BoundingBoxXYZ bbox = element.PhysicalBounds();
+                if (bbox != null)
+                    locationPoint = (bbox.Max + bbox.Min) / 2;
+            }
+
+            return locationPoint;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Query/LocationPoint.cs
+++ b/Revit_Core_Engine/Query/LocationPoint.cs
@@ -37,7 +37,7 @@ namespace BH.Revit.Engine.Core
             else if (locationPoint == null && element.Location is LocationCurve lc)
             {
                 Curve curve = lc?.Curve;
-                locationPoint = curve.Evaluate(0.5, true); // Midpoint of the curve
+                locationPoint = curve?.Evaluate(0.5, true); // Midpoint of the curve
             }
 
             // Fallback to bounding box center

--- a/Revit_Core_Engine/Query/Space.cs
+++ b/Revit_Core_Engine/Query/Space.cs
@@ -1,4 +1,26 @@
-﻿using Autodesk.Revit.DB;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Mechanical;
 using BH.oM.Base.Attributes;
 using System.Collections.Generic;

--- a/Revit_Core_Engine/Query/Space.cs
+++ b/Revit_Core_Engine/Query/Space.cs
@@ -1,0 +1,78 @@
+﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Mechanical;
+using BH.oM.Base.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****              Public methods               ****/
+        /***************************************************/
+
+        [Description("Returns the Revit Space that contains the given element.")]
+        [Input("element", "The Revit element for which to find the containing Space.")]
+        [Input("spaces", "An optional collection of Revit Spaces to search. If not provided, all Spaces in the element's document will be used.")]
+        [Input("useRoomCalculationPoint", "If true and the element is a FamilyInstance with a spatial element calculation point, that point will be used for containment checks.")]
+        [Output("space", "The Revit Space containing the element, or the element itself if it is a Space. Returns null if no containing Space is found.")]
+        public static Space Space(this Element element, IEnumerable<Space> spaces = null, bool useRoomCalculationPoint = false)
+        {
+            if (element == null)
+                return null;
+
+            // 1. If the element is a Space, return itself
+            if (element is Space space)
+                return space;
+
+            // 2. If the element is a FamilyInstance, try the .Space property
+            if (element is FamilyInstance fi && fi.Space != null)
+                return fi.Space;
+
+            // 3. Use location point and check which space contains it
+            if (spaces == null)
+            {
+                Document doc = element.Document;
+                spaces = new FilteredElementCollector(doc)
+                    .OfClass(typeof(SpatialElement))
+                    .OfType<Space>()
+                    .ToList();
+            }
+
+            foreach (var sp in spaces)
+            {
+                if (element.IsInSpace(sp, useRoomCalculationPoint))
+                    return sp;
+            }
+
+            // 4. Not found
+            return null;
+        }
+
+        /***************************************************/
+        /****              Private methods              ****/
+        /***************************************************/
+
+        private static bool IsInSpace(this Element element, Space space, bool useRoomCalculationPoint)
+        {
+            if (element is FamilyInstance && element.Document.Equals(space.Document))
+                return (element as FamilyInstance).Space?.Id == space.Id;
+
+            Transform elementTransform = element.Document.IsLinked ? element.Document.LinkInstance().GetTotalTransform() : Transform.Identity;
+            Transform spaceTransform = space.Document.IsLinked ? space.Document.LinkInstance().GetTotalTransform() : Transform.Identity;
+
+            XYZ locationPoint = element.LocationPoint(useRoomCalculationPoint);
+
+            if (!elementTransform.IsIdentity)
+                locationPoint = elementTransform.OfPoint(locationPoint);
+            if (!spaceTransform.IsIdentity)
+                locationPoint = spaceTransform.Inverse.OfPoint(locationPoint);
+
+            return space.IsPointInSpace(locationPoint);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Query/Space.cs
+++ b/Revit_Core_Engine/Query/Space.cs
@@ -41,9 +41,12 @@ namespace BH.Revit.Engine.Core
                     .ToList();
             }
 
+            XYZ locationPoint = element.LocationPoint(useRoomCalculationPoint);
+            Transform elementTransform = element.Document.IsLinked ? element.Document.LinkInstance().GetTotalTransform() : Transform.Identity;
+
             foreach (var sp in spaces)
             {
-                if (element.IsInSpace(sp, useRoomCalculationPoint))
+                if (locationPoint.IsInSpace(elementTransform, sp))
                     return sp;
             }
 
@@ -55,15 +58,9 @@ namespace BH.Revit.Engine.Core
         /****              Private methods              ****/
         /***************************************************/
 
-        private static bool IsInSpace(this Element element, Space space, bool useRoomCalculationPoint)
+        private static bool IsInSpace(this XYZ locationPoint, Transform elementTransform, Space space)
         {
-            if (element is FamilyInstance && element.Document.Equals(space.Document))
-                return (element as FamilyInstance).Space?.Id == space.Id;
-
-            Transform elementTransform = element.Document.IsLinked ? element.Document.LinkInstance().GetTotalTransform() : Transform.Identity;
             Transform spaceTransform = space.Document.IsLinked ? space.Document.LinkInstance().GetTotalTransform() : Transform.Identity;
-
-            XYZ locationPoint = element.LocationPoint(useRoomCalculationPoint);
 
             if (!elementTransform.IsIdentity)
                 locationPoint = elementTransform.OfPoint(locationPoint);

--- a/Revit_Core_Engine/Query/Space.cs
+++ b/Revit_Core_Engine/Query/Space.cs
@@ -43,10 +43,12 @@ namespace BH.Revit.Engine.Core
 
             XYZ locationPoint = element.LocationPoint(useRoomCalculationPoint);
             Transform elementTransform = element.Document.IsLinked ? element.Document.LinkInstance().GetTotalTransform() : Transform.Identity;
+            if (!elementTransform.IsIdentity)
+                locationPoint = elementTransform.OfPoint(locationPoint);
 
             foreach (var sp in spaces)
             {
-                if (locationPoint.IsInSpace(elementTransform, sp))
+                if (locationPoint.IsInSpace(sp))
                     return sp;
             }
 
@@ -58,12 +60,10 @@ namespace BH.Revit.Engine.Core
         /****              Private methods              ****/
         /***************************************************/
 
-        private static bool IsInSpace(this XYZ locationPoint, Transform elementTransform, Space space)
+        private static bool IsInSpace(this XYZ locationPoint, Space space)
         {
             Transform spaceTransform = space.Document.IsLinked ? space.Document.LinkInstance().GetTotalTransform() : Transform.Identity;
 
-            if (!elementTransform.IsIdentity)
-                locationPoint = elementTransform.OfPoint(locationPoint);
             if (!spaceTransform.IsIdentity)
                 locationPoint = spaceTransform.Inverse.OfPoint(locationPoint);
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1559 

<!-- Add short description of what has been fixed -->
Added `Space` and `LocationPoint` methods that are very often used for MEP elements.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->