### PR TITLE
Level property not found properly

### DIFF
--- a/Revit_Core_Engine/Query/Level.cs
+++ b/Revit_Core_Engine/Query/Level.cs
@@ -42,31 +42,32 @@ namespace BH.Revit.Engine.Core
             if (element == null)
                 return null;
 
+            Level level = null;
             Document doc = element.Document;
             ElementId levelId = element.LevelId;
 
             // First priority: Check LevelId property (most direct way to get level)
             if (levelId.Value() != -1)
-                return doc.GetElement(levelId) as Level;
-
-            Level level = null;
+                level = doc.GetElement(levelId) as Level;
+            if (level != null)
+                return level;
 
             // Second priority: Check level parameters (LevelParameter or BaseLevelParameter)
             Parameter levelParameter = element.LevelParameter() ?? element.BaseLevelParameter();
             if (levelParameter != null)
                 level = doc.GetElement(levelParameter?.AsElementId()) as Level;
-
             if (level != null)
                 return level;
 
             // Third priority: Check if element is work plane-based and hosted on a level
             if (element.IsWorkPlaneLevelBased())
                 level = (element as FamilyInstance)?.Host as Level;
+            if (level != null)
+                return level;
 
-            if (level == null)
-                level = element.Document.LevelBelow(element.LocationPoint());
+            // Fourth priority: Use the LevelBelow method to find the level below the element's location point
+            level = element.Document.LevelBelow(element.LocationPoint());
 
-            // No level found
             return level;
         }
 

--- a/Revit_Core_Engine/Query/Level.cs
+++ b/Revit_Core_Engine/Query/Level.cs
@@ -49,17 +49,25 @@ namespace BH.Revit.Engine.Core
             if (levelId.Value() != -1)
                 return doc.GetElement(levelId) as Level;
 
+            Level level = null;
+
             // Second priority: Check level parameters (LevelParameter or BaseLevelParameter)
             Parameter levelParameter = element.LevelParameter() ?? element.BaseLevelParameter();
             if (levelParameter != null)
-                return doc.GetElement(levelParameter.AsElementId()) as Level;
+                level = doc.GetElement(levelParameter?.AsElementId()) as Level;
+
+            if (level != null)
+                return level;
 
             // Third priority: Check if element is work plane-based and hosted on a level
             if (element.IsWorkPlaneLevelBased())
-                return (element as FamilyInstance)?.Host as Level;
+                level = (element as FamilyInstance)?.Host as Level;
+
+            if (level == null)
+                level = element.Document.LevelBelow(element.LocationPoint());
 
             // No level found
-            return null;
+            return level;
         }
 
         /***************************************************/

--- a/Revit_Core_Engine/Query/LevelParameter.cs
+++ b/Revit_Core_Engine/Query/LevelParameter.cs
@@ -45,7 +45,8 @@ namespace BH.Revit.Engine.Core
                 .Select(x => element.get_Parameter(x))
                 .Where(x => x != null)
                 .OrderByDescending(x => x.AsElementId().Value() != -1) // Valid ElementIds first
-                .FirstOrDefault(x => !x.IsReadOnly);
+                .ThenByDescending(x => x.IsReadOnly) 
+                .FirstOrDefault();
         }
 
         /***************************************************/
@@ -62,7 +63,8 @@ namespace BH.Revit.Engine.Core
                 .Select(x => element.get_Parameter(x))
                 .Where(x => x != null)
                 .OrderByDescending(x => x.AsElementId().Value() != -1) // Valid ElementIds first
-                .FirstOrDefault(x => !x.IsReadOnly);
+                .ThenByDescending(x => x.IsReadOnly)
+                .FirstOrDefault();
         }
 
         /***************************************************/
@@ -79,7 +81,8 @@ namespace BH.Revit.Engine.Core
                 .Select(x => element.get_Parameter(x))
                 .Where(x => x != null)
                 .OrderByDescending(x => x.AsElementId().Value() != -1) // Valid ElementIds first
-                .FirstOrDefault(x => !x.IsReadOnly);
+                .ThenByDescending(x => x.IsReadOnly)
+                .FirstOrDefault();
         }
 
         /***************************************************/


### PR DESCRIPTION
Level.cs: introduce a local Level variable and change lookup flow to prefer LevelParameter and family host, then fall back to Document.LevelBelow(location) instead of returning null. LevelParameter.cs: adjust LINQ selection to use ThenByDescending on IsReadOnly and call FirstOrDefault() (remove predicate) so the candidate is chosen via ordered ranking (valid ElementIds first, then read-only ordering). This makes level resolution more robust and centralizes parameter selection logic.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1684 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->