### PR TITLE
Call to LoadAllAssemblies at startup removed

### DIFF
--- a/Revit_Core_Adapter/Listener/RevitListener.cs
+++ b/Revit_Core_Adapter/Listener/RevitListener.cs
@@ -167,9 +167,6 @@ namespace BH.Revit.Adapter.Core
 
             UIControlledApplication = uIControlledApplication;
 
-            //Make sure all BHoM assemblies and methods are loaded
-            BH.Engine.Base.Compute.LoadAllAssemblies();
-
             //Add buttons to manage the adapter
             AddAdapterButtons(uIControlledApplication);
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1625

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Functionality: run you fav script + a few test procedures, everything should work exactly the same as before.
Load time: can be looked up in Revit 2026 via addin manager.

Installer available [here]().


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->