### PR TITLE
`Query.LocationPoint` - support `DirectShape`

### DIFF
--- a/Revit_Core_Engine/Query/LocationPoint.cs
+++ b/Revit_Core_Engine/Query/LocationPoint.cs
@@ -70,7 +70,12 @@ namespace BH.Revit.Engine.Core
             // Fallback to bounding box center
             if (locationPoint == null)
             {
-                BoundingBoxXYZ bbox = element.PhysicalBounds() ?? element.get_BoundingBox(null);
+                BoundingBoxXYZ bbox = null;
+                if (element is DirectShape)
+                    bbox = element.get_BoundingBox(null);
+                else
+                    bbox = element.PhysicalBounds() ?? element.get_BoundingBox(null);
+
                 if (bbox != null)
                     locationPoint = (bbox.Max + bbox.Min) / 2;
             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1687 

<!-- Add short description of what has been fixed -->
Fixed location point of `DirectShape` - use bbox instead of physical bounds.

### Test files
<!-- Link to test files to validate the proposed changes -->
[installer](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Revit_Toolkit/%231688-DirectShapeLocationPoint?d=wd16854b9a41a44cbb457f817ac1a75d9&csf=1&web=1&e=8ElVVC)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->