### PR TITLE
`Query.Proximity` - added max iterations to avoid infinite loop 

### DIFF
--- a/Revit_Core_Engine/Query/Proximity.cs
+++ b/Revit_Core_Engine/Query/Proximity.cs
@@ -222,6 +222,9 @@ namespace BH.Revit.Engine.Core
             XYZ point1 = current;
             XYZ point2 = current;
 
+            int maxIterations = 100;
+            int iteration = 0;
+
             do
             {
                 (double, XYZ) prox = face.Proximity(current, tolerance);
@@ -242,8 +245,14 @@ namespace BH.Revit.Engine.Core
 
                 difference = Math.Abs(prox.Item1 - distance);
                 distance = prox.Item1;
+                iteration++;
+                if (iteration >= maxIterations)
+                    break;
             }
             while (difference > tolerance);
+
+            if (difference > tolerance)
+                BH.Engine.Base.Compute.RecordWarning("Proximity iteration did not converge within maximum iterations.");
 
             return new Output<XYZ, XYZ, double> { Item1 = point1, Item2 = point2, Item3 = distance };
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1634 

<!-- Add short description of what has been fixed -->
Added iteration counter to face-face method to avoid infinite loop.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->