### PR TITLE
`LinkedElementsInView` - view type check added

### DIFF
--- a/Revit_Core_Engine/Query/LinkedElementsInView.cs
+++ b/Revit_Core_Engine/Query/LinkedElementsInView.cs
@@ -43,6 +43,12 @@ namespace BH.Revit.Engine.Core
             if (view == null || linkInstance == null)
                 return null;
 
+            if (!(view is ViewPlan || view is View3D || view is ViewSection))
+            {
+                BH.Engine.Base.Compute.RecordWarning("Cannot get linked elements because provided view is not a ViewPlan, View3D, or ViewSection.");
+                return new List<ElementId>();
+            }
+
             Document linkDoc = linkInstance.GetLinkDocument();
             Solid viewSolid = view.TransformedViewSolid(linkInstance);
             ElementIntersectsSolidFilter solidFilter = new ElementIntersectsSolidFilter(viewSolid);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1580 

<!-- Add short description of what has been fixed -->
Added view type check to `Query.LinkedElementsInView` to avoid crashing error when calling method on a drafting view.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->