### PR TITLE
Updated Connector Query to fallback to max distance if connector has no Origin, eg Logical Connectors

### DIFF
--- a/Revit_Core_Engine/Query/Connectors.cs
+++ b/Revit_Core_Engine/Query/Connectors.cs
@@ -58,7 +58,12 @@ namespace BH.Revit.Engine.Core
             foreach (Connector conn in connSet)
                 connList.Add(conn);
 
-            connList = connList.OrderBy(x => x.Origin.DistanceTo(startPoint)).ToList();
+            // Order by distance from the start point. Logical connectors have no Origin, so they are sorted to the end rather than crashing the query.
+            connList = connList.OrderBy(x =>
+            {
+                try { return x.Origin.DistanceTo(startPoint); }
+                catch { return double.MaxValue; }
+            }).ToList();
 
             return connList;
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1680 

The method threw an exception if it was called with Logical Connectors. This update places Logical Connectors at the end of the sorted list instead.


### Test files
Any Revit File with MEP Systems containing Logical Connectors.