### PR TITLE
Redundant call to BH.Engine.Base.Compute.LoadAllAssemblies removed

### DIFF
--- a/Revit_Core_Adapter/Listener/RevitListener.cs
+++ b/Revit_Core_Adapter/Listener/RevitListener.cs
@@ -167,9 +167,6 @@ namespace BH.Revit.Adapter.Core
 
             UIControlledApplication = uIControlledApplication;
 
-            //Make sure all BHoM assemblies and methods are loaded
-            BH.Engine.Base.Compute.LoadAllAssemblies();
-
             //Add buttons to manage the adapter
             AddAdapterButtons(uIControlledApplication);
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1625

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Functionality: run you fav script + a few test procedures, everything should work exactly the same as before.
Load time: can be looked up in Revit 2026 via addin manager.

Installer available [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231627%2DLoadSpeedup&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b) - **please test using it rather than compiling from source, this is what the users work with ultimately**.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->