### PR TITLE
`Query.Space` - find closest space added

### DIFF
--- a/Revit_Core_Engine/Query/Space.cs
+++ b/Revit_Core_Engine/Query/Space.cs
@@ -52,7 +52,7 @@ namespace BH.Revit.Engine.Core
             if (element is Space space)
                 return space;
 
-            // 2a. Check physical location - space property of family without calculation point
+            // 2a. Check physical location - family without room calculation point
             FamilyInstance fi = element as FamilyInstance;
             if (fi != null && !fi.HasSpatialElementCalculationPoint && fi.Space != null)
                 return fi.Space;
@@ -117,16 +117,16 @@ namespace BH.Revit.Engine.Core
                         connDirection = elementTransform.OfVector(connDirection);
                     }
 
-                    Space foundClosest = connPoint.FindClosestSpaceInDirection(connDirection, spaces, maxDistance: 3); // 3 feet max distance
-                    if (foundClosest != null)
-                        return foundClosest;
+                    Space closestToConnector = connPoint.FindClosestSpaceInDirection(connDirection, spaces, maxDistance: 3); // 3 feet max distance
+                    if (closestToConnector != null)
+                        return closestToConnector;
                 }
             }
 
             // 5. If still not found, try find closest below (negative Z direction)
-            Space foundClosestBelow = locationPoint.FindClosestSpaceInDirection(-XYZ.BasisZ, spaces, maxDistance: 10); // 10 feet max distance
-            if (foundClosestBelow != null)
-                return foundClosestBelow;
+            Space closestBelow = locationPoint.FindClosestSpaceInDirection(-XYZ.BasisZ, spaces, maxDistance: 10); // 10 feet max distance
+            if (closestBelow != null)
+                return closestBelow;
 
             // Not found
             return null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->
Added a mechanism to find closest space for elements that are physically outside the space (e.g. air terminals located above the space or fire dampers located in the walls between spaces).

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->