### PR TITLE
Pull of PileFoundation added

### DIFF
--- a/Revit_Core_Engine/Convert/Physical/FromRevit/PileFoundation.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/PileFoundation.cs
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Autodesk.Revit.DB;
+using BH.Engine.Adapters.Revit;
+using BH.Engine.Geometry;
+using BH.oM.Adapters.Revit.Settings;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Geometry;
+using BH.oM.Physical.Elements;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.Revit.Engine.Core
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        [Description("Converts a Revit FamilyInstance to BH.oM.Physical.Elements.PileFoundation.")]
+        [Input("familyInstance", "Revit FamilyInstance to be converted.")]
+        [Input("settings", "Revit adapter settings to be used while performing the convert.")]
+        [Input("refObjects", "Optional, a collection of objects already processed in the current adapter action, stored to avoid processing the same object more than once.")]
+        [Output("pileFoundation", "BH.oM.Physical.Elements.PileFoundation resulting from converting the input Revit FamilyInstance.")]
+        public static PileFoundation PileFoundationFromRevit(this FamilyInstance familyInstance, RevitSettings settings = null, Dictionary<string, List<IBHoMObject>> refObjects = null)
+        {
+            settings = settings.DefaultIfNull();
+
+            PileFoundation pileFoundation = refObjects.GetValue<PileFoundation>(familyInstance.Id);
+            if (pileFoundation != null)
+                return pileFoundation;
+
+            PlanarSurface location = familyInstance.LocationSurfacePadFoundation(settings);
+            oM.Physical.Constructions.Construction construction = familyInstance.ConstructionPadFoundation(settings, refObjects);
+            PadFoundation pileCap = BH.Engine.Physical.Create.PadFoundation(location, construction, familyInstance.FamilyTypeFullName());
+
+            List<Pile> piles = new List<Pile>();
+            double capTopZ = location.IBounds().Max.Z;
+            foreach (ElementId pileId in familyInstance.GetSubComponentIds())
+            {
+                FamilyInstance pileInstance = familyInstance.Document.GetElement(pileId) as FamilyInstance;
+                Pile pile = pileInstance.PileFromRevit(settings, refObjects);
+
+                if (pile.Location is oM.Geometry.Line line)
+                    line.End = new oM.Geometry.Point { X = line.End.X, Y = line.End.Y, Z = ((IGeometry)location).IBounds().Max.Z };
+
+                piles.Add(pile);
+            }
+
+            pileFoundation = BH.Engine.Physical.Create.PileFoundation(pileCap, piles, familyInstance.FamilyTypeFullName());
+
+            //Set identifiers, parameters & custom data
+            pileFoundation.SetIdentifiers(familyInstance);
+            pileFoundation.CopyParameters(familyInstance, settings.MappingSettings);
+            pileFoundation.SetProperties(familyInstance, settings.MappingSettings);
+
+            refObjects.AddOrReplace(familyInstance.Id, pileFoundation);
+            return pileFoundation;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Revit_Core_Engine/Convert/Physical/FromRevit/PileFoundation.cs
+++ b/Revit_Core_Engine/Convert/Physical/FromRevit/PileFoundation.cs
@@ -56,15 +56,17 @@ namespace BH.Revit.Engine.Core
             oM.Physical.Constructions.Construction construction = familyInstance.ConstructionPadFoundation(settings, refObjects);
             PadFoundation pileCap = BH.Engine.Physical.Create.PadFoundation(location, construction, familyInstance.FamilyTypeFullName());
 
+            oM.Geometry.Plane padPlane = location.FitPlane();
             List<Pile> piles = new List<Pile>();
-            double capTopZ = location.IBounds().Max.Z;
             foreach (ElementId pileId in familyInstance.GetSubComponentIds())
             {
                 FamilyInstance pileInstance = familyInstance.Document.GetElement(pileId) as FamilyInstance;
                 Pile pile = pileInstance.PileFromRevit(settings, refObjects);
 
                 if (pile.Location is oM.Geometry.Line line)
-                    line.End = new oM.Geometry.Point { X = line.End.X, Y = line.End.Y, Z = ((IGeometry)location).IBounds().Max.Z };
+                    line.End = line.End.ProjectAlong(padPlane, line.Direction());
+                else
+                    BH.Engine.Base.Compute.RecordWarning($"Could not extend the pile to the top of the cap because the pile is not linear. ElementId: {familyInstance.Id.Value()}");
 
                 piles.Add(pile);
             }

--- a/Revit_Core_Engine/Query/BHoMType.cs
+++ b/Revit_Core_Engine/Query/BHoMType.cs
@@ -95,13 +95,13 @@ namespace BH.Revit.Engine.Core
                         BoundingBoxXYZ bbox = familyInstance.get_BoundingBox(null);
                         double width = Math.Max(bbox.Max.X - bbox.Min.X, bbox.Max.Y - bbox.Min.Y);
                         double height = bbox.Max.Z - bbox.Min.Z;
-                        if (height < width)
+                        if (familyInstance.GetSubComponentIds().Count != 0)
+                            return typeof(BH.oM.Physical.Elements.PileFoundation);
+                        else if (height < width)
                             return typeof(BH.oM.Physical.Elements.PadFoundation);
-                        else if (familyInstance.GetSubComponentIds().Count != 0)
-                            //return typeof(BH.oM.Physical.Elements.PileFoundation);
-                            return null; // Temporarily disabled until PileFoundation is properly implemented in the Revit adapter.
-                        else
-                            return typeof(BH.oM.Physical.Elements.Pile);
+                        return null; // Temporarily disabled until PileFoundation is properly implemented in the Revit adapter.
+                        //else
+                        //    return typeof(BH.oM.Physical.Elements.Pile);
                     }
                     if (typeof(BH.oM.Physical.Elements.Window).BuiltInCategories().Contains(category))
                         return typeof(BH.oM.Physical.Elements.Window);

--- a/Revit_Core_Engine/Query/BHoMType.cs
+++ b/Revit_Core_Engine/Query/BHoMType.cs
@@ -92,16 +92,15 @@ namespace BH.Revit.Engine.Core
                 case Discipline.Architecture:
                     if (category == Autodesk.Revit.DB.BuiltInCategory.OST_StructuralFoundation)
                     {
-                        BoundingBoxXYZ bbox = familyInstance.get_BoundingBox(null);
+                        BoundingBoxXYZ bbox = familyInstance.PhysicalBounds();
                         double width = Math.Max(bbox.Max.X - bbox.Min.X, bbox.Max.Y - bbox.Min.Y);
                         double height = bbox.Max.Z - bbox.Min.Z;
                         if (familyInstance.GetSubComponentIds().Count != 0)
                             return typeof(BH.oM.Physical.Elements.PileFoundation);
-                        if (familyInstance.SuperComponent != null)
-                            return typeof(BH.oM.Physical.Elements.Pile);
                         else if (height < width)
                             return typeof(BH.oM.Physical.Elements.PadFoundation);
-                        return null;
+                        else
+                            return typeof(BH.oM.Physical.Elements.Pile);
                     }
                     if (typeof(BH.oM.Physical.Elements.Window).BuiltInCategories().Contains(category))
                         return typeof(BH.oM.Physical.Elements.Window);

--- a/Revit_Core_Engine/Query/BHoMType.cs
+++ b/Revit_Core_Engine/Query/BHoMType.cs
@@ -97,11 +97,11 @@ namespace BH.Revit.Engine.Core
                         double height = bbox.Max.Z - bbox.Min.Z;
                         if (familyInstance.GetSubComponentIds().Count != 0)
                             return typeof(BH.oM.Physical.Elements.PileFoundation);
+                        if (familyInstance.SuperComponent != null)
+                            return typeof(BH.oM.Physical.Elements.Pile);
                         else if (height < width)
                             return typeof(BH.oM.Physical.Elements.PadFoundation);
-                        return null; // Temporarily disabled until PileFoundation is properly implemented in the Revit adapter.
-                        //else
-                        //    return typeof(BH.oM.Physical.Elements.Pile);
+                        return null;
                     }
                     if (typeof(BH.oM.Physical.Elements.Window).BuiltInCategories().Contains(category))
                         return typeof(BH.oM.Physical.Elements.Window);

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByBHoMType.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByBHoMType.cs
@@ -27,10 +27,10 @@ using BH.oM.Adapters.Revit.Enums;
 using BH.oM.Adapters.Revit.Properties;
 using BH.oM.Adapters.Revit.Settings;
 using BH.oM.Base;
+using BH.oM.Base.Attributes;
 using BH.oM.Physical.Elements;
 using BH.oM.Physical.FramingProperties;
 using BH.oM.Physical.Materials;
-using BH.oM.Base.Attributes;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -109,7 +109,7 @@ namespace BH.Revit.Engine.Core
                 else
                     unsupportedAPITypes.Add(new Tuple<Type, Type>(t, t.SupportedAPIType()));
             }
-            
+
             elementIds.UnionWith(collector.WherePasses(new LogicalOrFilter(filters)).ToElementIds());
             foreach (Tuple<Type, Type> unsupportedAPIType in unsupportedAPITypes)
             {
@@ -126,6 +126,10 @@ namespace BH.Revit.Engine.Core
             // Filter out walls that are parts of stacked wall
             if (types.Any(x => typeof(Autodesk.Revit.DB.Wall).IsAssignableFrom(x)))
                 elementIds = elementIds.RemoveStackedWallParts(document);
+
+            //TODO: Set this comment
+            if (type == typeof(Pile))
+                elementIds = new HashSet<ElementId>(elementIds.Select(x => (document.GetElement(x) as FamilyInstance)).Where(x => x.SuperComponent == null).Select(x => x.Id));
 
             //Revit returns additional "parent" Autodesk.Revit.DB.Panel with no geometry when pulling all panels from model. This part of the code filter them out
             if (type == typeof(Window))

--- a/Revit_Core_Engine/Query/ElementIds/ElementIdsByBHoMType.cs
+++ b/Revit_Core_Engine/Query/ElementIds/ElementIdsByBHoMType.cs
@@ -127,7 +127,7 @@ namespace BH.Revit.Engine.Core
             if (types.Any(x => typeof(Autodesk.Revit.DB.Wall).IsAssignableFrom(x)))
                 elementIds = elementIds.RemoveStackedWallParts(document);
 
-            //TODO: Set this comment
+            // Filter out pile sub-components that are nested
             if (type == typeof(Pile))
                 elementIds = new HashSet<ElementId>(elementIds.Select(x => (document.GetElement(x) as FamilyInstance)).Where(x => x.SuperComponent == null).Select(x => x.Id));
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1672 

<!-- Add short description of what has been fixed -->
Add support for pull of Revit pile foundations (pile cap + nested piles).

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->