### PR TITLE
Null reference bug on family update fixed

### DIFF
--- a/Revit_Core_Engine/Modify/SetType.cs
+++ b/Revit_Core_Engine/Modify/SetType.cs
@@ -25,8 +25,8 @@ using BH.oM.Adapters.Revit.Elements;
 using BH.oM.Adapters.Revit.Parameters;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
-using BH.oM.Physical.Elements;
 using BH.oM.Base.Attributes;
+using BH.oM.Physical.Elements;
 using System;
 using System.ComponentModel;
 using System.Linq;
@@ -105,7 +105,7 @@ namespace BH.Revit.Engine.Core
 
             return false;
         }
-        
+
         /***************************************************/
 
         [Description("Updates the type of the Revit Element based on the given BHoM object.")]
@@ -161,7 +161,7 @@ namespace BH.Revit.Engine.Core
         [Output("success", "True if the type of the Element has been successfully updated.")]
         private static bool TrySetTypeFromString(this Element element, IBHoMObject bHoMObject, RevitSettings settings)
         {
-            if (element.Category.Id.IntegerValue < 0)
+            if (element?.Category != null && element.Category.Id.IntegerValue < 0)
             {
                 RevitParameter param = (bHoMObject.Fragments?.FirstOrDefault(x => x is RevitParametersToPush) as RevitParametersToPush)?.Parameters?.FirstOrDefault(x => x.Name == "Type");
                 if (param?.Value is string)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1586

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231587%2DFamilyUpdateBug)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->